### PR TITLE
fix(auth): reliable session-expiry redirect (COS-26)

### DIFF
--- a/front/src/app/(private)/layout.tsx
+++ b/front/src/app/(private)/layout.tsx
@@ -3,6 +3,7 @@ import NavBar from "@components/shared/navBar/NavBar";
 import { AuthProvider } from "@auth/context/AuthContext";
 import { getServerSession } from "@auth/server/getServerSession";
 import { Toaster } from "@components/ui/sonner";
+import SessionWatcher from "@components/shared/sessionWatcher/SessionWatcher";
 
 export default async function PrivateLayout({
   children,
@@ -17,6 +18,7 @@ export default async function PrivateLayout({
 
   return (
     <AuthProvider initialUser={session.user} initialCsrfToken={session.csrfToken}>
+      <SessionWatcher />
       <div className="min-h-screen w-full bg-background">
         <div className="mx-auto w-full max-w-[2000px] px-4 pt-4 pb-16 sm:px-6 lg:px-8">
           <NavBar />

--- a/front/src/components/shared/sessionWatcher/SessionWatcher.tsx
+++ b/front/src/components/shared/sessionWatcher/SessionWatcher.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+import useRequestHelper from "@helpers/useRequestHelper";
+
+// Minimum delay between two liveness probes, so focus + visibilitychange firing
+// together on a tab switch (or rapid navigations) don't stack up requests.
+const REVALIDATE_THROTTLE_MS = 10_000;
+
+/**
+ * Proactively re-checks the session on window focus, tab visibility, client-side
+ * navigation and network reconnect. Without it, an idle tab whose pages are served
+ * from the React Query cache issues no request, so an expired session goes unnoticed
+ * until a stale-enough refetch or a mutation happens (the "2-3 clicks before being
+ * kicked out" symptom).
+ *
+ * The probe goes through `privateRequest`, so an expired session (401) is handled by
+ * the shared apiClient interceptor (redirect to /login); any other error is ignored so
+ * a transient network blip never ejects the user. Mounted only under the `(private)`
+ * layout, never on `/login`.
+ */
+const SessionWatcher = () => {
+  const { privateRequest } = useRequestHelper();
+  const pathname = usePathname();
+  // Seeded to "now" so the first run — right after the server guard already validated
+  // the session on this page load — doesn't fire a redundant probe.
+  const lastCheck = useRef(Date.now());
+  const revalidateRef = useRef<() => void>(() => {});
+
+  revalidateRef.current = () => {
+    const now = Date.now();
+    if (now - lastCheck.current < REVALIDATE_THROTTLE_MS) {
+      return;
+    }
+    lastCheck.current = now;
+    // GET is a safe method (no CSRF needed). A 401 is handled by the interceptor; every
+    // other outcome is intentionally swallowed so blips don't kick the user out.
+    privateRequest("/users/me").catch(() => {});
+  };
+
+  useEffect(() => {
+    const onFocus = () => revalidateRef.current();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") {
+        revalidateRef.current();
+      }
+    };
+    const onOnline = () => revalidateRef.current();
+
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("online", onOnline);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("online", onOnline);
+    };
+  }, []);
+
+  // Re-check on client-side navigation (the first click after an idle period).
+  useEffect(() => {
+    revalidateRef.current();
+  }, [pathname]);
+
+  return null;
+};
+
+export default SessionWatcher;

--- a/front/src/helpers/useRequestHelper.ts
+++ b/front/src/helpers/useRequestHelper.ts
@@ -1,7 +1,6 @@
 "use client";
 
 import axios from "axios";
-import { useRouter } from "next/navigation";
 import { useAuth } from "@auth/context/AuthContext";
 import { ROUTES } from "@components/shared/config/constants";
 
@@ -23,9 +22,31 @@ const getRequestUrl = (url: string): string => `${getApiBase()}/api${normalizeUr
 
 const isUnsafeMethod = (method?: string): boolean => !SAFE_HTTP_METHODS.has((method ?? "GET").toUpperCase());
 
+/**
+ * Sends the user to the login screen when the backend session is gone.
+ *
+ * Returns `true` when it triggered the redirect — the caller should then leave its
+ * promise pending so the 401 never reaches the error boundary. Returns `false` when it
+ * can't / shouldn't navigate (SSR, or already on `/login`), so the caller rejects /
+ * throws normally instead of hanging forever. The hard navigation (like logout)
+ * discards the auth context + React Query cache and re-runs the server `(private)`
+ * guard. `trailingSlash: true` means the path can be `/login/`, hence the strip.
+ */
+const redirectToLogin = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  if (window.location.pathname.replace(/\/$/, "") === ROUTES.login.path) {
+    return false;
+  }
+
+  window.location.replace(ROUTES.login.path);
+  return true;
+};
+
 const useRequestHelper = () => {
-  const router = useRouter();
-  const { user, csrfToken, setCsrfToken, clearAuth } = useAuth();
+  const { user, csrfToken, setCsrfToken } = useAuth();
 
   const request = (url: string, options?: AxiosRequestConfig): Promise<AxiosResponse> => {
     return axios(getRequestUrl(url), {
@@ -40,8 +61,9 @@ const useRequestHelper = () => {
     config?: AxiosRequestConfig,
   ): Promise<AxiosResponse> => {
     if (!user) {
-      clearAuth();
-      router.replace(ROUTES.login.path);
+      if (redirectToLogin()) {
+        return new Promise<never>(() => {});
+      }
       throw new Error("User not logged in");
     }
 
@@ -86,13 +108,14 @@ const useRequestHelper = () => {
             });
           }
         } catch {
-          // Fall through to 401/throw path.
+          // Fall through to the 401 / throw path below.
         }
       }
 
-      if (status === 401) {
-        clearAuth();
-        router.replace(ROUTES.login.path);
+      if (status === 401 && redirectToLogin()) {
+        // Expired session: navigate to /login and leave this promise pending so the
+        // 401 never becomes a React Query error and never reaches error.tsx.
+        return new Promise<never>(() => {});
       }
 
       throw error;


### PR DESCRIPTION
Handle 401 in one place inside privateRequest: on an expired session, redirect to /login (hard navigation, like logout, so the auth context + React Query cache are cleared and the server guard re-runs) and leave the promise pending so the 401 never reaches the error boundary — no more "Something went wrong" screen. Public login/signup/reset keep their inline handling. Drop the now-unused useRouter / clearAuth.

Add SessionWatcher (mounted in the private layout) to revalidate the session on focus / visibility / route change / reconnect, so an idle tab served from the React Query cache is redirected on return instead of after several clicks.