### PR TITLE
refactor(front): major TypeScript type revamp with Zod v4 schemas

### DIFF
--- a/front/app/error.tsx
+++ b/front/app/error.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect } from "react";
+
+interface ErrorPageProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen w-full bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 px-4 py-16">
+      <div className="mx-auto flex max-w-2xl flex-col items-center rounded-xl border border-slate-400/20 bg-slate-900/50 p-8 text-slate-100 shadow-2xl backdrop-blur-sm">
+        <p className="mb-2 text-xs uppercase tracking-[0.22em] text-amber-300">Application Error</p>
+        <h1 className="mb-4 text-center text-3xl font-bold">Something went wrong</h1>
+        <p className="mb-8 text-center text-sm text-slate-300">
+          The page failed to load. You can retry now or go back to the dashboard.
+        </p>
+
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <button
+            type="button"
+            onClick={reset}
+            className="rounded-sm bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400"
+          >
+            Retry
+          </button>
+          <a
+            href="/dashboard"
+            className="rounded-sm border border-slate-300/50 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-100 hover:text-slate-900"
+          >
+            Back to dashboard
+          </a>
+        </div>
+
+        {process.env.NODE_ENV !== "production" && (
+          <pre className="mt-6 w-full overflow-auto rounded-sm bg-slate-950 p-3 text-xs text-rose-300">
+            {error.message}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "recharts": "^3.4.1",
     "sweetalert2": "^11.4.14",
     "use-onclickoutside": "^0.4.0",
-    "zod": "^3.14.3",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^0.4.0
         version: 0.4.0(@types/react@19.2.7)(react@19.2.3)
       zod:
-        specifier: ^3.14.3
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@19.2.7)(immer@9.0.14)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
@@ -2747,6 +2747,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
   zustand@5.0.11:
     resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
@@ -5541,6 +5544,8 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}
 
   zustand@5.0.11(@types/react@19.2.7)(immer@9.0.14)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3)):
     optionalDependencies:

--- a/front/src/components/categories/CategoriesListcontainer.tsx
+++ b/front/src/components/categories/CategoriesListcontainer.tsx
@@ -2,27 +2,25 @@ import useCategories from "@components/spendings/services/useCategories";
 import CategoryItem from "@components/categories/CategoryItem";
 import Spinner from "@components/common/Spinner";
 
-
-interface CategoryItemProps {
-  ID: string;
-  userID: string;
-  name: string;
-  color: string;
-};
+import type { Category } from "@src/schemas/categories";
 
 const CategoriesListcontainer = () => {
-  const { categories } = useCategories();
+  const { categories, error } = useCategories();
+
+  if (error) {
+    throw error;
+  }
 
   return (
     <div className="flex flex-col md:mt-20 pl-1 space-y-2">
       <div className="ml-1 font-ubuntu text-grey3 font-bold underline">
-        Nombre de catégories : {categories?.data?.length || 0}
+        Nombre de catégories : {categories?.length || 0}
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-      {categories?.data && categories.data.length > 0 ?
-        categories.data
-          .sort((c1: CategoryItemProps, c2: CategoryItemProps) => c1.name.localeCompare(c2.name))
-          .map((category: CategoryItemProps) => (
+      {categories && categories.length > 0 ?
+        categories
+          .sort((c1: Category, c2: Category) => c1.name.localeCompare(c2.name))
+          .map((category: Category) => (
             <CategoryItem
               key={category.ID}
               category={category}

--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -5,9 +5,13 @@ import CategoryComponent from "@components/common/Category";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPencilAlt, faTrashAlt } from "@fortawesome/free-solid-svg-icons";
 import useCategories from "@components/spendings/services/useCategories";
+import type { Category } from "@src/schemas/categories";
 
+interface CategoryItemProps {
+  category: Category;
+}
 
-const CategoryItem = ({ category }) => {
+const CategoryItem = ({ category }: CategoryItemProps) => {
   const { deleteCategory, updateCategory } = useCategories();
   const [isDeleteConfirmVisible, setIsDeleteConfirmVisible] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -27,7 +31,7 @@ const CategoryItem = ({ category }) => {
   //   }
   // }, [updateError]);
 
-  const deleteCallback = (categoryID) => {
+  const deleteCallback = (categoryID: string) => {
     deleteCategory.mutate({ categoryID });
     setIsDeleteConfirmVisible(false);
   };

--- a/front/src/components/common/Category.tsx
+++ b/front/src/components/common/Category.tsx
@@ -10,18 +10,20 @@ interface CategoryComponentProps {
 }
 
 const CategoryComponent = ({ item, customCss = "", isDynamic = false, isClicked = false }: CategoryComponentProps) => {
+  const resolvedColor = item.categoryColor ?? "#ffffff";
+
   const getBackgroundColor = () => {
     if (isDynamic && isClicked) {
-      return item.categoryColor;
+      return resolvedColor;
     } else if (isDynamic) {
-      return item.categoryColor;
+      return resolvedColor;
     } else {
       return "#efefef";
     }
   };
 
   const getTextColor = () => {
-    return isDynamic ? adjustFontColor(item.categoryColor) : "#000";
+    return isDynamic ? adjustFontColor(resolvedColor) : "#000";
   };
 
   return (
@@ -38,8 +40,8 @@ const CategoryComponent = ({ item, customCss = "", isDynamic = false, isClicked 
         <span
           className="absolute left-0 top-0 bottom-0"
           style={{
-            border: item.categoryColor,
-            backgroundColor: item.categoryColor,
+            border: resolvedColor,
+            backgroundColor: resolvedColor,
             width: "5px",
             borderTopLeftRadius: "inherit",
             borderBottomLeftRadius: "inherit",

--- a/front/src/components/common/dropdown/Dropdown.tsx
+++ b/front/src/components/common/dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import { faAngleUp, faAngleDown} from '@fortawesome/free-solid-svg-icons';
 import useOnClickOutside from "use-onclickoutside";
 
 import type { Dropdown } from "./types";
+import type { RefObject } from "react";
 
 
 const DropDown = ({ children, displayCaret = true }: Dropdown) => {
@@ -13,7 +14,7 @@ const DropDown = ({ children, displayCaret = true }: Dropdown) => {
   const toggleDropdown = () => { setIsOpen(!isOpen) };
 
   const handleClickOutside = () => { setIsOpen(false) };
-  useOnClickOutside(ref as any, handleClickOutside);
+  useOnClickOutside(ref as RefObject<HTMLElement>, handleClickOutside);
 
   const close = () => { setIsOpen(false) };
 

--- a/front/src/components/common/dropdown/types.ts
+++ b/front/src/components/common/dropdown/types.ts
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 
 export interface Dropdown {
-  children: ReactElement<any>[];
+  children: [ReactElement, ReactElement<{ handleclosefromchild?: () => void }>];
   displayCaret?: boolean;
 }

--- a/front/src/components/common/form/Input.tsx
+++ b/front/src/components/common/form/Input.tsx
@@ -3,7 +3,7 @@ import type { FieldValues, Path, UseFormRegister } from "react-hook-form";
 interface InputProps<T extends FieldValues> {
   register: UseFormRegister<T>;
   registerName: Path<T>;
-  defaultValue?: any;
+  defaultValue?: string | number;
   placeHolder: string;
 }
 

--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -10,6 +10,7 @@ import format from "date-fns/format";
 import { WEEKDAYS_LONG, WEEKDAYS_SHORT, MONTHS } from "./locale-fr";
 import useDatePickerState from "@components/datePickerWrapper/helpers/useDatePickerState";
 import { DATE_QUERY_PARAM } from "@helpers/dateRoute";
+import type { Modifiers } from "react-day-picker";
 
 const DatePickerWrapper = () => {
   const {
@@ -30,17 +31,20 @@ const DatePickerWrapper = () => {
 
   const daysAreSelected = selectedDays.length > 0;
 
-  const modifiers: any = {
-    hoverRange,
-    selectedRange: daysAreSelected && {
+  const modifiers: Partial<Modifiers> = {};
+  if (hoverRange) {
+    modifiers.hoverRange = hoverRange;
+    modifiers.hoverRangeStart = hoverRange.from;
+    modifiers.hoverRangeEnd = hoverRange.to;
+  }
+  if (daysAreSelected) {
+    modifiers.selectedRange = {
       from: selectedDays[0],
       to: selectedDays[selectedDays.length - 1],
-    },
-    hoverRangeStart: hoverRange && hoverRange.from,
-    hoverRangeEnd: hoverRange && hoverRange.to,
-    selectedRangeStart: daysAreSelected && selectedDays[0],
-    selectedRangeEnd: daysAreSelected && selectedDays[selectedDays.length - 1],
-  };
+    };
+    modifiers.selectedRangeStart = selectedDays[0];
+    modifiers.selectedRangeEnd = selectedDays[selectedDays.length - 1];
+  }
 
   useOnClickOutside(ref as React.RefObject<HTMLElement>, handleClickOutside);
 

--- a/front/src/components/spendings/Spendings.tsx
+++ b/front/src/components/spendings/Spendings.tsx
@@ -5,14 +5,13 @@ import { endOfMonth } from "date-fns";
 import startOfMonth from "date-fns/startOfMonth";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { getWeekRange, getWeekDays } from "@components/datePickerWrapper/helpers";
-import useDashboard from "@components/spendings/services/useDashboard";
 import SpendingDashboard from "@components/spendings/spendingDashboard/SpendingDashboard";
 import useSpendings from "@components/spendings/services/useSpendings";
-import useInitialAmount from "@components/spendings/services/useInitialAmount";
 import SpendingDayItem from "@components/spendings/spendingDayItem/SpendingDayItem";
 import useBlur from "@components/common/helpers/blurHelper";
 
 import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
+import type { SpendingDayGroup } from "@components/spendings/types";
 
 const Spendings = () => {
   const { isBlurActive } = useBlur();
@@ -33,11 +32,7 @@ const Spendings = () => {
     }
   }, [from, setFrom, setTo, setRange]);
 
-  const { spendingsByWeek, spendingsByMonth, isLoading: isSpendingsLoading } = useSpendings();
-
-  // const { get: { data: dashboard } } = useDashboard();
-
-  // const { data: initialAmount } = useInitialAmount();
+  const { spendingsByWeek, isLoading: isSpendingsLoading, error } = useSpendings();
 
   useEffect(() => {
     if (from && to) {
@@ -48,6 +43,10 @@ const Spendings = () => {
     }
   }, [from, to]);
 
+  if (error) {
+    throw error;
+  }
+
   return (
     <>
       {month &&
@@ -56,10 +55,11 @@ const Spendings = () => {
           <div className={`flex justify-center w-full ${isBlurActive && "blur-xs"}`}>
             <div className="flex flex-wrap justify-start mt-36 md:mt-96 md:pl-1 w-full md:w-11/12 space-y-2">
             {/*<div className="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-8 mt-36 md:mt-96">*/}
-              {spendingsByWeek?.map((spending: any, i: number) =>
+              {spendingsByWeek?.map((spending: SpendingDayGroup, i: number) =>
                 <SpendingDayItem
-                  key={i}
-                  spendingsByDay={spending}
+                  key={spending.dayOfMonth}
+                  spendingsByDay={spending.items}
+                  total={spending.total}
                   date={range![i]}
                   isLoading={isSpendingsLoading}
                 />

--- a/front/src/components/spendings/common/deleteSpendingButton.tsx
+++ b/front/src/components/spendings/common/deleteSpendingButton.tsx
@@ -2,7 +2,18 @@ import commonTexts from "@components/common/config/text";
 import useSpendings from "@components/spendings/services/useSpendings";
 import useReccurings from "@components/spendings/services/useReccurings";
 
-const DeleteSpendingButton = ({ spending, recurringType, hideConfirm }) => {
+interface DeletableSpending {
+  ID: string;
+  itemType: string;
+}
+
+interface DeleteSpendingButtonProps {
+  spending: DeletableSpending;
+  recurringType: boolean;
+  hideConfirm: () => void;
+}
+
+const DeleteSpendingButton = ({ spending, recurringType, hideConfirm }: DeleteSpendingButtonProps) => {
   const { deleteSpending } = useSpendings();
   const { deleteRecurring } = useReccurings();
 

--- a/front/src/components/spendings/common/deleteSpendingPopin.tsx
+++ b/front/src/components/spendings/common/deleteSpendingPopin.tsx
@@ -1,11 +1,14 @@
 import ConfirmDelete from "@components/common/confirmDelete";
 import DeleteSpendingButton from "@components/spendings/common/deleteSpendingButton";
 
-import type { Spending } from "@components/spendings/interfaces/spendingDashboardTypes";
+interface DeletableSpending {
+  ID: string;
+  itemType: string;
+}
 
 interface ConfirmDeletePopinProps {
   hideConfirm: () => void;
-  spending: Spending;
+  spending: DeletableSpending;
   recurringType: boolean;
 }
 

--- a/front/src/components/spendings/common/spendingModal/AutocompleteItem.tsx
+++ b/front/src/components/spendings/common/spendingModal/AutocompleteItem.tsx
@@ -1,25 +1,50 @@
 import adjustFontColor from "@components/shared/helpers/adjustColor";
+import type {
+  HTMLAttributes,
+  Key,
+  MouseEventHandler,
+} from "react";
+
+type AutocompleteRenderOptionProps = HTMLAttributes<HTMLLIElement> & {
+  key?: Key;
+};
 
 interface AutocompleteListProps {
-  props: any;
+  props: AutocompleteRenderOptionProps;
   color: string;
   name: string;
 }
 
 const AutocompleteItem = ({ props, color, name }: AutocompleteListProps) => {
-  const { key, ...restProps } = props;
+  const {
+    key: optionKey,
+    onMouseOver,
+    onMouseOut,
+    ...optionProps
+  } = props;
+
+  const handleMouseOver: MouseEventHandler<HTMLLIElement> = (event) => {
+    onMouseOver?.(event);
+    event.currentTarget.style.backgroundColor = "rgb(220, 220, 220)";
+  };
+
+  const handleMouseOut: MouseEventHandler<HTMLLIElement> = (event) => {
+    onMouseOut?.(event);
+    event.currentTarget.style.backgroundColor = "white";
+  };
+
   return (
-    <span
-      key={key}
-      {...restProps}
+    <li
+      key={optionKey}
+      {...optionProps}
       style={{
         display: "flex",
         justifyContent: "center",
         padding: "7px 0",
         backgroundColor: "white",
       }}
-      onMouseOver={(e) => {(e.currentTarget as HTMLInputElement).style.backgroundColor = "rgb(220, 220, 220)"}}
-      onMouseOut={(e) => {(e.currentTarget as HTMLInputElement).style.backgroundColor = "white"}}
+      onMouseOver={handleMouseOver}
+      onMouseOut={handleMouseOut}
     >
       <span
         style={{
@@ -37,7 +62,7 @@ const AutocompleteItem = ({ props, color, name }: AutocompleteListProps) => {
       >
         {name}
       </span>
-    </span>
+    </li>
   );
 };
 

--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -15,31 +15,37 @@ import useSpendings from "@components/spendings/services/useSpendings";
 import useReccurings from "@components/spendings/services/useReccurings";
 import AutocompleteItem from "@components/spendings/common/spendingModal/AutocompleteItem";
 import { DATE_FORMAT } from "@components/spendings/config/constants";
+import { SpendingCategoryInputSchema } from "@src/schemas/spendings";
+import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
+import type { SpendingItem, SpendingListItem } from "@components/spendings/types";
 
 const spendingSchema = z.object({
-  spendingLabel: z.string().nonempty(),
-  spendingAmount: z.string().nonempty(),
-  category: z.any(),
+  spendingLabel: z.string().min(1),
+  spendingAmount: z.string().min(1),
+  category: z.union([z.string(), SpendingCategoryInputSchema, z.null()]).optional(),
 });
 
 type SpendingForm = z.infer<typeof spendingSchema>;
+type CategoryOption = z.infer<typeof SpendingCategoryInputSchema>;
 
-type CategoryOption = {
-  ID: string | null;
-  userID: string | null;
-  name: string;
-  color: string | null;
-};
+interface SpendingModalProps {
+  date?: Date;
+  closeModal: () => void;
+  spending: SpendingListItem | null;
+  recurringType?: boolean;
+  isEditing: boolean;
+  month?: MonthRange | null;
+}
 
 
 const SpendingModal = ({
    date,
    closeModal,
    spending,
-   recurringType,
+   recurringType = false,
    isEditing,
-   month,
- }) => {
+   month = null,
+ }: SpendingModalProps) => {
   const { user } = useAuth();
   const { createSpending, updateSpending } = useSpendings();
   const {
@@ -48,7 +54,16 @@ const SpendingModal = ({
     updateRecurring,
     copyRecurrings,
   } = useReccurings();
-  const { categories } = useCategories();
+  const { categories, error: categoriesError } = useCategories();
+  if (categoriesError) {
+    throw categoriesError;
+  }
+  const categoryOptions: CategoryOption[] = (categories ?? []).map((category) => ({
+    ID: category.ID,
+    userID: category.userID,
+    name: category.name,
+    color: category.color,
+  }));
 
 
   const initialEmptyCategoryState: CategoryOption = {
@@ -57,12 +72,15 @@ const SpendingModal = ({
     name: "",
     color: null
   };
-  const initialCategoryState: CategoryOption = spending?.category ?
+  const isSpendingItem = (value: SpendingListItem | null): value is SpendingItem =>
+    !!value && "date" in value;
+
+  const initialCategoryState: CategoryOption = (isSpendingItem(spending) && spending.category) ?
     {
-      ID: spending.categoryID,
+      ID: spending.categoryID ?? null,
       userID: user?.id ?? null,
-      name: spending.category,
-      color: spending.categoryColor,
+      name: spending.category ?? "",
+      color: spending.categoryColor ?? null,
     }
     :
     initialEmptyCategoryState;
@@ -79,10 +97,10 @@ const SpendingModal = ({
     name: "category",
     control,
     rules: { required: true },
-    defaultValue: null as unknown as CategoryOption | null,
+    defaultValue: null,
   });
 
-  const [selectedCategory, setselectedCategory] = useState<CategoryOption>(initialCategoryState);
+  const [selectedCategory, setSelectedCategory] = useState<CategoryOption>(initialCategoryState);
 
   const getRandomHexColor = () => {
     let r = Math.floor(Math.random()*255).toString(16);
@@ -138,11 +156,11 @@ const SpendingModal = ({
       date: date ? format(date, 'yyyy-MM-dd') : null,
       // ///////////////////////////////////////////////////
       label: values.spendingLabel,
-      amount: amountEvaluatedExpr,
+      amount: Number(amountEvaluatedExpr),
       category: processCategory(values),
       currency: user.baseCurrency,
       userID: user.id,
-      id: spending.ID,
+      id: spending?.ID,
     };
 
     if (isEditing) {
@@ -154,6 +172,9 @@ const SpendingModal = ({
       }
     } else {
       if (recurringType) {
+        if (!month) {
+          throw new Error("Missing month range for recurring spending modal");
+        }
         const formattedMonth = {
           start: format(month.start, 'yyyy-MM-dd'),
           end: format(month.end, 'yyyy-MM-dd'),
@@ -168,7 +189,7 @@ const SpendingModal = ({
   };
 
   const handleAutocompleteChange = (value: CategoryOption | null) => {
-    setselectedCategory(value ?? initialEmptyCategoryState);
+    setSelectedCategory(value ?? initialEmptyCategoryState);
   }
 
   return (
@@ -184,22 +205,25 @@ const SpendingModal = ({
         <Input
           placeHolder="label"
           register={register}
-          defaultValue={spending.label}
+          defaultValue={spending?.label}
           registerName="spendingLabel"
         />
         <Input
           placeHolder="montant"
           register={register}
-          defaultValue={spending.amount}
+          defaultValue={spending?.amount}
           registerName="spendingAmount"
         />
 
         {!recurringType &&
-          <Autocomplete
+          <Autocomplete<CategoryOption, false, false, true>
             {...field}
             freeSolo
-            isOptionEqualToValue={(option: any, value: any) => {
-                return option?.ID === value?.ID;
+            isOptionEqualToValue={(option, value) => {
+                if (typeof value === "string") {
+                  return option.name === value;
+                }
+                return option.ID === value?.ID;
               }
             }
             autoComplete={true}
@@ -207,11 +231,14 @@ const SpendingModal = ({
             classes={{
              root: "backgroundColor: yellow"
             }}
-            getOptionLabel={(option: any) => (typeof option === "string" ? option : (option?.name ?? ""))}
-            options={(categories?.data || []) as any[]}
-            renderOption={(props, option: any) => {
+            getOptionLabel={(option) => (typeof option === "string" ? option : (option?.name ?? ""))}
+            options={categoryOptions}
+            renderOption={(props, option) => {
+              if (typeof option === "string") {
+                return null;
+              }
               const { name, color } = option;
-              return <AutocompleteItem key={name} props={props} color={color!} name={name} />;
+              return <AutocompleteItem key={name} props={props} color={color ?? "#ffffff"} name={name} />;
             }}
             renderInput={(params) => (
               <TextField
@@ -224,7 +251,12 @@ const SpendingModal = ({
             )}
             value={selectedCategory}
             onChange={
-              (_e, value: any) => {
+              (_e, value) => {
+                if (typeof value === "string") {
+                  field.onChange(value);
+                  handleAutocompleteChange(initialEmptyCategoryState);
+                  return;
+                }
                 handleAutocompleteChange(value as CategoryOption | null);
                 return field.onChange(value);
               }
@@ -242,6 +274,9 @@ const SpendingModal = ({
                 if (!user) {
                   console.error("User is not available");
                   return;
+                }
+                if (!month) {
+                  throw new Error("Missing month range for recurring copy action");
                 }
                 closeModal();
                 copyRecurrings.mutate({ userID: user.id, dates: {

--- a/front/src/components/spendings/helpers/useClickSort.ts
+++ b/front/src/components/spendings/helpers/useClickSort.ts
@@ -6,45 +6,36 @@ import {
   SORT_BY_AMOUNT,
 } from "@components/spendings/helpers/sortConstants";
 
-import type { SpendingCompoundType } from "@components/spendings/types";
+import type { SpendingListItem } from "@components/spendings/types";
+
+type SortOrder = "asc" | "desc";
+type SortField = typeof SORT_BY_LABEL | typeof SORT_BY_CATEGORY | typeof SORT_BY_AMOUNT;
 
 const useClickSort = () => {
-  const [spendingsByDaySorted, setSpendingsByDaySorted] = useState<any>([] as unknown as SpendingCompoundType);
-  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
+  const [spendingsByDaySorted, setSpendingsByDaySorted] = useState<SpendingListItem[]>([]);
+  const [sortOrder, setSortOrder] = useState<SortOrder>("asc");
 
-  const onClickSort = (name: string) => {
-    let tempArr: any[] = [];
-
-    // array of spending use [].total and [].date, lodash orderBy remove these two keys
-    let preserveArrayKeys = (() => {
-      const keys = Object.keys(spendingsByDaySorted).filter((k) => isNaN(parseInt(k, 10)));
-      return keys.map(k => ({ [k]: spendingsByDaySorted[k] }));
-    })();
-    ///////////////////////////////////////////////////////////////////////////////////
-
-    setSortOrder('asc');
+  const onClickSort = (name: SortField) => {
+    let sorted: SpendingListItem[] = [];
 
     if (name === SORT_BY_LABEL) {
-      tempArr = _.orderBy(spendingsByDaySorted, o => o.label, [sortOrder]);
+      sorted = _.orderBy(spendingsByDaySorted, (entry) => entry.label, [sortOrder]);
     }
 
     if (name === SORT_BY_CATEGORY) {
-      tempArr = _.orderBy(spendingsByDaySorted, o => o.category, [sortOrder]);
+      sorted = _.orderBy(
+        spendingsByDaySorted,
+        (entry) => ("category" in entry ? entry.category : "") ?? "",
+        [sortOrder]
+      );
     }
 
     if (name === SORT_BY_AMOUNT) {
-      tempArr = _.orderBy(spendingsByDaySorted, o => parseFloat(o.amount), [sortOrder]);
+      sorted = _.orderBy(spendingsByDaySorted, (entry) => entry.amount, [sortOrder]);
     }
 
-    // array of spending use [].total and [].date, lodash orderBy remove these two keys
-    for (const i of preserveArrayKeys) {
-      const tempObjKey = Object.keys(i)[0];
-      tempArr[tempObjKey as unknown as number] = (i as Record<string, unknown>)[tempObjKey];
-    }
-    ///////////////////////////////////////////////////////////////////////////////////
-
-    setSpendingsByDaySorted(tempArr);
-    setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    setSpendingsByDaySorted(sorted);
+    setSortOrder(sortOrder === "asc" ? "desc" : "asc");
   };
 
   return {

--- a/front/src/components/spendings/interfaces/spendingDashboardTypes.ts
+++ b/front/src/components/spendings/interfaces/spendingDashboardTypes.ts
@@ -1,10 +1,10 @@
 export interface Spending {
   ID: string;
   amount: number;
-  category: string;
-  categoryColor: string;
-  categoryID: string;
-  currency: string;
+  category: string | null;
+  categoryColor: string | null;
+  categoryID: string | null;
+  currency: string | null;
   date: string;
   invoicefile: null | string;
   itemType: string;

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
 import { useQueryClient } from "react-query";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faFileUpload } from "@fortawesome/free-solid-svg-icons";
@@ -38,7 +39,7 @@ const InvoiceModal = ({ handleClickOutside, spending }) => {
     !isClickOnThumbnail && handleClickOutside();
   }
 
-  useOnClickOutside(ref as any, handleClickOutsideCheckFullImage);
+  useOnClickOutside(ref as RefObject<HTMLElement>, handleClickOutsideCheckFullImage);
 
   const confirmDeleteImage = () => {
     setShowConfirmDeleteImage(true);

--- a/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
+++ b/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
@@ -1,11 +1,12 @@
 import { useRef } from "react";
+import type { RefObject } from "react";
 import Image from "next/image";
 import useOnClickOutside from 'use-onclickoutside';
 
 
 const InvoiceImageModal = ({ image, closeImage }) => {
   const ref = useRef<HTMLDivElement | null>(null);
-  useOnClickOutside(ref as any, closeImage);
+  useOnClickOutside(ref as RefObject<HTMLElement>, closeImage);
 
   return (
     <div className="fixed top-0 left-0 bottom-0 right-0 bg-grey2 z-10">

--- a/front/src/components/spendings/services/useCategories.ts
+++ b/front/src/components/spendings/services/useCategories.ts
@@ -5,14 +5,20 @@ import {
   QUERY_KEYS,
   QUERY_OPTIONS,
 } from "@components/spendings/config/constants";
+import {
+  CategoryListSchema,
+  UpdateCategoryPayloadSchema,
+} from "@src/schemas/categories";
 
+import type { AxiosError } from "axios";
+import type { UpdateCategoryPayload } from "@src/schemas/categories";
 
 const useCategories = () => {
   const { privateRequest } = useRequestHelper();
   const { user } = useAuth();
   const userID = user?.id;
   const queryClient = useQueryClient();
-  type UpdateCategoryVariables = { singleCategory: any };
+  type UpdateCategoryVariables = { singleCategory: UpdateCategoryPayload };
   type DeleteCategoryVariables = { categoryID: string };
 
   const invalidation = async () => {
@@ -23,37 +29,39 @@ const useCategories = () => {
 
   const getCategoriesService = async () => {
     try {
-      return privateRequest(`/categories?userID=${userID}`);
+      const response = await privateRequest(`/categories?userID=${userID}`);
+      return CategoryListSchema.parse(response.data);
     } catch (e) {
       console.log("get categories error : ", e);
       throw e; // Re-throw pour que React Query gère l'erreur correctement
     }
   };
-  const { data: categories } = useQuery(QUERY_KEYS.CATEGORIES, getCategoriesService, {
+  const { data: categories, error } = useQuery(QUERY_KEYS.CATEGORIES, getCategoriesService, {
       retry: 2, // Retry 2 fois en cas d'erreur
       enabled: !!userID,
       ...QUERY_OPTIONS,
     });
 
 
-  const updateCategoryService = async (category) => {
+  const updateCategoryService = async (category: UpdateCategoryPayload) => {
     try {
-      return privateRequest(`/categories/${category.ID}`, {
+      const payload = UpdateCategoryPayloadSchema.parse(category);
+      return privateRequest(`/categories/${payload.ID}`, {
         method: 'PUT',
-        data: category,
+        data: payload,
       })
     } catch (e) {
       console.log(e);
     }
   };
-  const updateCategory = useMutation<unknown, unknown, UpdateCategoryVariables>(({ singleCategory: category }) => {
+  const updateCategory = useMutation<unknown, AxiosError, UpdateCategoryVariables>(({ singleCategory: category }) => {
     return updateCategoryService(category);
   }, {
     onSuccess: async () => { await invalidation() },
     onError: ((e) => {console.log("error updating category", e)}),
   })
 
-  const deleteCategoryService = async (categoryID) => {
+  const deleteCategoryService = async (categoryID: string) => {
     return privateRequest(`/categories/${categoryID}`, {
       method: 'DELETE',
     });
@@ -67,6 +75,7 @@ const useCategories = () => {
 
   return {
     categories,
+    error,
     deleteCategory,
     updateCategory,
   }

--- a/front/src/components/spendings/services/useCharts.tsx
+++ b/front/src/components/spendings/services/useCharts.tsx
@@ -7,6 +7,7 @@ import { useAuth } from "@auth/context/AuthContext";
 import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import { MONTHLY } from "@components/spendings/spendingDashboard/common/widgetHeaderConstants";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { ChartsCategoryListSchema } from "@src/schemas/stats";
 
 
 const useCharts = (periodType: string) => {
@@ -28,7 +29,8 @@ const useCharts = (periodType: string) => {
   }, [from, to]);
 
   const getCharts = async () => {
-    return privateRequest(`/spendings/charts?userID=${userID}&from=${startDate}&to=${endDate}`);
+    const response = await privateRequest(`/spendings/charts?userID=${userID}&from=${startDate}&to=${endDate}`);
+    return ChartsCategoryListSchema.parse(response.data);
   }
 
   return useQuery([QUERY_KEYS.CHARTS, startDate, endDate], getCharts, {

--- a/front/src/components/spendings/services/useDashboard.ts
+++ b/front/src/components/spendings/services/useDashboard.ts
@@ -8,26 +8,16 @@ import useRequestHelper from "@src/helpers/useRequestHelper";
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { DashboardResponseSchema } from "@src/schemas/dashboard";
 
-import type { UseQueryResult } from "react-query";
+import type { UseMutationResult, UseQueryResult } from "react-query";
+import type { AxiosError } from "axios";
+import type { DashboardResponse } from "@src/schemas/dashboard";
 
-
-export interface DashBoard {
-  ID: string;
-  dateFrom: string;
-  dateTo: string;
-  initialAmount: string;
-  initialCeiling: string;
-  userID: string;
-}
-
-export interface DashBoardData {
-  data: DashBoard;
-}
 
 interface UseDashboard {
-  get: UseQueryResult<DashBoardData>;
-  mutation: any;
+  get: UseQueryResult<DashboardResponse>;
+  mutation: UseMutationResult<unknown, AxiosError, DashboardMutationVariables>;
   remaining: number,
   monthlyTotal: number,
 }
@@ -50,9 +40,10 @@ const useDashboard = (): UseDashboard => {
   const [monthlyTotal, setMonthlyTotal] = useState<number>(0);
 
   const getDashboard = async () => {
-    return privateRequest(
+    const response = await privateRequest(
       `/dashboard?userID=${userID}&start=${startOfMonth(from!)}`
     );
+    return DashboardResponseSchema.parse(response.data);
   };
 
   const setInitialSalary = async (amount: string) => {
@@ -61,7 +52,7 @@ const useDashboard = (): UseDashboard => {
         method: 'POST',
         data: {
           userID,
-          amount,
+          amount: Number(amount),
           start: formatISO(startOfMonth(from!), { representation: "date" }),
           end: formatISO(endOfMonth(from!), { representation: "date" }),
         }
@@ -75,7 +66,7 @@ const useDashboard = (): UseDashboard => {
         method: 'PUT',
         data: {
           userID,
-          amount,
+          amount: Number(amount),
         },
       }
     )
@@ -88,14 +79,14 @@ const useDashboard = (): UseDashboard => {
   });
 
   useEffect(() => {
-    if (get.data?.data && initialAmount) {
-      const totalOfMonth: number = (Number(initialAmount.spendingsSum.amount) + Number(initialAmount.recurringsSum.amount));
+    if (get.data && initialAmount) {
+      const totalOfMonth: number = Number(initialAmount.spendingsSum.amount) + Number(initialAmount.recurringsSum.amount);
       setMonthlyTotal(Number(totalOfMonth.toFixed(2)));
-      setRemaining(Number((Number(get.data.data.initialAmount) - totalOfMonth).toFixed(2)));
+      setRemaining(Number((Number(get.data.initialAmount) - totalOfMonth).toFixed(2)));
     }
   }, [get.data, initialAmount]);
 
-  const mutation = useMutation<unknown, unknown, DashboardMutationVariables>(({ dashboardID, initialAmount }) => {
+  const mutation = useMutation<unknown, AxiosError, DashboardMutationVariables>(({ dashboardID, initialAmount }) => {
     if (dashboardID) {
       return updateInitialSalary(dashboardID, initialAmount);
     } else {
@@ -103,7 +94,7 @@ const useDashboard = (): UseDashboard => {
     }
   }, {
     onSuccess: async () => {
-      await queryClient.invalidateQueries(["dashboard", monthBeginning]);
+      await queryClient.invalidateQueries([QUERY_KEYS.DASHBOARD, monthBeginning]);
     }
   });
 

--- a/front/src/components/spendings/services/useInitialAmount.ts
+++ b/front/src/components/spendings/services/useInitialAmount.ts
@@ -4,6 +4,7 @@ import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { useQuery } from "react-query";
 import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import startOfMonth from "date-fns/startOfMonth";
+import { MonthlyStatsSchema } from "@src/schemas/dashboard";
 
 
 const useInitialAmount = () => {
@@ -20,7 +21,7 @@ const useInitialAmount = () => {
 
     try {
       const monthlyStats = await privateRequest(`/monthlystats?userID=${userID}&from=${startOfMonth(from)}`);
-      return monthlyStats.data;
+      return MonthlyStatsSchema.parse(monthlyStats.data);
     } catch (e) {
       console.log("get initial amount error : ", e);
       throw e;

--- a/front/src/components/spendings/services/useReccurings.ts
+++ b/front/src/components/spendings/services/useReccurings.ts
@@ -6,8 +6,14 @@ import useRequestHelper from "@helpers/useRequestHelper";
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import {
+  RecurringListSchema,
+  RecurringMutationPayloadSchema,
+  SpendingMutationPayloadSchema,
+} from "@src/schemas/spendings";
 
-import type { Spending } from "@components/spendings/interfaces/spendingDashboardTypes";
+import type { AxiosError } from "axios";
+import type { RecurringItem, SpendingMutationPayload } from "@src/schemas/spendings";
 
 
 interface FormattedMonth {
@@ -21,7 +27,7 @@ interface Dates extends FormattedMonth {
 }
 
 interface CreateRecurring {
-  spendingEdited: any;
+  spendingEdited: SpendingMutationPayload;
   formattedMonth: FormattedMonth;
 }
 
@@ -31,7 +37,7 @@ const useReccurings = () => {
   const userID = user?.id;
   const { from } = useDatePickerWrapperStore();
   const monthBeginning = startOfMonth(from!);
-  const [recurrings, setRecurrings] = useState<any[]>([]);
+  const [recurrings, setRecurrings] = useState<RecurringItem[]>([]);
 
 
   const recurringsActionOnSuccess = async (message: string) => {
@@ -42,43 +48,43 @@ const useReccurings = () => {
   }
 
   const getRecurrings = async () => {
-    try {
-      return privateRequest(
-        `/recurrings?userID=${userID}&start=${startOfMonth(from!)}`
-      );
-    } catch (e) {
-      console.log("get recurrings error", e);
-    }
+    const response = await privateRequest(
+      `/recurrings?userID=${userID}&start=${startOfMonth(from!)}`
+    );
+    return RecurringListSchema.parse(response.data);
   }
 
-  const { data, isLoading } = useQuery([QUERY_KEYS.RECURRINGS, monthBeginning], getRecurrings, {
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.RECURRINGS, monthBeginning], getRecurrings, {
     retry: false,
     enabled: !!from && !!userID,
     ...QUERY_OPTIONS,
   });
 
   useEffect(() => {
-    setRecurrings(data?.data);
+    if (data) {
+      setRecurrings(data);
+    }
   }, [data]);
 
   const queryClient = useQueryClient();
 
-  const deleteRecurringService = async (recurring: Spending) => {
+  const deleteRecurringService = async (recurring: DeletableRecurring) => {
     return privateRequest(`/recurrings/${recurring.ID}`, {method: "DELETE"});
   };
 
-  const deleteRecurring = useMutation(({ recurring }: { recurring: Spending }) => {
+  const deleteRecurring = useMutation(({ recurring }: { recurring: DeletableRecurring }) => {
     return deleteRecurringService(recurring);
   }, {
     onSuccess: () => recurringsActionOnSuccess("effacé"),
     onError: ((e) => {console.log("error deleting recurring", e)}),
   });
 
-  const createRecurringService = async (recurring: Spending, formattedMonth: any) => {
+  const createRecurringService = async (recurring: SpendingMutationPayload, formattedMonth: FormattedMonth) => {
+    const payload = SpendingMutationPayloadSchema.parse(recurring);
     return privateRequest("/recurrings", {
       method: "POST",
       data: {
-        ...recurring,
+        ...payload,
         ...formattedMonth,
       }
     });
@@ -94,21 +100,22 @@ const useReccurings = () => {
     });
   };
 
-  const createRecurring = useMutation<unknown, unknown, CreateRecurring>(({ spendingEdited, formattedMonth }: CreateRecurring) => {
+  const createRecurring = useMutation<unknown, AxiosError, CreateRecurring>(({ spendingEdited, formattedMonth }: CreateRecurring) => {
     return createRecurringService(spendingEdited, formattedMonth);
   }, {
     onSuccess: () => recurringsActionOnSuccess("créé"),
     onError: ((e) => {console.log("error creating recurring", e)}),
   });
 
-  const updateRecurringService = async (recurring: any) => {
+  const updateRecurringService = async (recurring: SpendingMutationPayload) => {
+    const payload = RecurringMutationPayloadSchema.parse(recurring);
     return privateRequest(`/recurrings/${recurring.id}`, {
       method: "PUT",
-      data: recurring,
+      data: payload,
     });
   };
 
-  const updateRecurring = useMutation<unknown, unknown, any>((recurring) => {
+  const updateRecurring = useMutation<unknown, AxiosError, SpendingMutationPayload>((recurring) => {
     return updateRecurringService(recurring);
   }, {
     onSuccess: () => { recurringsActionOnSuccess("mis à jour") },
@@ -127,6 +134,7 @@ const useReccurings = () => {
   return {
     recurrings,
     isLoading,
+    error,
     deleteRecurring,
     createRecurring,
     updateRecurring,
@@ -135,3 +143,6 @@ const useReccurings = () => {
 }
 
 export default useReccurings;
+interface DeletableRecurring {
+  ID: string;
+}

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -9,73 +9,76 @@ import useRequestHelper from "@helpers/useRequestHelper";
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import {
+  SpendingListSchema,
+  SpendingMutationPayloadSchema,
+} from "@src/schemas/spendings";
 
-import type { SpendingCompoundType } from "@components/spendings/types";
-import type { Spending } from "@components/spendings/interfaces/spendingDashboardTypes";
+import type { AxiosError } from "axios";
+import type { SpendingDayGroup, SpendingItem } from "@components/spendings/types";
+import type { SpendingMutationPayload } from "@src/schemas/spendings";
+
+interface DeletableSpending {
+  ID: string;
+}
 
 const useSpendings = () => {
-  const [spendingsByWeek, setSpendingsByWeek] = useState<SpendingCompoundType[]>();
-  const [spendingsByMonth, setSpendingsByMonth] = useState<SpendingCompoundType>();
+  const [spendingsByWeek, setSpendingsByWeek] = useState<SpendingDayGroup[]>();
+  const [spendingsByMonth, setSpendingsByMonth] = useState<SpendingItem[]>();
   const { privateRequest } = useRequestHelper();
   const { user } = useAuth();
   const userID = user?.id;
   const { from, to, range } = useDatePickerWrapperStore();
   const monthBeginning = startOfMonth(from!);
 
-  // transform an array of object into an array of array<Object> aggregated
-  // by same date
-  // const aggregateSpendingByDate = (spendings, range, exchangeRates, baseCurrency) => {
-  const aggregateSpendingByDate = (spendings: SpendingCompoundType, range: Date[]): SpendingCompoundType[] => {
-    const tempArr: any = [];
-    tempArr.total = 0;
-    const spendingsPlaceholder = new Array(range.length).fill(tempArr);
-    const spendingsFinal: any[] = [...spendingsPlaceholder];
+  const aggregateSpendingByDate = (spendings: SpendingItem[], dateRange: Date[]): SpendingDayGroup[] => {
+    const grouped = dateRange.map((currentDate) => ({
+      dayOfMonth: getDate(currentDate),
+      total: 0,
+      items: [] as SpendingItem[],
+    }));
 
-    for (let j = 0, r = range.length; j < r; j += 1) {
-      const arr: any = [];
-      arr.total = 0;
-      arr.date = getDate(range[j]);
-      spendingsFinal[j] = arr;
-    }
-
-    for (let i = 0, l = spendings.length; i < l; i += 1 ) {
-      for (let k = 0, ll = spendingsFinal.length; k < ll; k += 1) {
-        if (getDate(parseISO(spendings[i].date)) === spendingsFinal[k].date) {
-          spendingsFinal[k].push(spendings[i]);
-          spendingsFinal[k].total += parseFloat(spendings[i].amount);
-        }
+    for (const spending of spendings) {
+      const day = getDate(parseISO(spending.date));
+      const matchingGroup = grouped.find((entry) => entry.dayOfMonth === day);
+      if (matchingGroup) {
+        matchingGroup.items.push(spending);
+        matchingGroup.total += spending.amount;
       }
     }
 
-    return spendingsFinal;
+    return grouped;
   };
 
   const getSpendings = async () => {
-    try {
-      return privateRequest(
-        `/spendings?userID=${userID}&from=${startOfMonth(from!)}&to=${endOfMonth(to!)}`
-      );
-    } catch (e) {
-      console.log("get spendings error", e);
-    }
+    const response = await privateRequest(
+      `/spendings?userID=${userID}&from=${startOfMonth(from!)}&to=${endOfMonth(to!)}`
+    );
+    return SpendingListSchema.parse(response.data);
   };
 
-  const { data, isLoading } = useQuery([QUERY_KEYS.SPENDINGS_BY_MONTH, startOfMonth(from!), endOfMonth(to!)], getSpendings, {
-    retry: false,
-    // date store is available when coming from login because DatePicker
-    // mounts before Spendings
-    // but I don't know why when already logged in, and coming directly to spendings
-    // Spendings mounts before DatePickerWrapper, causing from to be undefined and
-    // hence this query to fail
-    // so enable below
-    enabled: !!from && !!userID,
-    ...QUERY_OPTIONS,
-  });
+  const { data, isLoading, error } = useQuery(
+    [QUERY_KEYS.SPENDINGS_BY_MONTH, startOfMonth(from!), endOfMonth(to!)],
+    getSpendings,
+    {
+      retry: false,
+      // date store is available when coming from login because DatePicker
+      // mounts before Spendings
+      // but I don't know why when already logged in, and coming directly to spendings
+      // Spendings mounts before DatePickerWrapper, causing from to be undefined and
+      // hence this query to fail
+      // so enable below
+      enabled: !!from && !!userID,
+      ...QUERY_OPTIONS,
+    }
+  );
 
   useEffect(() => {
-    if (data?.data) {
-      range && setSpendingsByWeek(aggregateSpendingByDate(data.data, range));
-      setSpendingsByMonth(data.data);
+    if (data) {
+      if (range) {
+        setSpendingsByWeek(aggregateSpendingByDate(data, range));
+      }
+      setSpendingsByMonth(data);
     }
   }, [data, range]);
 
@@ -91,23 +94,25 @@ const useSpendings = () => {
     await queryClient.invalidateQueries([QUERY_KEYS.CHARTS, monthBeginning]);
   }
 
-  const deleteSpendingService = async (spending: Spending) => {
+  const deleteSpendingService = async (spending: DeletableSpending) => {
     return privateRequest(`/spendings/${spending.ID}`, { method: "DELETE" });
   }
 
-  const deleteSpending = useMutation(({ spending }: { spending: Spending }) => {
+  const deleteSpending = useMutation(({ spending }: { spending: DeletableSpending }) => {
     return deleteSpendingService(spending);
   }, {
     onSuccess: () => { spendingsActionOnSuccess("effacée") }
   });
 
-  const createSpendingService = async (spending: any) => {
+  const createSpendingService = async (spending: SpendingMutationPayload) => {
+    const payload = SpendingMutationPayloadSchema.parse(spending);
     return privateRequest("/spendings", {
       method: 'POST',
-      data: spending,
+      data: payload,
     });
   }
-  const createSpending = useMutation<unknown, unknown, any>((spending) => {
+
+  const createSpending = useMutation<unknown, AxiosError, SpendingMutationPayload>((spending) => {
     return createSpendingService(spending);
   }, {
     onSuccess: () => { spendingsActionOnSuccess("créée") },
@@ -116,14 +121,15 @@ const useSpendings = () => {
     }
   });
 
-  const updateSpendingService = async (spending: any) => {
-    return privateRequest(`/spendings/${spending.id}`, {
+  const updateSpendingService = async (spending: SpendingMutationPayload) => {
+    const payload = SpendingMutationPayloadSchema.parse(spending);
+    return privateRequest(`/spendings/${payload.id}`, {
       method: "PUT",
-      data: spending,
+      data: payload,
     });
   };
 
-  const updateSpending = useMutation<unknown, unknown, any>((spending) => {
+  const updateSpending = useMutation<unknown, AxiosError, SpendingMutationPayload>((spending) => {
     return updateSpendingService(spending);
   }, {
     onSuccess: () => { spendingsActionOnSuccess("mise à jour") },
@@ -136,6 +142,7 @@ const useSpendings = () => {
     spendingsByWeek,
     spendingsByMonth,
     isLoading,
+    error,
     deleteSpending,
     createSpending,
     updateSpending,

--- a/front/src/components/spendings/services/useWeeklyStats.ts
+++ b/front/src/components/spendings/services/useWeeklyStats.ts
@@ -6,6 +6,7 @@ import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constant
 import startOfMonth from "date-fns/startOfMonth";
 import useDashboard from "@components/spendings/services/useDashboard";
 import { endOfMonth } from "date-fns";
+import { WeeklyStatsSchema } from "@src/schemas/dashboard";
 
 
 const useWeeklyStats = () => {
@@ -18,20 +19,21 @@ const useWeeklyStats = () => {
   const queryClient = useQueryClient();
 
   const getWeeklyStats = async () => {
-    try {
-      return privateRequest(`/weeklystats?userID=${userID}&start=${startOfMonth(from!)}`);
-    } catch (e) {
-      console.log("get weekly stats error : ", e);
-    }
+    const response = await privateRequest(`/weeklystats?userID=${userID}&start=${startOfMonth(from!)}`);
+    return WeeklyStatsSchema.parse(response.data);
   };
 
   const setInitialCeiling = async (ceiling: string) => {
+    if (!dashboard?.ID) {
+      return null;
+    }
+
     try {
-      return privateRequest(`/dashboard/${dashboard!.data.ID}`, {
+      return privateRequest(`/dashboard/${dashboard.ID}`, {
         method: "PUT",
         data: {
           userID,
-          ceiling,
+          ceiling: Number(ceiling),
           start: startOfMonth(from!),
           end: endOfMonth(from!),
         }
@@ -49,7 +51,7 @@ const useWeeklyStats = () => {
 
   const mutation = useMutation((ceiling: string) => setInitialCeiling(ceiling), {
     onSuccess: async () => {
-      await queryClient.invalidateQueries(["dashboard", startOfMonth(from!)]);
+      await queryClient.invalidateQueries([QUERY_KEYS.DASHBOARD, startOfMonth(from!)]);
     }
   });
 

--- a/front/src/components/spendings/spendingDashboard/SpendingDashboard.tsx
+++ b/front/src/components/spendings/spendingDashboard/SpendingDashboard.tsx
@@ -16,7 +16,11 @@ interface SpendingDashboardProps {
 const SpendingDashboard = ({ month }: SpendingDashboardProps) => {
   const { isBlurActive } = useBlur();
   const { user } = useAuth();
-  const { recurrings, isLoading: isRecurringsLoading, deleteRecurring } = useReccurings();
+  const { recurrings, isLoading: isRecurringsLoading, error } = useReccurings();
+
+  if (error) {
+    throw error;
+  }
 
   return (
     <div className={`hidden md:flex justify-around mt-14 items-center w-full h-72 bg-grey2 z-30 fixed ${isBlurActive && "blur-xs"}`}>
@@ -28,7 +32,6 @@ const SpendingDashboard = ({ month }: SpendingDashboardProps) => {
         spendingsByDay={recurrings}
         total={0}
         isLoading={isRecurringsLoading}
-        deleteSpending={deleteRecurring}
         user={user}
         recurringType
         month={month}

--- a/front/src/components/spendings/spendingDashboard/charts/Charts.tsx
+++ b/front/src/components/spendings/spendingDashboard/charts/Charts.tsx
@@ -11,7 +11,7 @@ import WidgetHeader from "@components/spendings/spendingDashboard/common/WidgetH
 import SpendingsListModal from "@components/spendings/spendingsListModal/SpendingsListModal";
 import { MONTHLY, WEEKLY } from "@components/spendings/spendingDashboard/common/widgetHeaderConstants";
 
-import type { CategoryProps } from "@src/interfaces/category";
+import type { ChartsCategory } from "@src/schemas/stats";
 
 
 type periodType = typeof MONTHLY | typeof WEEKLY;
@@ -21,8 +21,8 @@ interface ChartsProps {
   periodType: periodType;
 }
 
-const getMaxValue = (data: CategoryProps[]) => Math.max(...data.map(category => +(category.value ?? 0)));
-const getTotal = (data: CategoryProps[]) => data.reduce((acc, curr) => acc + +(curr.value ?? 0), 0);
+const getMaxValue = (data: ChartsCategory[]) => Math.max(...data.map((category) => category.value));
+const getTotal = (data: ChartsCategory[]) => data.reduce((acc, curr) => acc + curr.value, 0);
 
 const widthOfContainer = 290; // 300 - (border width * 2)
 
@@ -31,14 +31,18 @@ const Charts = ({ title, periodType }: ChartsProps) => {
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const [isInvoiceModalVisible, setIsInvoiceModalVisible] = useState(false);
   const [tooltipPos, setTooltipPos] = useState({x: 0, y: 0});
-  const [categoryInfos, setCategoryInfos] = useState<CategoryProps>();
-  const { data: charts } = useCharts(periodType);
+  const [categoryInfos, setCategoryInfos] = useState<ChartsCategory>();
+  const { data: charts, error } = useCharts(periodType);
 
-  const maxv = charts?.data && charts.data.length > 0 ? getMaxValue(charts.data) : 0;
-  const total = charts?.data && charts.data.length > 0 ? getTotal(charts.data) : 0;
+  if (error) {
+    throw error;
+  }
+
+  const maxv = charts && charts.length > 0 ? getMaxValue(charts) : 0;
+  const total = charts && charts.length > 0 ? getTotal(charts) : 0;
 
   // https://keyholesoftware.com/2022/07/13/cancel-a-react-modal-with-escape-key-or-external-click/
-  const handleEscKey = useCallback((event) => {
+  const handleEscKey = useCallback((event: KeyboardEvent) => {
     if (event.key === "Escape") {
       setIsInvoiceModalVisible(false);
     }
@@ -78,7 +82,7 @@ const Charts = ({ title, periodType }: ChartsProps) => {
       />
       <div className="flex w-full h-3/4 overflow-hidden overflow-y-auto">
         {
-          charts?.data.length === 0 && (
+          charts?.length === 0 && (
             <div className="flex justify-center items-center w-full h-full text-8xl text-grey01">
               <div>
                 <FontAwesomeIcon icon={faChartBar} />
@@ -89,7 +93,7 @@ const Charts = ({ title, periodType }: ChartsProps) => {
         <div className="flex flex-col gap-y-1">
         {
           maxv !== 0 && charts &&
-            charts.data.map((category: CategoryProps, index: number) => {
+            charts.map((category: ChartsCategory, index: number) => {
               return (
                 <div
                   key={`cat-${category.category ?? "uncategorized"}-${index}`}
@@ -136,4 +140,3 @@ const Charts = ({ title, periodType }: ChartsProps) => {
 }
 
 export default Charts;
-

--- a/front/src/components/spendings/spendingDashboard/charts/Tooltip.tsx
+++ b/front/src/components/spendings/spendingDashboard/charts/Tooltip.tsx
@@ -1,11 +1,11 @@
 import adjustFontColor from "@components/shared/helpers/adjustColor";
 
-import type { CategoryProps } from "@src/interfaces/category";
+import type { ChartsCategory } from "@src/schemas/stats";
 
 
 interface TooltipProps {
   tooltipPos: { x: number, y: number };
-  categoryInfos: CategoryProps;
+  categoryInfos: ChartsCategory;
 }
 
 const Tooltip = ({ tooltipPos, categoryInfos }: TooltipProps) => {
@@ -27,7 +27,7 @@ const Tooltip = ({ tooltipPos, categoryInfos }: TooltipProps) => {
       {
         categoryInfos && (
           <div
-            className={`flex h-1/2 justify-center items-center uppercase text-tiny font-bold ${adjustFontColor(categoryInfos.categoryColor) === "#ffffff" ? "text-white" : "text-black"}`}
+            className={`flex h-1/2 justify-center items-center uppercase text-tiny font-bold ${adjustFontColor(categoryInfos.categoryColor ?? "#ffffff") === "#ffffff" ? "text-white" : "text-black"}`}
             style={{backgroundColor: categoryInfos?.categoryColor ?? "#ffffff"}}
           >
             {categoryInfos?.category ?? "sans catégories"}
@@ -39,4 +39,3 @@ const Tooltip = ({ tooltipPos, categoryInfos }: TooltipProps) => {
 };
 
 export default Tooltip;
-

--- a/front/src/components/spendings/spendingDashboard/monthlyBudget/MonthlyBudget.tsx
+++ b/front/src/components/spendings/spendingDashboard/monthlyBudget/MonthlyBudget.tsx
@@ -15,16 +15,24 @@ interface InitialSalary {
 const MonthlyBudget = () => {
   const { to } = useDatePickerWrapperStore();
   const [isInputVisible, setIsInputVisible] = useState<boolean>(false);
-  const { get : { data: dashboard }, mutation, remaining, monthlyTotal } = useDashboard();
-  const { data: initialAmount } = useInitialAmount();
+  const { get : { data: dashboard, error: dashboardError }, mutation, remaining, monthlyTotal } = useDashboard();
+  const { data: initialAmount, error: initialAmountError } = useInitialAmount();
   const { register, handleSubmit, setFocus, reset } = useForm<InitialSalary>();
   const [monthlyTotalPercentage, setMonthlyTotalPercentage] = useState<number>(0);
+
+  if (dashboardError) {
+    throw dashboardError;
+  }
+
+  if (initialAmountError) {
+    throw initialAmountError;
+  }
 
   useEffect(() => {
     if (dashboard && initialAmount) {
       reset();
-      if (dashboard.data?.initialAmount && monthlyTotal) {
-        const percentage = +(((monthlyTotal / +dashboard.data.initialAmount) * 100).toFixed(2));
+      if (dashboard.initialAmount && monthlyTotal) {
+        const percentage = +(((monthlyTotal / +dashboard.initialAmount) * 100).toFixed(2));
         setMonthlyTotalPercentage(Math.min(100, percentage));
       }
     }
@@ -32,7 +40,7 @@ const MonthlyBudget = () => {
 
   const onSubmit = (value: InitialSalary) => {
     setIsInputVisible(false);
-    mutation.mutate({dashboardID: dashboard?.data?.ID, initialAmount: value.initialAmount});
+    mutation.mutate({ dashboardID: dashboard?.ID, initialAmount: value.initialAmount });
   }
 
   useEffect(() => {
@@ -55,7 +63,7 @@ const MonthlyBudget = () => {
             onClick={() => {setIsInputVisible(true)}}
           >
             <div className="text-initialAmount font-bold hover:bg-initialAmountHover hover:cursor-pointer hover:rounded-sm hover:px-1">
-              {dashboard?.data?.initialAmount ?? 0} €
+              {dashboard?.initialAmount ?? 0} €
             </div>
           </div>
 
@@ -69,7 +77,7 @@ const MonthlyBudget = () => {
                   <input
                     className="w-10 outline-0 bg-transparent border-b border-b-black"
                     onKeyDown={(e: KeyboardEvent) => {e.key === "Escape" && setIsInputVisible(false)}}
-                    defaultValue={dashboard?.data?.initialAmount ?? 0}
+                    defaultValue={dashboard?.initialAmount ?? 0}
                     {...register("initialAmount")}
                   />
                 </form>

--- a/front/src/components/spendings/spendingDashboard/weeklyStats/WeeklyStats.tsx
+++ b/front/src/components/spendings/spendingDashboard/weeklyStats/WeeklyStats.tsx
@@ -25,16 +25,24 @@ const WeeklyStats = () => {
   const { makeSlices, makeRange, isCurrentWeek} = useWeeklyStatsHelper();
   const { from } = useDatePickerWrapperStore();
   const [isInputVisible, setIsInputVisible] = useState<boolean>(false);
-  const { get: { data: weeklyStats }, mutation } = useWeeklyStats();
-  const { get: { data: dashboard } } = useDashboard();
+  const { get: { data: weeklyStats, error: weeklyStatsError }, mutation } = useWeeklyStats();
+  const { get: { data: dashboard, error: dashboardError } } = useDashboard();
   const { register, handleSubmit, setFocus, reset } = useForm<InitialCeiling>();
   const [initialCeiling, setInitialCeiling] = useState<number>(0);
-  const [weeklySlices, setWeeklySlices] = useState<any>();
+  const [weeklySlices, setWeeklySlices] = useState<Array<string | number>>([]);
   const [averageWeeklyStatsAmount, setAverageWeeklyStatsAmount] = useState(0);
   const CEILING_WARN_LIMIT = 50;
 
+  if (weeklyStatsError) {
+    throw weeklyStatsError;
+  }
+
+  if (dashboardError) {
+    throw dashboardError;
+  }
+
   useEffect(() => {
-    dashboard?.data ? setInitialCeiling(+dashboard?.data?.initialCeiling) : setInitialCeiling(0);
+    dashboard ? setInitialCeiling(+dashboard.initialCeiling) : setInitialCeiling(0);
   }, [dashboard]);
 
   useEffect(() => {
@@ -46,9 +54,9 @@ const WeeklyStats = () => {
   }, [from]);
 
   useEffect(() => {
-    if (weeklyStats?.data.length > 0) {
+    if (weeklyStats && weeklyStats.length > 0) {
       // filter(Boolean) removes 0 from array
-      const zeroedOutWeeklyStats = weeklyStats!.data.filter(Boolean);
+      const zeroedOutWeeklyStats = weeklyStats.filter(Boolean);
       setAverageWeeklyStatsAmount(
         accurateFixed(
           zeroedOutWeeklyStats
@@ -82,9 +90,9 @@ const WeeklyStats = () => {
 
         <div
           className={`${!isInputVisible ? "visible" : "hidden"}`}
-          onClick={() => {dashboard?.data?.initialAmount && setIsInputVisible(true)}}
+          onClick={() => {dashboard?.initialAmount && setIsInputVisible(true)}}
         >
-          <div className={`text-initialAmountWeekly font-bold px-1 ${dashboard?.data?.initialAmount ? "hover:bg-initialAmountHover hover:text-spendingActionHover hover:cursor-pointer hover:rounded-sm" : "cursor-not-allowed"}`}>
+          <div className={`text-initialAmountWeekly font-bold px-1 ${dashboard?.initialAmount ? "hover:bg-initialAmountHover hover:text-spendingActionHover hover:cursor-pointer hover:rounded-sm" : "cursor-not-allowed"}`}>
             {initialCeiling ?? 0} €
           </div>
         </div>
@@ -107,15 +115,15 @@ const WeeklyStats = () => {
 
       <div className="flex flex-col justify-center w-5/6 text-sm gap-y-1 h-1/2">
         {
-          weeklyStats?.data.length > 0 && weeklySlices?.length > 0 ?
-            weeklyStats!.data.map((weekSliceValue: number, i: number) => {
+          weeklyStats && weeklyStats.length > 0 && weeklySlices.length > 0 ?
+            weeklyStats.map((weekSliceValue: number, i: number) => {
               const ceilingDiff = weekSliceValue - initialCeiling;
               return (
                 <div
                   key={i}
-                  className={`flex justify-between items-center ${isCurrentWeek(weeklySlices[i], from) && "font-bold bg-grey3 rounded-sm"}`}
+                  className={`flex justify-between items-center ${from && isCurrentWeek(weeklySlices[i], from) && "font-bold bg-grey3 rounded-sm"}`}
                 >
-                  {isCurrentWeek(weeklySlices[i], from)}
+                  {from ? isCurrentWeek(weeklySlices[i], from) : false}
                   <div className="flex w-4/12 gap-x-2">
                     <div>{weeklySlices[i]}</div>
                     <div>:</div>
@@ -169,4 +177,3 @@ const WeeklyStats = () => {
 }
 
 export default WeeklyStats;
-

--- a/front/src/components/spendings/spendingDashboard/weeklyStats/helpers/useWeeklyStatsHelper.ts
+++ b/front/src/components/spendings/spendingDashboard/weeklyStats/helpers/useWeeklyStatsHelper.ts
@@ -5,7 +5,7 @@ import getDate from "date-fns/getDate";
 
 
 const useWeeklyStatsHelper = () => {
-  const makeRange = (from: any) => {
+  const makeRange = (from: Date) => {
     const ranges: number[] = [];
     const startDate = startOfMonth(from);
     const dayNumberFromMonthStart = getDay(startDate); // Sunday is 0
@@ -35,7 +35,7 @@ const useWeeklyStatsHelper = () => {
     return acc;
   }, [] as Array<string | number>);
 
-  const isCurrentWeek = (slice: string | number, from: any) => {
+  const isCurrentWeek = (slice: string | number, from: Date) => {
     return typeof slice === 'string' ?
       +(slice.split(' - ')[0]) === getDate(from)
       :

--- a/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
-import format from 'date-fns/format';
 import { getDayOfYear, endOfMonth } from "date-fns";
-import fr from "date-fns/locale/fr";
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 import useSpendingDayItem from "@components/spendings/spendingDayItem/spendingItem/helpers/useSpendingDayItem";
 import SpendingItemHeader from "@components/spendings/spendingDayItem/SpendingItemHeader";
 import useClickSort from "@components/spendings/helpers/useClickSort";
@@ -13,27 +9,27 @@ import SpendingSort from "@components/spendings/spendingSort/SpendingSort";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal"
 import type { AuthUser } from "@auth/types";
 
-import type { SpendingCompoundType, SpendingType } from "@components/spendings/types";
-import { dividerClasses } from "@mui/material";
+import type { SpendingItem, SpendingListItem } from "@components/spendings/types";
+import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
 import CategoryComponent from "@components/common/Category";
 import useDashboard from "@components/spendings/services/useDashboard";
 
 interface SpendingDayItemProps {
-  spendingsByDay: any;
-  deleteSpending?: any;
+  spendingsByDay: SpendingListItem[];
   isLoading: boolean;
   date?: Date;
   user?: AuthUser | null;
   recurringType?: boolean;
-  month?: any;
+  month?: MonthRange | null;
   total?: number;
 }
 
 
-const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recurringType = false, month = null }: SpendingDayItemProps) => {
+const SpendingDayItem = ({ spendingsByDay, isLoading, date, recurringType = false, month = null, total = 0 }: SpendingDayItemProps) => {
   const { remaining: remainingAmount } = useDashboard();
   const [todayCredits, setTodayCredits] = useState<number>(0);
   const [isToday, setIsToday] = useState(false);
+  const [displayTotal, setDisplayTotal] = useState<number>(total);
 
   useEffect(() => {
     if (date) {
@@ -56,35 +52,40 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
 
   useEffect(() => {
     setSpendingsByDaySorted(spendingsByDay);
-  }, [spendingsByDay]);
+    setDisplayTotal(total);
+  }, [spendingsByDay, setSpendingsByDaySorted, total]);
 
-  const getRecurringsTotal = (recurrings: SpendingCompoundType) => {
+  const getRecurringsTotal = (recurrings: SpendingListItem[]) => {
     if (recurrings?.length > 0) {
       return recurrings.reduce((acc, curr) => {
-        acc = acc + Number(curr.amount);
-        return acc;
+        return acc + Number(curr.amount);
       }, 0);
     }
+    return 0;
   }
 
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   useEffect(() => {
     if (selectedCategory) {
       const spendingsFilteredByCategory = spendingsByDay.filter(
-        (spending: SpendingType) => {
+        (spending) => {
+          if (!("category" in spending)) {
+            return false;
+          }
           if (spending.category === null && selectedCategory === "none") return true;
           return spending.category === selectedCategory;
         }
       );
-      const total = spendingsFilteredByCategory.length > 0 ? spendingsFilteredByCategory.reduce((acc, spending) => {
-        return Number(spending.amount) + acc;
+      const filteredTotal = spendingsFilteredByCategory.length > 0 ? spendingsFilteredByCategory.reduce((acc, spending) => {
+        return spending.amount + acc;
       }, 0) : 0;
-      spendingsFilteredByCategory.total = total.toFixed(2);
       setSpendingsByDaySorted(spendingsFilteredByCategory);
+      setDisplayTotal(filteredTotal);
     } else {
       setSpendingsByDaySorted(spendingsByDay);
+      setDisplayTotal(total);
     }
-  }, [selectedCategory]);
+  }, [selectedCategory, setSpendingsByDaySorted, spendingsByDay, total]);
 
   const {
     isModalVisible,
@@ -97,8 +98,11 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
     editSpending,
   } = useSpendingDayItem();
 
-  const getCategories = (spendingsByDay) => Array.from(new Set(spendingsByDay.map((spending: SpendingType) => spending.category)))
-  const getCategoryColor = (category) => spendingsByDay?.filter((spending) => spending.category === category)[0].categoryColor || "#fff";
+  const categorySpendings = spendingsByDay.filter((spending): spending is SpendingItem => "category" in spending);
+  const getCategories = (items: SpendingItem[]) =>
+    Array.from(new Set(items.map((spending) => spending.category).filter((category): category is string | null => category !== undefined)));
+  const getCategoryColor = (category: string | null) =>
+    categorySpendings.find((spending) => spending.category === category)?.categoryColor ?? "#fff";
 
   return (
     <div
@@ -125,14 +129,14 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
           }
         </div>
         <SpendingItemHeader
-          date={date!}
+          date={date}
           recurringType={recurringType}
           isToday={isToday}
           addSpending={addSpending}
           addSpendingEnabled={addSpendingEnabled}
         />
         <div className={`flex ${recurringType || !isToday ? "justify-center" : "justify-between"} items-center font-poppins border-b border-b-grey3 mx-3`}>
-          {spendingsByDaySorted &&
+          {spendingsByDaySorted.length > 0 &&
             <div className="flex justify-center gap-x-2 text-md">
               <div className="uppercase">{spendingsText.dayItem.total}</div>
               <div className="total-amount font-bold">
@@ -140,7 +144,7 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
                   ?
                   <div>{Number(getRecurringsTotal(spendingsByDaySorted) || 0).toFixed(2)} €</div>
                   :
-                  <div>{Number(spendingsByDaySorted.total).toFixed(2)} €</div>
+                  <div>{Number(displayTotal).toFixed(2)} €</div>
                 }
               </div>
             </div>
@@ -154,12 +158,11 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
         {!recurringType &&
           <div className="flex overflow-y-auto max-h-7 bg-white space-x-2 border-b border-b-grey2 mx-3 py-1 justify-between">
             <div className="flex flex-row space-x-1">
-            {spendingsByDay &&
-              getCategories(spendingsByDay).map(
-                // @ts-ignore
+            {categorySpendings.length > 0 &&
+              getCategories(categorySpendings).map(
                 (category: string | null) =>
                   <div
-                    key={(new Date()).getMilliseconds() + Math.trunc(Math.random()*1000000)}
+                    key={category ?? "none"}
                     className="cursor-pointer"
                     onClick={() => {
                       const nextCategory = category ?? "none";
@@ -194,7 +197,6 @@ const SpendingDayItem = ({ spendingsByDay, deleteSpending, isLoading, date, recu
         <div className="flex flex-col mt-2">
           <SpendingsListContainer
             spendingsByDaySorted={spendingsByDaySorted}
-            deleteSpending={deleteSpending}
             toggleAddSpending={toggleAddSpending}
             editSpending={editSpending}
             isLoading={isLoading}

--- a/front/src/components/spendings/spendingDayItem/SpendingItemHeader.tsx
+++ b/front/src/components/spendings/spendingDayItem/SpendingItemHeader.tsx
@@ -5,7 +5,7 @@ import { faPlusSquare } from "@fortawesome/free-solid-svg-icons";
 import spendingsText from "@components/spendings/config/text";
 
 interface SpendingItemHeaderProps {
-  date: Date;
+  date?: Date;
   recurringType: boolean;
   isToday: boolean;
   addSpending: () => void;
@@ -19,7 +19,7 @@ const SpendingItemHeader = ({ date, recurringType, isToday, addSpending, addSpen
         !recurringType
           ?
           <div className={`flex font-poppins uppercase ${isToday ? "bg-datePickerWrapper" : "bg-grey01"} text-blueNavy justify-center font-bold text-sm items-center rounded-sm w-5/6 h-6`}>
-            <div>{format(date, "dd MMM yyyy", { locale: fr })}</div>
+            <div>{date ? format(date, "dd MMM yyyy", { locale: fr }) : ""}</div>
           </div>
           :
           <div className="flex text-grey2 uppercase justify-center items-center font-bold text-sm bg-grey0 rounded-sm w-5/6">

--- a/front/src/components/spendings/spendingDayItem/spendingItem/SpendingItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/spendingItem/SpendingItem.tsx
@@ -5,15 +5,22 @@ import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import CategoryComponent from '@components/common/Category';
 // import cssSizes from "@src/css-sizes";
 import ConfirmDeletePopin from "@components/spendings/common/deleteSpendingPopin";
+import type { SpendingListItem } from "@components/spendings/types";
+
+interface SpendingItemProps {
+  spending: SpendingListItem;
+  editCallback: (spending: SpendingListItem) => void;
+  toggleAddSpending: () => void;
+  isRecurring?: boolean;
+}
 
 
 const SpendingItem = ({
   spending,
   editCallback,
-  deleteCallback,
   toggleAddSpending,
   isRecurring,
-}) => {
+}: SpendingItemProps) => {
   const [isHover, setIsHover] = useState(false);
   const [isDeleteConfirmVisible, setIsDeleteConfirmVisible] = useState(false);
   const [isInvoiceModalVisible, setIsInvoiceModalVisible] = useState(false);
@@ -59,11 +66,11 @@ const SpendingItem = ({
             </div>
 
             {!isRecurring && (
-              spending?.category ?
+              ("category" in spending && spending?.category) ?
                 <div className="flex justify-center items-center w-1/3">
                   <div className="w-3/4">
                     {spending?.category &&
-                      <CategoryComponent item={spending} />
+                      <CategoryComponent item={{ category: spending.category ?? null, categoryColor: spending.categoryColor ?? null }} />
                     }
                   </div>
                 </div>
@@ -73,7 +80,7 @@ const SpendingItem = ({
 
             <div className={`flex justify-around items-center ${!isRecurring ? "w-1/6" : "w-1/4"} text-grey1`}>
               <div
-                className={`cursor-pointer ${spending.invoicefile ? "text-invoiceImageIsPresent hover:text-invoiceImageIsPresentHover" : "hover:text-spendingActionHover"}`}
+                className={`cursor-pointer ${("invoicefile" in spending && spending.invoicefile) ? "text-invoiceImageIsPresent hover:text-invoiceImageIsPresentHover" : "hover:text-spendingActionHover"}`}
                 title="display invoice"
                 onClick={() => {setIsInvoiceModalVisible(!isInvoiceModalVisible)}}
               >
@@ -104,17 +111,13 @@ const SpendingItem = ({
 
           </div>
           :
-          <ConfirmDeletePopin spending={spending} recurringType={isRecurring} hideConfirm={hideConfirm} />
+          <ConfirmDeletePopin spending={spending} recurringType={Boolean(isRecurring)} hideConfirm={hideConfirm} />
       }
     </div>
   )
 }
 
 export default SpendingItem;
-
-
-
-
 
 
 

--- a/front/src/components/spendings/spendingDayItem/spendingItem/helpers/useSpendingDayItem.ts
+++ b/front/src/components/spendings/spendingDayItem/spendingItem/helpers/useSpendingDayItem.ts
@@ -1,10 +1,10 @@
-import { SpendingCompoundType } from "@components/spendings/types";
 import { useState } from "react";
+import type { SpendingListItem } from "@components/spendings/types";
 
 const useSpendingDayItem = () => {
   const [isModalVisible, setIsModalVisible] = useState(false);
   const [addSpendingEnabled, setAddSpendingEnabled] = useState(true);
-  const [spending, setSpending] = useState({});
+  const [spending, setSpending] = useState<SpendingListItem | null>(null);
   const [isEditing, setIsEditing] = useState(false);
 
   const addSpending = () => {
@@ -15,7 +15,7 @@ const useSpendingDayItem = () => {
   const closeModal = () => {
     setIsModalVisible(false);
     setAddSpendingEnabled(true);
-    setSpending({});
+    setSpending(null);
     setIsEditing(false);
   };
 
@@ -23,7 +23,7 @@ const useSpendingDayItem = () => {
     setAddSpendingEnabled(!addSpendingEnabled);
   };
 
-  const editSpending = (spending: SpendingCompoundType) => {
+  const editSpending = (spending: SpendingListItem) => {
     setIsEditing(true);
     setIsModalVisible(true);
     setAddSpendingEnabled(false);
@@ -43,4 +43,3 @@ const useSpendingDayItem = () => {
 }
 
 export default useSpendingDayItem;
-

--- a/front/src/components/spendings/spendingsListContainer/SpendingListContainer.tsx
+++ b/front/src/components/spendings/spendingsListContainer/SpendingListContainer.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from "react";
 import SpendingItem from "@components/spendings/spendingDayItem/spendingItem/SpendingItem";
 
 import type { SpendingsListContainerType } from "@components/spendings/types";
@@ -7,34 +6,25 @@ import Spinner from "@components/common/Spinner";
 
 const SpendingsListContainer = ({
   spendingsByDaySorted,
-  deleteSpending,
   toggleAddSpending,
   editSpending,
   isLoading,
   recurringType
 }: SpendingsListContainerType) => {
-  const [spendings, setSpendings] = useState<any>();
-
-  useEffect(() => {
-    setSpendings(spendingsByDaySorted);
-  }, [recurringType, spendingsByDaySorted]);
-
   return (
   <div className={`space-y-1 ${recurringType ? 'recurrings' : 'spendings'}-list-container overflow-auto ${recurringType ? "h-[150px] w-[390px] px-2" : "h-[210px]"}`}>
     {
-      spendings?.length > 0 ?
+      spendingsByDaySorted?.length > 0 ?
         isLoading ?
           <div className="flex justify-center items-center h-[220px]">
             <Spinner />
           </div>
           :
-          // spendingsByDay.map((spending: SpendingType) => {
-          spendings.map((spending: any) => (
+          spendingsByDaySorted.map((spending) => (
               <SpendingItem
                 key={spending.ID}
                 spending={spending}
                 editCallback={editSpending}
-                deleteCallback={deleteSpending}
                 toggleAddSpending={toggleAddSpending}
                 isRecurring={recurringType}
               />

--- a/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
+++ b/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
@@ -20,10 +20,10 @@ import texts from "@components/spendings/config/text";
 import { DASHBOARD_PATH, DATE_QUERY_PARAM } from "@helpers/dateRoute";
 
 import type { CategoryProps } from "@src/interfaces/category";
-import type { SpendingType } from "@components/spendings/types";
+import type { SpendingItem } from "@components/spendings/types";
 
 interface SpendingsListModalProps {
-  handleClickOutside: any;
+  handleClickOutside: () => void;
   periodType: string;
   categoryInfos: CategoryProps;
   total: number;
@@ -53,8 +53,8 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
     }
   }, []);
 
-  const groupByDate = (spendings: SpendingType[]): Record<string, SpendingType[]> => {
-    return spendings?.reduce((acc: Record<string, SpendingType[]>, curr) => {
+  const groupByDate = (spendings: SpendingItem[]): Record<string, SpendingItem[]> => {
+    return spendings?.reduce((acc: Record<string, SpendingItem[]>, curr) => {
       if (!acc[curr.date]) {
         acc[curr.date] = []
       }
@@ -64,7 +64,7 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
   }
 
   const displaySpendingsList = () => {
-    const getAllPreviousEntries = (currentIndex: number): SpendingType[] => {
+    const getAllPreviousEntries = (currentIndex: number): SpendingItem[] => {
       const normalizedSearchTerm = searchTerm.toLowerCase();
 
       if (periodType === MONTHLY && spendingsByMonth) {
@@ -76,11 +76,11 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
         const entries = Object.entries(grouped);
         return entries
           .slice(0, currentIndex + 1)
-          .reduce((acc: SpendingType[], [_, daySpendings]) => [...acc, ...daySpendings as SpendingType[]], []);
+          .reduce((acc: SpendingItem[], [_, daySpendings]) => [...acc, ...daySpendings as SpendingItem[]], []);
       } else if (spendingsByWeek) {
         const flattenedSpendings = spendingsByWeek
-          .filter(spending => spending.length > 0)
-          .flat()
+          .filter((spendingGroup) => spendingGroup.items.length > 0)
+          .flatMap((spendingGroup) => spendingGroup.items)
           .filter(spending =>
             spending.category === categoryInfos.category &&
             spending.label.toLowerCase().includes(normalizedSearchTerm)
@@ -89,16 +89,16 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
         const entries = Object.entries(grouped);
         return entries
           .slice(0, currentIndex + 1)
-          .reduce((acc: SpendingType[], [_, daySpendings]) => [...acc, ...daySpendings as SpendingType[]], []);
+          .reduce((acc: SpendingItem[], [_, daySpendings]) => [...acc, ...daySpendings as SpendingItem[]], []);
       }
       return [];
     };
 
-    const calculateDayTotal = (daySpendings: SpendingType[]): number => {
+    const calculateDayTotal = (daySpendings: SpendingItem[]): number => {
       return daySpendings.reduce((acc, spending) => acc + Number(spending.amount), 0);
     };
 
-    const spendingsList = (spendings: [string, SpendingType[]], i: number) => {
+    const spendingsList = (spendings: [string, SpendingItem[]], i: number) => {
       const dayTotal = calculateDayTotal(spendings[1]);
       const cumulativeTotal = getAllPreviousEntries(i)
         .reduce((acc, spending) => acc + Number(spending.amount), 0);
@@ -159,7 +159,7 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
           )}
 
           <div className="flex flex-col space-y-2 py-2">
-            {spendings[1].map((spending: SpendingType, j: number) => (
+            {spendings[1].map((spending: SpendingItem, j: number) => (
               <div
                 className="flex items-center space-x-2 text-sm px-2"
                 key={i + j}
@@ -202,8 +202,8 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
         Object.entries(
           groupByDate(
             spendingsByWeek
-              .filter((spending) => spending.length > 0)
-              .flat()
+              .filter((spendingGroup) => spendingGroup.items.length > 0)
+              .flatMap((spendingGroup) => spendingGroup.items)
               ?.filter((spending) => {
                 return (spending.category === categoryInfos.category) &&
                   spending.label.toLowerCase().includes(normalizedSearchTerm);

--- a/front/src/components/spendings/types.ts
+++ b/front/src/components/spendings/types.ts
@@ -1,48 +1,26 @@
 import { User } from "@src/interfaces/user";
+import type {
+  RecurringItem,
+  SpendingItem,
+} from "@src/schemas/spendings";
 
 export type Month =
   | { start: Date; end: Date; }
   | null;
 
+export type SpendingListItem = SpendingItem | RecurringItem;
+export type { SpendingItem, RecurringItem };
 
-export type ReccuringType = {
-  amount: number;
-  createdAt: string;
-  createdBy: string;
-  currency: string;
-  dateFrom: string;
-  dateTo: string;
-  itemType: string;
-  label: string;
-  updatedAt: string;
-  id?: number;
-};
+export interface SpendingDayGroup {
+  dayOfMonth: number;
+  total: number;
+  items: SpendingItem[];
+}
 
-export type SpendingType = {
-  amount: string;
-  catID: number;
-  category: string;
-  createdAt: string;
-  createdBy: string;
-  currency: string;
-  date: string;
-  itemType: string;
-  label: string;
-  updatedAt: string;
-  id?: number;
-};
-
-export type SpendingCompoundType = SpendingType[] & {
-  id: string;
-  date: number;
-  total : number
-};
-
-export type SpendingsType = Array<SpendingCompoundType>;
+export type SpendingsType = Array<SpendingDayGroup>;
 
 interface SpendingsPartial {
-  spendingsByDaySorted: SpendingCompoundType;
-  deleteSpending: (itemID: string, itemType: string) => void;
+  spendingsByDaySorted: SpendingListItem[];
   isLoading: boolean;
   recurringType?: boolean;
 }
@@ -50,12 +28,11 @@ interface SpendingsPartial {
 export interface SpendingDayItemType extends SpendingsPartial {
   user: User;
   month?: string | null;
-  date?: number | Date;
+  date?: Date;
   total?: number;
 }
 
 export interface SpendingsListContainerType extends SpendingsPartial {
   toggleAddSpending: () => void;
-  editSpending: (spending: SpendingCompoundType) => void;
+  editSpending: (spending: SpendingListItem) => void;
 }
-

--- a/front/src/components/statistics/PFABarCharts.tsx
+++ b/front/src/components/statistics/PFABarCharts.tsx
@@ -10,9 +10,16 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 
-const PFABarCharts = ({ data, year }) => {
-  const currentYearData = data?.data?.[year] ?? 0;
-  if (!currentYearData) {
+import type { StatisticsResponse } from "@src/schemas/stats";
+
+interface PFABarChartsProps {
+  data: StatisticsResponse | null;
+  year: number;
+}
+
+const PFABarCharts = ({ data, year }: PFABarChartsProps) => {
+  const currentYearData = data?.data?.[String(year)] ?? [];
+  if (currentYearData.length === 0) {
     return <div className="text-center text-sm text-gray-500">pas de données.</div>;
   }
 
@@ -25,9 +32,9 @@ const PFABarCharts = ({ data, year }) => {
         <XAxis dataKey="month" />
         <YAxis />
         <Tooltip
-          labelFormatter={(label: any) => `${label} ${year}`}
+          labelFormatter={(label: string | number) => `${label} ${year}`}
           labelClassName="bg-gray-200 p-1 rounded-sm font-semibold"
-          formatter={(value: any) => `${value} €`}
+          formatter={(value: number | string) => `${value} €`}
           offset={7}
           contentStyle={{
             fontSize: "0.8rem",
@@ -47,7 +54,7 @@ const PFABarCharts = ({ data, year }) => {
                 dataKey={key}
                 fill="#111"
                 position="top"
-                formatter={(label: any) => Number(label) > 0 ? `${label}€` : ""}
+                formatter={(label: number | string | boolean | null | undefined) => Number(label ?? 0) > 0 ? `${label}€` : ""}
                 fontSize="10px"
               />
             </Bar>

--- a/front/src/components/statistics/PFALineCharts.tsx
+++ b/front/src/components/statistics/PFALineCharts.tsx
@@ -9,12 +9,19 @@ import {
   YAxis
 } from "recharts";
 
-const PFALineCharts = ({ data, year }) => {
-  const lineData = data?.data?.[year] ?? 0;
+import type { StatisticsResponse } from "@src/schemas/stats";
+
+interface PFALineChartsProps {
+  data: StatisticsResponse | null;
+  year: number;
+}
+
+const PFALineCharts = ({ data, year }: PFALineChartsProps) => {
+  const lineData = data?.data?.[String(year)] ?? [];
   const colors = data?.colors ?? {};
   const categories = Object.keys(colors).sort();
 
-  if (!lineData) {
+  if (lineData.length === 0) {
     return <div className="text-center text-sm text-gray-500">pas de données.</div>;
   }
   
@@ -25,9 +32,9 @@ const PFALineCharts = ({ data, year }) => {
         <XAxis dataKey="month" />
         <YAxis />
         <Tooltip
-          labelFormatter={label => `${label} ${year}`}
+          labelFormatter={(label: string | number) => `${label} ${year}`}
           labelClassName="bg-gray-200 p-1 rounded-sm font-semibold"
-          formatter={(value: number) => `${value} €`}
+          formatter={(value: number | string) => `${value} €`}
           offset={7}
           contentStyle={{
             fontSize: "0.8rem",

--- a/front/src/components/statistics/PFAResponsiveChartsContainer.tsx
+++ b/front/src/components/statistics/PFAResponsiveChartsContainer.tsx
@@ -1,4 +1,10 @@
-const PFAResponsiveChartsContainer = ({ children }) => (
+import type { ReactNode } from "react";
+
+interface PFAResponsiveChartsContainerProps {
+  children: ReactNode;
+}
+
+const PFAResponsiveChartsContainer = ({ children }: PFAResponsiveChartsContainerProps) => (
   <div className="bg-[#adadad] p-4 rounded-sm w-full lg:w-1/2 h-[500px]">
     <div className="h-full w-full">
       {children}

--- a/front/src/components/statistics/Statistics.tsx
+++ b/front/src/components/statistics/Statistics.tsx
@@ -10,14 +10,24 @@ import useStatistics from "@components/statistics/services/useStatistics";
 import PFABarCharts from "@components/statistics/PFABarCharts";
 import PFALineCharts from "@components/statistics/PFALineCharts";
 import PFAResponsiveChartsContainer from "@components/statistics/PFAResponsiveChartsContainer";
+import type { StatisticsCategoryOption } from "@components/statistics/helpers/useStatisticsCategories";
 
+interface YearOption {
+  value: number;
+  label: number;
+}
+
+interface StatisticsFormValues {
+  categorySelector: StatisticsCategoryOption[];
+  yearSelector: YearOption;
+}
 
 const firstYearAvailable = 2018;
 
 const Statistics = () => {
-  const { categories } = useCategories();
+  const { categories, error: categoriesError } = useCategories();
   const categoriesMarshalled = useStatisticsCategories(categories);
-  const [initialCategories, setinitialCategories] = useState();
+  const [initialCategories, setInitialCategories] = useState<StatisticsCategoryOption[]>([]);
 
   const currentYear = new Date().getFullYear();
   const makeYearsOptions = () => {
@@ -28,13 +38,13 @@ const Statistics = () => {
     return years.map(year => ({ value: year, label: year }));
   };
 
-  const defaultYear = { value: currentYear, label: currentYear };
-  const [initialYear, setinitialYear] = useState<number | { value: number; label: number }>(defaultYear);
+  const defaultYear: YearOption = { value: currentYear, label: currentYear };
+  const [initialYear, setInitialYear] = useState<YearOption>(defaultYear);
 
-  const { control, watch } = useForm<any>({
+  const { control, watch } = useForm<StatisticsFormValues>({
     mode: "onChange",
     defaultValues: {
-      categories: [],
+      categorySelector: [],
       yearSelector: defaultYear,
     }
   });
@@ -42,11 +52,15 @@ const Statistics = () => {
   const categorySelectorWatcher = watch("categorySelector");
   const yearSelectorWatcher = watch("yearSelector");
 
-  const { isLoading: isStatisticsLoading, statistics } = useStatistics(categorySelectorWatcher, yearSelectorWatcher);
+  const { isLoading: isStatisticsLoading, statistics, error } = useStatistics(categorySelectorWatcher, yearSelectorWatcher);
 
-  const getYearValue = () => {
-    return typeof initialYear === 'object' && initialYear !== null ? initialYear.value : initialYear;
-  };
+  if (categoriesError) {
+    throw categoriesError;
+  }
+
+  if (error) {
+    throw error;
+  }
 
   return (
     <>
@@ -63,8 +77,10 @@ const Statistics = () => {
                 options={makeYearsOptions()}
                 value={initialYear}
                 onChange={(selectedYear) => {
-                  setinitialYear(selectedYear);
-                  field.onChange(selectedYear);
+                  if (selectedYear) {
+                    setInitialYear(selectedYear);
+                    field.onChange(selectedYear);
+                  }
                 }}
               />
             }
@@ -84,8 +100,9 @@ const Statistics = () => {
                       options={categoriesMarshalled}
                       value={initialCategories}
                       onChange={(selectedOptions) => {
-                        setinitialCategories(selectedOptions);
-                        field.onChange(selectedOptions);
+                        const options = (selectedOptions ? Array.from(selectedOptions) : []) as StatisticsCategoryOption[];
+                        setInitialCategories(options);
+                        field.onChange(options);
                       }}
                     />
                   }
@@ -97,11 +114,11 @@ const Statistics = () => {
 
         <div className="w-full flex flex-col lg:flex-row lg:justify-between space-y-4 lg:space-y-0 lg:space-x-4">
           <PFAResponsiveChartsContainer>
-            <PFABarCharts data={statistics} year={getYearValue()} />
+            <PFABarCharts data={statistics ?? null} year={initialYear.value} />
           </PFAResponsiveChartsContainer>
 
           <PFAResponsiveChartsContainer>
-            <PFALineCharts data={statistics} year={getYearValue()} />
+            <PFALineCharts data={statistics ?? null} year={initialYear.value} />
           </PFAResponsiveChartsContainer>
         </div>
 

--- a/front/src/components/statistics/helpers/useStatisticsCategories.tsx
+++ b/front/src/components/statistics/helpers/useStatisticsCategories.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react';
 
-const useStatisticsCategories = (categories) => {
-  const [statisticsCategories, setStatisticsCategories] = useState<any>([]);
+import type { Category } from "@src/schemas/categories";
+
+export interface StatisticsCategoryOption extends Category {
+  label: string;
+  value: string;
+}
+
+const useStatisticsCategories = (categories: Category[] | undefined) => {
+  const [statisticsCategories, setStatisticsCategories] = useState<StatisticsCategoryOption[]>([]);
 
   useEffect(() => {
-    if (categories && categories.data) {
-      const categoriesTmp = [...categories.data];
-
-      categoriesTmp.forEach((category) => {
-        category.label = category.name;
-        category.value = category.ID;
-      });
+    if (categories) {
+      const categoriesTmp = categories.map((category) => ({
+        ...category,
+        label: category.name,
+        value: category.ID,
+      }));
 
       categoriesTmp.sort((a, b) => a.label.localeCompare(b.label));
 

--- a/front/src/components/statistics/services/useStatistics.tsx
+++ b/front/src/components/statistics/services/useStatistics.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { StatisticsResponseSchema } from "@src/schemas/stats";
+
+import type { StatisticsResponse } from "@src/schemas/stats";
+import type { Category } from "@src/schemas/categories";
+
+interface SelectOption {
+  value: number;
+  label: number;
+}
 
 const generateYearRange = (startYear: number) => {
   const currentYear = new Date().getFullYear();
@@ -12,34 +20,32 @@ const generateYearRange = (startYear: number) => {
   return years.join(',');
 }
 
-const useStatistics = (categories, yearSelectorWatcher) => {
+const useStatistics = (
+  categories: Category[] = [],
+  yearSelectorWatcher?: SelectOption,
+) => {
   const { privateRequest } = useRequestHelper();
-  const [ statistics, setStatistics ] = useState<any>([]);
-  const queryKey = ['statistics', yearSelectorWatcher?.value ?? "", ...categories?.map(category => category.ID) || ""];
+  const queryKey = ['statistics', yearSelectorWatcher?.value ?? "", ...(categories?.map((category) => category.ID) ?? [])];
 
-  const getStatistics = () => {
-    const categoryIds = categories.map(category => category.ID).join(',');
-    return privateRequest(`/statistics?years=${generateYearRange(yearSelectorWatcher.value)}&categories=${categoryIds}`);
+  const getStatistics = async (): Promise<StatisticsResponse> => {
+    const categoryIds = categories.map((category) => category.ID).join(',');
+    const response = await privateRequest(`/statistics?years=${generateYearRange(yearSelectorWatcher?.value ?? new Date().getFullYear())}&categories=${categoryIds}`);
+    return StatisticsResponseSchema.parse(response.data);
   };
 
-  const { data, isLoading } = useQuery(
+  const { data: statistics, isLoading, error } = useQuery(
     queryKey,
     getStatistics,
     {
       retry: true,
       ...QUERY_OPTIONS,
-      enabled: !!categories && !!yearSelectorWatcher,
+      enabled: categories.length > 0 && !!yearSelectorWatcher,
     });
-
-  useEffect(() => {
-    if (data?.data) {
-      setStatistics(data.data);
-    }
-  }, [data]);
 
   return {
     isLoading,
     statistics,
+    error,
   }
 }
 

--- a/front/src/interfaces/category.ts
+++ b/front/src/interfaces/category.ts
@@ -1,5 +1,5 @@
 export interface CategoryProps {
   value?: number;
-  category: string;
-  categoryColor: `#${string}`;
+  category: string | null;
+  categoryColor: string | null;
 }

--- a/front/src/interfaces/locales.ts
+++ b/front/src/interfaces/locales.ts
@@ -2,10 +2,10 @@ import localesDates from "@src/i18n/locales-dates";
 
 export type LangKeys = keyof typeof localesDates;
 
-// any should be replaced by Locale which is a date-fns type, but for a mysterious reason
-// it does not work, maybe a conflict with Locale type defined elsewhere
+// Locale from date-fns caused typing conflicts in this codebase.
+// Keep this object flexible but strongly avoid `any`.
 export interface LocaleObject {
-  [k: string]: any;
+  [k: string]: unknown;
   formatString: string;
 }
 

--- a/front/src/schemas/categories.ts
+++ b/front/src/schemas/categories.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const CategorySchema = z.object({
+  ID: z.string(),
+  userID: z.string().nullable(),
+  name: z.string(),
+  color: z.string(),
+});
+
+export type Category = z.infer<typeof CategorySchema>;
+export const CategoryListSchema = z.array(CategorySchema);
+
+export const UpdateCategoryPayloadSchema = z.object({
+  ID: z.string(),
+  userID: z.string().nullable(),
+  name: z.string().min(1),
+  color: z.string().min(1),
+});
+
+export type UpdateCategoryPayload = z.infer<typeof UpdateCategoryPayloadSchema>;

--- a/front/src/schemas/dashboard.ts
+++ b/front/src/schemas/dashboard.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+
+const numberLikeSchema = z.preprocess(
+  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
+  z.coerce.number().finite(),
+);
+
+const numberLikeWithZeroFallbackSchema = z.preprocess((value) => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === "string" && value.trim() === "") {
+    return 0;
+  }
+  return value;
+}, z.coerce.number().finite());
+
+export const DashboardSchema = z.object({
+  ID: z.string(),
+  dateFrom: z.string(),
+  dateTo: z.string(),
+  initialAmount: numberLikeWithZeroFallbackSchema,
+  initialCeiling: numberLikeWithZeroFallbackSchema,
+  userID: z.string(),
+});
+
+export type Dashboard = z.infer<typeof DashboardSchema>;
+
+export const DashboardResponseSchema = DashboardSchema.nullable();
+
+export type DashboardResponse = z.infer<typeof DashboardResponseSchema>;
+
+export const MonthlyStatsSchema = z.object({
+  spendingsSum: z.object({
+    amount: numberLikeSchema,
+  }),
+  recurringsSum: z.object({
+    amount: numberLikeSchema,
+  }),
+});
+
+export type MonthlyStats = z.infer<typeof MonthlyStatsSchema>;
+
+export const WeeklyStatsSchema = z.array(numberLikeSchema);
+export type WeeklyStats = z.infer<typeof WeeklyStatsSchema>;

--- a/front/src/schemas/spendings.ts
+++ b/front/src/schemas/spendings.ts
@@ -1,0 +1,66 @@
+import { z } from "zod";
+
+const numberLikeSchema = z.preprocess(
+  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
+  z.coerce.number().finite(),
+);
+
+export const SpendingCategoryInputSchema = z.object({
+  ID: z.string().nullable(),
+  userID: z.string().nullable(),
+  name: z.string(),
+  color: z.string().nullable(),
+});
+
+export type SpendingCategoryInput = z.infer<typeof SpendingCategoryInputSchema>;
+
+export const SpendingItemSchema = z.object({
+  ID: z.string(),
+  amount: numberLikeSchema,
+  category: z.string().nullable().optional(),
+  categoryColor: z.string().nullable().optional(),
+  categoryID: z.string().nullable().optional(),
+  currency: z.string().nullable().optional(),
+  date: z.string(),
+  invoicefile: z.string().nullable().optional(),
+  itemType: z.string(),
+  label: z.string(),
+  userID: z.string(),
+});
+
+export const SpendingListSchema = z.array(SpendingItemSchema);
+export type SpendingItem = z.infer<typeof SpendingItemSchema>;
+
+export const RecurringItemSchema = z.object({
+  ID: z.string(),
+  amount: numberLikeSchema,
+  currency: z.string().nullable().optional(),
+  dateFrom: z.string(),
+  dateTo: z.string(),
+  itemType: z.string(),
+  label: z.string(),
+  userID: z.string(),
+});
+
+export const RecurringListSchema = z.array(RecurringItemSchema);
+export type RecurringItem = z.infer<typeof RecurringItemSchema>;
+
+export const SpendingMutationPayloadSchema = z.object({
+  date: z.string().nullable().optional(),
+  label: z.string().min(1),
+  amount: numberLikeSchema,
+  category: SpendingCategoryInputSchema.nullable().optional(),
+  currency: z.string(),
+  userID: z.string(),
+  id: z.string().optional(),
+});
+
+export type SpendingMutationPayload = z.infer<typeof SpendingMutationPayloadSchema>;
+
+export const RecurringMutationPayloadSchema = z.object({
+  label: z.string().min(1),
+  amount: numberLikeSchema,
+  id: z.string().optional(),
+});
+
+export type RecurringMutationPayload = z.infer<typeof RecurringMutationPayloadSchema>;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+const statisticsMonthEntrySchema = z.record(z.string(), z.union([z.string(), z.number()]));
+
+export const StatisticsResponseSchema = z.object({
+  colors: z.record(z.string(), z.string()),
+  data: z.record(z.string(), z.array(statisticsMonthEntrySchema)),
+});
+
+export type StatisticsResponse = z.infer<typeof StatisticsResponseSchema>;
+
+export const ChartsCategorySchema = z.object({
+  category: z.string().nullable(),
+  categoryColor: z.string().nullable(),
+  value: z.preprocess(
+    (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
+    z.coerce.number().finite(),
+  ),
+});
+
+export type ChartsCategory = z.infer<typeof ChartsCategorySchema>;
+export const ChartsCategoryListSchema = z.array(ChartsCategorySchema);


### PR DESCRIPTION
```md
## Summary

This PR delivers a major frontend TypeScript revamp focused on stronger type safety and runtime data validation with Zod v4.

## What changed

- Upgraded `zod` to v4.
- Introduced centralized API schemas:
  - `src/schemas/spendings.ts`
  - `src/schemas/categories.ts`
  - `src/schemas/dashboard.ts`
  - `src/schemas/stats.ts`
- Refactored service hooks to validate API responses at the boundary using `Schema.parse(...)`.
- Refactored mutation payloads to be schema-validated before requests.
- Replaced the legacy compound array/object model (`SpendingCompoundType`) with explicit models:
  - `SpendingDayGroup`
  - `SpendingListItem`
- Removed/cleaned a large number of loose typings (`any` patterns), especially in spendings/statistics/dashboard flows.
- Added Next.js App Router global error boundary:
  - `app/error.tsx`
- Wired query errors to boundary rendering in key views (`Spendings`, `Statistics`, `Categories`, dashboard widgets).

## Bug fixes included

- Fixed dashboard parsing mismatch:
  - API returns `Dashboard | null` (not `{ data: Dashboard }`)
  - Updated schema/hook/component access accordingly.
- Added defensive numeric fallback for dashboard legacy values (`null`/empty string) on:
  - `initialAmount`
  - `initialCeiling`
- Fixed React warning in autocomplete option rendering:
  - stopped spreading a `key` prop into JSX
  - now passes `key` explicitly.

## Why

- Prevent silent frontend failures from malformed API payloads.
- Make domain types readable and maintainable.
- Improve DX and refactor safety across spendings/statistics/dashboard.
- Standardize error handling with Next.js `error.tsx`.

## Validation

- `npx tsc --noEmit` passes.
- Manual smoke test:
  - login -> `/dashboard?date=...` works
  - dashboard no longer crashes on Zod parsing for legacy ceiling values
  - autocomplete key-spread warning is gone.

## Notes

- No backend contract changes were introduced in this PR.
- Frontend parsing is now stricter by default, with explicit fallback where legacy data required it.
```