### PR TITLE
refactor(spending-modal): split SpendingModal into fields + hook (COS…

### DIFF
--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -1,52 +1,32 @@
 "use client";
 
-import { useMemo, useState } from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import Mexp from "math-expression-evaluator";
-import subMonths from "date-fns/subMonths";
-import addDays from "date-fns/addDays";
-import startOfMonth from "date-fns/startOfMonth";
-import endOfMonth from "date-fns/endOfMonth";
-import parseISO from "date-fns/parseISO";
-import format from "date-fns/format";
-import { Check, ChevronLeft, ChevronRight, ChevronsUpDown, Copy, Upload, X } from "lucide-react";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@components/ui/dialog";
-import { Input } from "@components/ui/input";
-import { Label } from "@components/ui/label";
-import { Button } from "@components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@components/ui/command";
-import { cn } from "@lib/utils";
-import useCategories from "@components/spendings/services/useCategories";
 import { useAuth } from "@auth/context/AuthContext";
-import useSpendings from "@components/spendings/services/useSpendings";
-import useReccurings from "@components/spendings/services/useReccurings";
-import { DATE_FORMAT } from "@components/spendings/config/constants";
+import AmountField from "@components/spendings/common/spendingModal/fields/AmountField";
+import CategoryField from "@components/spendings/common/spendingModal/fields/CategoryField";
+import DateField from "@components/spendings/common/spendingModal/fields/DateField";
+import LabelField from "@components/spendings/common/spendingModal/fields/LabelField";
+import ReceiptField from "@components/spendings/common/spendingModal/fields/ReceiptField";
 import { mockLabelSuggestions } from "@components/spendings/common/spendingModal/mockSuggestions";
-import { SpendingCategoryInputSchema } from "@src/schemas/spendings";
-
+import type { CategoryOption, SpendingForm } from "@components/spendings/common/spendingModal/schema";
+import { spendingSchema } from "@components/spendings/common/spendingModal/schema";
+import Toggle from "@components/spendings/common/spendingModal/Toggle";
+import useSpendingSubmit from "@components/spendings/common/spendingModal/useSpendingSubmit";
+import { DATE_FORMAT } from "@components/spendings/config/constants";
 import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
+import useCategories from "@components/spendings/services/useCategories";
+import useReccurings from "@components/spendings/services/useReccurings";
+import useSpendings from "@components/spendings/services/useSpendings";
 import type { SpendingItem, SpendingListItem } from "@components/spendings/types";
-
-const spendingSchema = z.object({
-  spendingLabel: z.string().min(1, "Label requis"),
-  spendingAmount: z.string().min(1, "Montant requis"),
-  spendingDate: z.string().optional(),
-  categoryName: z.string().optional(),
-});
-
-type SpendingForm = z.infer<typeof spendingSchema>;
-type CategoryOption = z.infer<typeof SpendingCategoryInputSchema>;
-
-const FALLBACK_COLOR = "#94a3b8";
-
-const humanSize = (bytes: number) => {
-  if (bytes < 1024) return `${bytes} o`;
-  if (bytes < 1_048_576) return `${Math.round(bytes / 1024)} Ko`;
-  return `${(bytes / 1_048_576).toFixed(1)} Mo`;
-};
+import { Button } from "@components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@components/ui/dialog";
+import { zodResolver } from "@hookform/resolvers/zod";
+import endOfMonth from "date-fns/endOfMonth";
+import format from "date-fns/format";
+import startOfMonth from "date-fns/startOfMonth";
+import subMonths from "date-fns/subMonths";
+import { Copy } from "lucide-react";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
 
 interface SpendingModalProps {
   date?: Date;
@@ -56,53 +36,6 @@ interface SpendingModalProps {
   isEditing: boolean;
   month?: MonthRange | null;
 }
-
-const getRandomHexColor = () => {
-  const r = Math.floor(Math.random() * 255)
-    .toString(16)
-    .padStart(2, "0");
-  const g = Math.floor(Math.random() * 255)
-    .toString(16)
-    .padStart(2, "0");
-  const b = Math.floor(Math.random() * 255)
-    .toString(16)
-    .padStart(2, "0");
-  return `#${r}${g}${b}`;
-};
-
-const Toggle = ({
-  active,
-  onClick,
-  disabled = false,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) => (
-  <button
-    type="button"
-    onClick={onClick}
-    disabled={disabled}
-    aria-pressed={active}
-    className={cn(
-      "inline-flex select-none items-center gap-2 rounded-md border px-3 py-2 text-xs transition-colors",
-      active ? "border-accent-d bg-accent-strong/10 text-ink" : "border-line bg-background text-ink-3 hover:text-ink-2",
-      disabled && "cursor-not-allowed opacity-45 hover:text-ink-3",
-    )}
-  >
-    <span
-      className={cn(
-        "grid size-3.5 place-items-center rounded-[3px] border",
-        active ? "border-accent-strong bg-accent-strong text-[oklch(0.15_0.02_180)]" : "border-line bg-bg-hi",
-      )}
-    >
-      {active && <Check className="size-2.5" strokeWidth={3} />}
-    </span>
-    {children}
-  </button>
-);
 
 const SpendingModal = ({
   date,
@@ -125,20 +58,12 @@ const SpendingModal = ({
     throw categoriesError;
   }
 
-  const categoryOptions: CategoryOption[] = useMemo(
-    () =>
-      (categories ?? []).map((c) => ({
-        ID: c.ID,
-        userID: c.userID,
-        name: c.name,
-        color: c.color,
-      })),
-    [categories],
-  );
-
-  // MOCK — "Fréquentes" quick-picks: the SELECTION is real, but the ranking
-  // (first N categories) stands in for real per-category usage counts.
-  const frequentCategories = useMemo(() => categoryOptions.filter((c) => c.name).slice(0, 6), [categoryOptions]);
+  const categoryOptions: CategoryOption[] = (categories ?? []).map((c) => ({
+    ID: c.ID,
+    userID: c.userID,
+    name: c.name,
+    color: c.color,
+  }));
 
   const isSpendingItem = (v: SpendingListItem | null): v is SpendingItem => !!v && "date" in v;
 
@@ -170,14 +95,14 @@ const SpendingModal = ({
   // MOCK — receipt-at-creation is visual only: POST /spendings returns no ID and
   // /spendings/upload needs the spendingID, so the file can't be persisted at
   // creation. Local preview only; add the receipt after creation via the row's
-  // receipt icon. See REFACTO_NOTES.md §9.
+  // receipt icon. De-mock tracked in COS-24. See REFACTO_NOTES.md §9.
   const [isReceiptToggle, setIsReceiptToggle] = useState(false);
   const [receiptFile, setReceiptFile] = useState<File | null>(null);
   const [receiptPreview, setReceiptPreview] = useState<string | null>(null);
   const [isReceiptDragging, setIsReceiptDragging] = useState(false);
 
   const onReceiptFile = (file: File | undefined) => {
-    if (!file || !file.type.startsWith("image/")) return;
+    if (!file?.type.startsWith("image/")) return;
     setReceiptFile(file);
     const reader = new FileReader();
     reader.onload = (e) => setReceiptPreview(typeof e.target?.result === "string" ? e.target.result : null);
@@ -211,14 +136,6 @@ const SpendingModal = ({
     },
   });
 
-  const stepDate = (delta: number) => {
-    const current = getValues("spendingDate");
-    const base = current ? parseISO(current) : new Date();
-    setValue("spendingDate", format(addDays(base, delta), DATE_FORMAT), {
-      shouldValidate: true,
-    });
-  };
-
   const labelSuggestions = mockLabelSuggestions(labelQuery);
 
   const applySuggestion = (suggestion: { label: string; category: string }) => {
@@ -230,99 +147,22 @@ const SpendingModal = ({
     }
   };
 
-  const exactMatch = categoryOptions.find((c) => c.name.toLowerCase() === comboboxQuery.trim().toLowerCase());
-
-  const onSubmit = (values: SpendingForm) => {
-    if (!user) {
-      console.error("User is not available");
-      return;
-    }
-
-    let amountEvaluatedExpr: number;
-    try {
-      const mexp = new Mexp();
-      const lexed = mexp.lex(values.spendingAmount.trim());
-      const postfixed = mexp.toPostfix(lexed);
-      amountEvaluatedExpr = mexp.postfixEval(postfixed);
-    } catch (error) {
-      console.error("Invalid amount expression", error);
-      return;
-    }
-
-    if (Number.isNaN(amountEvaluatedExpr)) {
-      return;
-    }
-
-    // Category resolution (legacy behaviour): an explicit pick wins; otherwise
-    // whatever was typed in the combobox becomes the category — an existing one
-    // if it matches, else a brand-new one created on the fly at submit. No
-    // separate "create category" step.
-    const trimmedQuery = comboboxQuery.trim();
-    const resolvedCategory: CategoryOption | null = selectedCategory
-      ? selectedCategory
-      : trimmedQuery
-        ? (categoryOptions.find((c) => c.name.toLowerCase() === trimmedQuery.toLowerCase()) ?? {
-            ID: null,
-            userID: user.id,
-            name: trimmedQuery,
-            color: getRandomHexColor(),
-          })
-        : null;
-
-    const categoryPayload: CategoryOption = resolvedCategory ?? {
-      ID: null,
-      userID: user.id,
-      name: "",
-      color: null,
-    };
-
-    const spendingDateStr = !asRecurring ? values.spendingDate || format(new Date(), "yyyy-MM-dd") : null;
-
-    const spendingEdited = {
-      date: spendingDateStr,
-      label: values.spendingLabel,
-      amount: Number(amountEvaluatedExpr),
-      category: categoryPayload,
-      currency: user.baseCurrency,
-      userID: user.id,
-      id: spending?.ID,
-    };
-
-    // NOTE: a receiptFile attached here is NOT uploaded — see the MOCK note on
-    // the receipt state above.
-
-    if (isEditing) {
-      if (recurringType) {
-        updateRecurring.mutate(spendingEdited);
-      } else {
-        updateSpending.mutate(spendingEdited);
-      }
-    } else {
-      if (asRecurring) {
-        const formattedMonth = {
-          start: format(startOfMonth(recurringMonth), "yyyy-MM-dd"),
-          end: format(endOfMonth(recurringMonth), "yyyy-MM-dd"),
-        };
-        createRecurring.mutate({ spendingEdited, formattedMonth });
-      } else {
-        createSpending.mutate(spendingEdited);
-      }
-    }
-
-    closeModal();
-  };
-
-  const onCreateCategory = (name: string) => {
-    const newCategory: CategoryOption = {
-      ID: null,
-      userID: user?.id ?? null,
-      name,
-      color: getRandomHexColor(),
-    };
-    setSelectedCategory(newCategory);
-    setComboboxOpen(false);
-    setComboboxQuery("");
-  };
+  const onSubmit = useSpendingSubmit({
+    user,
+    spending,
+    isEditing,
+    recurringType,
+    asRecurring,
+    recurringMonth,
+    categoryOptions,
+    selectedCategory,
+    comboboxQuery,
+    createSpending,
+    updateSpending,
+    createRecurring,
+    updateRecurring,
+    closeModal,
+  });
 
   // Title tracks recurringType (dashboard "dépense fixe" entry) only, NOT the
   // in-modal toggle — so ticking "Récurrente mensuelle" keeps the title stable
@@ -343,252 +183,34 @@ const SpendingModal = ({
           onSubmit={handleSubmit(onSubmit)}
           className="flex max-h-[min(78vh,720px)] flex-col gap-[18px] overflow-y-auto px-[22px] py-[22px]"
         >
-          {/* Date is not applicable to a recurring (no single charge date), so
-              it is disabled — not removed or swapped for a month stepper — when
-              "Récurrente mensuelle" is on. */}
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="spendingDate" className="text-[13px] text-ink-2">
-              Date
-            </Label>
-            <div
-              className={cn(
-                "flex items-stretch overflow-hidden rounded-md border border-line bg-background transition-opacity",
-                asRecurring ? "opacity-45" : "focus-within:border-accent-d",
-              )}
-            >
-              <button
-                type="button"
-                aria-label="Jour précédent"
-                onClick={() => stepDate(-1)}
-                disabled={asRecurring}
-                className="grid place-items-center border-r border-line px-3 text-ink-3 transition-colors hover:bg-bg-hi hover:text-ink disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-ink-3"
-              >
-                <ChevronLeft className="size-4" />
-              </button>
-              <Input
-                id="spendingDate"
-                type="date"
-                disabled={asRecurring}
-                className="num flex-1 rounded-none border-0 bg-transparent text-sm text-ink [color-scheme:dark] focus-visible:ring-0 disabled:cursor-not-allowed"
-                {...register("spendingDate")}
-              />
-              <button
-                type="button"
-                aria-label="Jour suivant"
-                onClick={() => stepDate(1)}
-                disabled={asRecurring}
-                className="grid place-items-center border-l border-line px-3 text-ink-3 transition-colors hover:bg-bg-hi hover:text-ink disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-ink-3"
-              >
-                <ChevronRight className="size-4" />
-              </button>
-            </div>
-          </div>
+          <DateField register={register} getValues={getValues} setValue={setValue} asRecurring={asRecurring} />
 
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="spendingLabel" className="text-[13px] text-ink-2">
-              Label
-            </Label>
-            <Input
-              id="spendingLabel"
-              placeholder="Ex : Boulangerie du coin"
-              className="border-line bg-background text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0"
-              {...register("spendingLabel", {
-                onChange: (e) => setLabelQuery(e.target.value),
-              })}
-            />
-            {errors.spendingLabel && <p className="text-xs text-neg">{errors.spendingLabel.message}</p>}
-            {!asRecurring && labelSuggestions.length > 0 && (
-              // MOCK suggestions — spending-specific, hidden for recurrings.
-              // (see mockSuggestions.ts)
-              <div className="flex flex-wrap gap-1.5">
-                {labelSuggestions.map((s) => (
-                  <button
-                    key={s.label}
-                    type="button"
-                    onClick={() => applySuggestion(s)}
-                    className="rounded-md border border-line bg-bg-hi px-2 py-1 text-[11px] text-ink-2 transition-colors hover:border-ink-4 hover:text-ink"
-                  >
-                    {s.label}
-                    <span className="text-ink-4"> — {s.category}</span>
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
+          <LabelField
+            register={register}
+            errors={errors}
+            asRecurring={asRecurring}
+            labelSuggestions={labelSuggestions}
+            applySuggestion={applySuggestion}
+            setLabelQuery={setLabelQuery}
+          />
 
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="spendingAmount" className="text-[13px] text-ink-2">
-              Montant
-            </Label>
-            <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-4 py-3 transition-colors focus-within:border-accent-d">
-              <input
-                id="spendingAmount"
-                inputMode="decimal"
-                placeholder="0,00"
-                className="num min-w-0 flex-1 bg-transparent text-[28px] font-medium tracking-[-0.02em] text-ink outline-none placeholder:text-ink-5"
-                {...register("spendingAmount")}
-              />
-              <span className="num text-[18px] text-ink-3">€</span>
-            </div>
-            {errors.spendingAmount && <p className="text-xs text-neg">{errors.spendingAmount.message}</p>}
-          </div>
+          <AmountField register={register} errors={errors} />
 
           {/* Category is hidden for recurrings: the backend/DB have no notion of
               a category on a recurring (no column, postRecurringController drops
               it, RecurringItemSchema omits it). Enabling it needs DB + back work
               — tracked separately, not in this modal-layout fix. */}
           {!asRecurring && (
-            <div className="flex flex-col gap-2">
-              <Label className="text-[13px] text-ink-2">Catégorie</Label>
-              <Popover
-                open={comboboxOpen}
-                onOpenChange={(isOpen) => {
-                  // On close (click-away / Escape), commit whatever was typed as
-                  // the category — matching existing, else a new one — so the
-                  // user never has to click a "create" action.
-                  if (!isOpen) {
-                    const q = comboboxQuery.trim();
-                    if (q) {
-                      const match = categoryOptions.find((c) => c.name.toLowerCase() === q.toLowerCase());
-                      setSelectedCategory(
-                        match ?? {
-                          ID: null,
-                          userID: user?.id ?? null,
-                          name: q,
-                          color: getRandomHexColor(),
-                        },
-                      );
-                      setComboboxQuery("");
-                    }
-                  }
-                  setComboboxOpen(isOpen);
-                }}
-                modal
-              >
-                <PopoverTrigger asChild>
-                  <button
-                    type="button"
-                    role="combobox"
-                    aria-expanded={comboboxOpen}
-                    onKeyDown={(e) => {
-                      if (!comboboxOpen && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
-                        e.preventDefault();
-                        setComboboxQuery(e.key);
-                        setComboboxOpen(true);
-                      }
-                    }}
-                    className={cn(
-                      "flex w-full items-center gap-2.5 rounded-md border bg-background px-3 py-2.5 text-left text-sm text-ink transition-colors hover:border-ink-4",
-                      comboboxOpen ? "border-accent-d" : "border-line",
-                    )}
-                  >
-                    {selectedCategory && selectedCategory.name ? (
-                      <>
-                        <span
-                          className="size-2.5 shrink-0 rounded-[3px]"
-                          style={{
-                            backgroundColor: selectedCategory.color ?? FALLBACK_COLOR,
-                          }}
-                        />
-                        <span className="capitalize">{selectedCategory.name}</span>
-                      </>
-                    ) : (
-                      <span className="text-ink-4">Aucune</span>
-                    )}
-                    <ChevronsUpDown className="ml-auto size-4 shrink-0 text-ink-4" />
-                  </button>
-                </PopoverTrigger>
-                <PopoverContent className="w-[--radix-popover-trigger-width] border-line bg-bg-elev p-0" align="start">
-                  <Command className="bg-transparent">
-                    <CommandInput
-                      placeholder="Rechercher ou saisir…"
-                      value={comboboxQuery}
-                      onValueChange={setComboboxQuery}
-                      className="text-ink"
-                    />
-                    <CommandList>
-                      <CommandEmpty>Aucune catégorie.</CommandEmpty>
-                      <CommandGroup>
-                        {selectedCategory && (
-                          <CommandItem
-                            value="__none"
-                            onSelect={() => {
-                              setSelectedCategory(null);
-                              setComboboxQuery("");
-                              setComboboxOpen(false);
-                            }}
-                          >
-                            <span className="text-ink-4">Aucune catégorie</span>
-                          </CommandItem>
-                        )}
-                        {categoryOptions.map((category) => (
-                          <CommandItem
-                            key={category.ID ?? category.name}
-                            value={category.name}
-                            onSelect={() => {
-                              setSelectedCategory(category);
-                              setComboboxQuery("");
-                              setComboboxOpen(false);
-                            }}
-                          >
-                            <span
-                              className="mr-1 size-2.5 rounded-[3px]"
-                              style={{
-                                backgroundColor: category.color ?? FALLBACK_COLOR,
-                              }}
-                            />
-                            <span className="flex-1 capitalize">{category.name}</span>
-                            {selectedCategory?.ID === category.ID && <Check className="size-4 text-accent-strong" />}
-                          </CommandItem>
-                        ))}
-                        {comboboxQuery.trim() && !exactMatch && (
-                          // The typed value shown as a normal option — selecting
-                          // it (or just closing) uses it; it's persisted when the
-                          // spending is created. No explicit "create" step.
-                          <CommandItem
-                            value={`__new-${comboboxQuery.trim()}`}
-                            onSelect={() => onCreateCategory(comboboxQuery.trim())}
-                          >
-                            <span className="mr-1 size-2.5 rounded-[3px] bg-ink-4" />
-                            <span className="flex-1 capitalize">{comboboxQuery.trim()}</span>
-                          </CommandItem>
-                        )}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-
-              {frequentCategories.length > 0 && (
-                <div className="flex flex-wrap items-center gap-1.5">
-                  <span className="mr-1 text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-4">
-                    Fréquentes
-                  </span>
-                  {frequentCategories.map((c) => {
-                    const active = selectedCategory?.name === c.name;
-                    return (
-                      <button
-                        key={c.ID ?? c.name}
-                        type="button"
-                        onClick={() => setSelectedCategory(c)}
-                        className={cn(
-                          "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs capitalize transition-colors",
-                          active
-                            ? "border-accent-d bg-accent-strong/10 text-ink"
-                            : "border-line bg-bg-hi text-ink-2 hover:text-ink",
-                        )}
-                      >
-                        <span
-                          className="size-[7px] shrink-0 rounded-[2px]"
-                          style={{ backgroundColor: c.color ?? FALLBACK_COLOR }}
-                        />
-                        {c.name}
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
+            <CategoryField
+              categoryOptions={categoryOptions}
+              selectedCategory={selectedCategory}
+              setSelectedCategory={setSelectedCategory}
+              comboboxOpen={comboboxOpen}
+              setComboboxOpen={setComboboxOpen}
+              comboboxQuery={comboboxQuery}
+              setComboboxQuery={setComboboxQuery}
+              userId={user?.id ?? null}
+            />
           )}
 
           <div className="flex flex-wrap gap-2.5 pt-0.5">
@@ -604,75 +226,14 @@ const SpendingModal = ({
           </div>
 
           {!asRecurring && isReceiptToggle && (
-            <div className="flex flex-col gap-2">
-              {!receiptFile ? (
-                <label
-                  onDragEnter={(e) => {
-                    e.preventDefault();
-                    setIsReceiptDragging(true);
-                  }}
-                  onDragOver={(e) => {
-                    e.preventDefault();
-                    setIsReceiptDragging(true);
-                  }}
-                  onDragLeave={(e) => {
-                    e.preventDefault();
-                    setIsReceiptDragging(false);
-                  }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    setIsReceiptDragging(false);
-                    onReceiptFile(e.dataTransfer.files?.[0]);
-                  }}
-                  className={cn(
-                    // children are pointer-events-none so drag events target the
-                    // label itself (no flicker when hovering child elements)
-                    "flex cursor-pointer items-center gap-3 rounded-md border-[1.5px] border-dashed px-4 py-3.5 transition-colors [&_*]:pointer-events-none",
-                    isReceiptDragging
-                      ? "border-elec bg-elec/[0.06]"
-                      : "border-line hover:border-elec hover:bg-elec/[0.06]",
-                  )}
-                >
-                  <span className="grid size-10 shrink-0 place-items-center rounded-[10px] bg-elec/10 text-elec">
-                    <Upload className="size-5" />
-                  </span>
-                  <span className="flex min-w-0 flex-col gap-0.5">
-                    <span className="text-sm font-semibold text-ink">
-                      Glisser un reçu ou <span className="text-elec underline underline-offset-2">parcourir</span>
-                    </span>
-                    <span className="num text-xs text-ink-4">jpg, png, webp</span>
-                  </span>
-                  <input
-                    type="file"
-                    accept="image/jpeg,image/png,image/webp,image/gif"
-                    hidden
-                    onChange={(e) => {
-                      onReceiptFile(e.target.files?.[0]);
-                      e.currentTarget.value = "";
-                    }}
-                  />
-                </label>
-              ) : (
-                <div className="flex items-center gap-3 rounded-md border border-line bg-background p-2 pr-2.5">
-                  {receiptPreview && (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img src={receiptPreview} alt="" className="size-11 shrink-0 rounded-md object-cover" />
-                  )}
-                  <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                    <span className="truncate text-sm font-semibold text-ink">{receiptFile.name}</span>
-                    <span className="num text-xs text-ink-4">{humanSize(receiptFile.size)}</span>
-                  </span>
-                  <button
-                    type="button"
-                    onClick={clearReceipt}
-                    aria-label="Retirer le reçu"
-                    className="grid size-8 shrink-0 place-items-center rounded-md border border-line bg-bg-hi text-ink-3 transition-colors hover:border-[oklch(0.55_0.15_25)] hover:text-neg"
-                  >
-                    <X className="size-4" />
-                  </button>
-                </div>
-              )}
-            </div>
+            <ReceiptField
+              receiptFile={receiptFile}
+              receiptPreview={receiptPreview}
+              isReceiptDragging={isReceiptDragging}
+              setIsReceiptDragging={setIsReceiptDragging}
+              onReceiptFile={onReceiptFile}
+              clearReceipt={clearReceipt}
+            />
           )}
 
           {recurringType && (recurrings?.length ?? 0) === 0 && (

--- a/front/src/components/spendings/common/spendingModal/Toggle.tsx
+++ b/front/src/components/spendings/common/spendingModal/Toggle.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@lib/utils";
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+
+const Toggle = ({
+  active,
+  onClick,
+  disabled = false,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    disabled={disabled}
+    aria-pressed={active}
+    className={cn(
+      "inline-flex select-none items-center gap-2 rounded-md border px-3 py-2 text-xs transition-colors",
+      active ? "border-accent-d bg-accent-strong/10 text-ink" : "border-line bg-background text-ink-3 hover:text-ink-2",
+      disabled && "cursor-not-allowed opacity-45 hover:text-ink-3",
+    )}
+  >
+    <span
+      className={cn(
+        "grid size-3.5 place-items-center rounded-[3px] border",
+        active ? "border-accent-strong bg-accent-strong text-[oklch(0.15_0.02_180)]" : "border-line bg-bg-hi",
+      )}
+    >
+      {active && <Check className="size-2.5" strokeWidth={3} />}
+    </span>
+    {children}
+  </button>
+);
+
+export default Toggle;

--- a/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
@@ -1,0 +1,29 @@
+import type { SpendingForm } from "@components/spendings/common/spendingModal/schema";
+import { Label } from "@components/ui/label";
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface AmountFieldProps {
+  register: UseFormRegister<SpendingForm>;
+  errors: FieldErrors<SpendingForm>;
+}
+
+const AmountField = ({ register, errors }: AmountFieldProps) => (
+  <div className="flex flex-col gap-2">
+    <Label htmlFor="spendingAmount" className="text-[13px] text-ink-2">
+      Montant
+    </Label>
+    <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-4 py-3 transition-colors focus-within:border-accent-d">
+      <input
+        id="spendingAmount"
+        inputMode="decimal"
+        placeholder="0,00"
+        className="num min-w-0 flex-1 bg-transparent text-[28px] font-medium tracking-[-0.02em] text-ink outline-none placeholder:text-ink-5"
+        {...register("spendingAmount")}
+      />
+      <span className="num text-[18px] text-ink-3">€</span>
+    </div>
+    {errors.spendingAmount && <p className="text-xs text-neg">{errors.spendingAmount.message}</p>}
+  </div>
+);
+
+export default AmountField;

--- a/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
@@ -1,0 +1,203 @@
+import { FALLBACK_COLOR, getRandomHexColor } from "@components/spendings/common/spendingModal/helpers";
+import type { CategoryOption } from "@components/spendings/common/spendingModal/schema";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@components/ui/command";
+import { Label } from "@components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover";
+import { cn } from "@lib/utils";
+import { Check, ChevronsUpDown } from "lucide-react";
+import type { Dispatch, SetStateAction } from "react";
+
+interface CategoryFieldProps {
+  categoryOptions: CategoryOption[];
+  selectedCategory: CategoryOption | null;
+  setSelectedCategory: Dispatch<SetStateAction<CategoryOption | null>>;
+  comboboxOpen: boolean;
+  setComboboxOpen: Dispatch<SetStateAction<boolean>>;
+  comboboxQuery: string;
+  setComboboxQuery: Dispatch<SetStateAction<string>>;
+  userId: string | null;
+}
+
+const CategoryField = ({
+  categoryOptions,
+  selectedCategory,
+  setSelectedCategory,
+  comboboxOpen,
+  setComboboxOpen,
+  comboboxQuery,
+  setComboboxQuery,
+  userId,
+}: CategoryFieldProps) => {
+  // MOCK — "Fréquentes" quick-picks: the SELECTION is real, but the ranking
+  // (first N categories) stands in for real per-category usage counts.
+  // De-mock tracked in COS-22.
+  const frequentCategories = categoryOptions.filter((c) => c.name).slice(0, 6);
+
+  const exactMatch = categoryOptions.find((c) => c.name.toLowerCase() === comboboxQuery.trim().toLowerCase());
+
+  const onCreateCategory = (name: string) => {
+    const newCategory: CategoryOption = {
+      ID: null,
+      userID: userId,
+      name,
+      color: getRandomHexColor(),
+    };
+    setSelectedCategory(newCategory);
+    setComboboxOpen(false);
+    setComboboxQuery("");
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Label className="text-[13px] text-ink-2">Catégorie</Label>
+      <Popover
+        open={comboboxOpen}
+        onOpenChange={(isOpen) => {
+          // On close (click-away / Escape), commit whatever was typed as
+          // the category — matching existing, else a new one — so the
+          // user never has to click a "create" action.
+          if (!isOpen) {
+            const q = comboboxQuery.trim();
+            if (q) {
+              const match = categoryOptions.find((c) => c.name.toLowerCase() === q.toLowerCase());
+              setSelectedCategory(
+                match ?? {
+                  ID: null,
+                  userID: userId,
+                  name: q,
+                  color: getRandomHexColor(),
+                },
+              );
+              setComboboxQuery("");
+            }
+          }
+          setComboboxOpen(isOpen);
+        }}
+        modal
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            role="combobox"
+            aria-expanded={comboboxOpen}
+            onKeyDown={(e) => {
+              if (!comboboxOpen && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                e.preventDefault();
+                setComboboxQuery(e.key);
+                setComboboxOpen(true);
+              }
+            }}
+            className={cn(
+              "flex w-full items-center gap-2.5 rounded-md border bg-background px-3 py-2.5 text-left text-sm text-ink transition-colors hover:border-ink-4",
+              comboboxOpen ? "border-accent-d" : "border-line",
+            )}
+          >
+            {selectedCategory?.name ? (
+              <>
+                <span
+                  className="size-2.5 shrink-0 rounded-[3px]"
+                  style={{
+                    backgroundColor: selectedCategory.color ?? FALLBACK_COLOR,
+                  }}
+                />
+                <span className="capitalize">{selectedCategory.name}</span>
+              </>
+            ) : (
+              <span className="text-ink-4">Aucune</span>
+            )}
+            <ChevronsUpDown className="ml-auto size-4 shrink-0 text-ink-4" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent className="w-[--radix-popover-trigger-width] border-line bg-bg-elev p-0" align="start">
+          <Command className="bg-transparent">
+            <CommandInput
+              placeholder="Rechercher ou saisir…"
+              value={comboboxQuery}
+              onValueChange={setComboboxQuery}
+              className="text-ink"
+            />
+            <CommandList>
+              <CommandEmpty>Aucune catégorie.</CommandEmpty>
+              <CommandGroup>
+                {selectedCategory && (
+                  <CommandItem
+                    value="__none"
+                    onSelect={() => {
+                      setSelectedCategory(null);
+                      setComboboxQuery("");
+                      setComboboxOpen(false);
+                    }}
+                  >
+                    <span className="text-ink-4">Aucune catégorie</span>
+                  </CommandItem>
+                )}
+                {categoryOptions.map((category) => (
+                  <CommandItem
+                    key={category.ID ?? category.name}
+                    value={category.name}
+                    onSelect={() => {
+                      setSelectedCategory(category);
+                      setComboboxQuery("");
+                      setComboboxOpen(false);
+                    }}
+                  >
+                    <span
+                      className="mr-1 size-2.5 rounded-[3px]"
+                      style={{
+                        backgroundColor: category.color ?? FALLBACK_COLOR,
+                      }}
+                    />
+                    <span className="flex-1 capitalize">{category.name}</span>
+                    {selectedCategory?.ID === category.ID && <Check className="size-4 text-accent-strong" />}
+                  </CommandItem>
+                ))}
+                {comboboxQuery.trim() && !exactMatch && (
+                  // The typed value shown as a normal option — selecting
+                  // it (or just closing) uses it; it's persisted when the
+                  // spending is created. No explicit "create" step.
+                  <CommandItem
+                    value={`__new-${comboboxQuery.trim()}`}
+                    onSelect={() => onCreateCategory(comboboxQuery.trim())}
+                  >
+                    <span className="mr-1 size-2.5 rounded-[3px] bg-ink-4" />
+                    <span className="flex-1 capitalize">{comboboxQuery.trim()}</span>
+                  </CommandItem>
+                )}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+
+      {frequentCategories.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="mr-1 text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-4">Fréquentes</span>
+          {frequentCategories.map((c) => {
+            const active = selectedCategory?.name === c.name;
+            return (
+              <button
+                key={c.ID ?? c.name}
+                type="button"
+                onClick={() => setSelectedCategory(c)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs capitalize transition-colors",
+                  active
+                    ? "border-accent-d bg-accent-strong/10 text-ink"
+                    : "border-line bg-bg-hi text-ink-2 hover:text-ink",
+                )}
+              >
+                <span
+                  className="size-[7px] shrink-0 rounded-[2px]"
+                  style={{ backgroundColor: c.color ?? FALLBACK_COLOR }}
+                />
+                {c.name}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CategoryField;

--- a/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
@@ -1,0 +1,72 @@
+import type { SpendingForm } from "@components/spendings/common/spendingModal/schema";
+import { DATE_FORMAT } from "@components/spendings/config/constants";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import { cn } from "@lib/utils";
+import addDays from "date-fns/addDays";
+import format from "date-fns/format";
+import parseISO from "date-fns/parseISO";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { UseFormGetValues, UseFormRegister, UseFormSetValue } from "react-hook-form";
+
+interface DateFieldProps {
+  register: UseFormRegister<SpendingForm>;
+  getValues: UseFormGetValues<SpendingForm>;
+  setValue: UseFormSetValue<SpendingForm>;
+  asRecurring: boolean;
+}
+
+const DateField = ({ register, getValues, setValue, asRecurring }: DateFieldProps) => {
+  const stepDate = (delta: number) => {
+    const current = getValues("spendingDate");
+    const base = current ? parseISO(current) : new Date();
+    setValue("spendingDate", format(addDays(base, delta), DATE_FORMAT), {
+      shouldValidate: true,
+    });
+  };
+
+  return (
+    // Date is not applicable to a recurring (no single charge date), so
+    // it is disabled — not removed or swapped for a month stepper — when
+    // "Récurrente mensuelle" is on.
+    <div className="flex flex-col gap-2">
+      <Label htmlFor="spendingDate" className="text-[13px] text-ink-2">
+        Date
+      </Label>
+      <div
+        className={cn(
+          "flex items-stretch overflow-hidden rounded-md border border-line bg-background transition-opacity",
+          asRecurring ? "opacity-45" : "focus-within:border-accent-d",
+        )}
+      >
+        <button
+          type="button"
+          aria-label="Jour précédent"
+          onClick={() => stepDate(-1)}
+          disabled={asRecurring}
+          className="grid place-items-center border-r border-line px-3 text-ink-3 transition-colors hover:bg-bg-hi hover:text-ink disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-ink-3"
+        >
+          <ChevronLeft className="size-4" />
+        </button>
+        <Input
+          id="spendingDate"
+          type="date"
+          disabled={asRecurring}
+          className="num flex-1 rounded-none border-0 bg-transparent text-sm text-ink [color-scheme:dark] focus-visible:ring-0 disabled:cursor-not-allowed"
+          {...register("spendingDate")}
+        />
+        <button
+          type="button"
+          aria-label="Jour suivant"
+          onClick={() => stepDate(1)}
+          disabled={asRecurring}
+          className="grid place-items-center border-l border-line px-3 text-ink-3 transition-colors hover:bg-bg-hi hover:text-ink disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-ink-3"
+        >
+          <ChevronRight className="size-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default DateField;

--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -1,0 +1,58 @@
+import type { LabelSuggestion } from "@components/spendings/common/spendingModal/mockSuggestions";
+import type { SpendingForm } from "@components/spendings/common/spendingModal/schema";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import type { Dispatch, SetStateAction } from "react";
+import type { FieldErrors, UseFormRegister } from "react-hook-form";
+
+interface LabelFieldProps {
+  register: UseFormRegister<SpendingForm>;
+  errors: FieldErrors<SpendingForm>;
+  asRecurring: boolean;
+  labelSuggestions: LabelSuggestion[];
+  applySuggestion: (suggestion: LabelSuggestion) => void;
+  setLabelQuery: Dispatch<SetStateAction<string>>;
+}
+
+const LabelField = ({
+  register,
+  errors,
+  asRecurring,
+  labelSuggestions,
+  applySuggestion,
+  setLabelQuery,
+}: LabelFieldProps) => (
+  <div className="flex flex-col gap-2">
+    <Label htmlFor="spendingLabel" className="text-[13px] text-ink-2">
+      Label
+    </Label>
+    <Input
+      id="spendingLabel"
+      placeholder="Ex : Boulangerie du coin"
+      className="border-line bg-background text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0"
+      {...register("spendingLabel", {
+        onChange: (e) => setLabelQuery(e.target.value),
+      })}
+    />
+    {errors.spendingLabel && <p className="text-xs text-neg">{errors.spendingLabel.message}</p>}
+    {!asRecurring && labelSuggestions.length > 0 && (
+      // MOCK suggestions — spending-specific, hidden for recurrings.
+      // (see mockSuggestions.ts) — de-mock tracked in COS-23.
+      <div className="flex flex-wrap gap-1.5">
+        {labelSuggestions.map((s) => (
+          <button
+            key={s.label}
+            type="button"
+            onClick={() => applySuggestion(s)}
+            className="rounded-md border border-line bg-bg-hi px-2 py-1 text-[11px] text-ink-2 transition-colors hover:border-ink-4 hover:text-ink"
+          >
+            {s.label}
+            <span className="text-ink-4"> — {s.category}</span>
+          </button>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export default LabelField;

--- a/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
@@ -1,0 +1,99 @@
+import { humanSize } from "@components/spendings/common/spendingModal/helpers";
+import { cn } from "@lib/utils";
+import { Upload, X } from "lucide-react";
+import Image from "next/image";
+import type { Dispatch, SetStateAction } from "react";
+
+interface ReceiptFieldProps {
+  receiptFile: File | null;
+  receiptPreview: string | null;
+  isReceiptDragging: boolean;
+  setIsReceiptDragging: Dispatch<SetStateAction<boolean>>;
+  onReceiptFile: (file: File | undefined) => void;
+  clearReceipt: () => void;
+}
+
+const ReceiptField = ({
+  receiptFile,
+  receiptPreview,
+  isReceiptDragging,
+  setIsReceiptDragging,
+  onReceiptFile,
+  clearReceipt,
+}: ReceiptFieldProps) => (
+  <div className="flex flex-col gap-2">
+    {!receiptFile ? (
+      <label
+        onDragEnter={(e) => {
+          e.preventDefault();
+          setIsReceiptDragging(true);
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsReceiptDragging(true);
+        }}
+        onDragLeave={(e) => {
+          e.preventDefault();
+          setIsReceiptDragging(false);
+        }}
+        onDrop={(e) => {
+          e.preventDefault();
+          setIsReceiptDragging(false);
+          onReceiptFile(e.dataTransfer.files?.[0]);
+        }}
+        className={cn(
+          // children are pointer-events-none so drag events target the
+          // label itself (no flicker when hovering child elements)
+          "flex cursor-pointer items-center gap-3 rounded-md border-[1.5px] border-dashed px-4 py-3.5 transition-colors [&_*]:pointer-events-none",
+          isReceiptDragging ? "border-elec bg-elec/[0.06]" : "border-line hover:border-elec hover:bg-elec/[0.06]",
+        )}
+      >
+        <span className="grid size-10 shrink-0 place-items-center rounded-[10px] bg-elec/10 text-elec">
+          <Upload className="size-5" />
+        </span>
+        <span className="flex min-w-0 flex-col gap-0.5">
+          <span className="text-sm font-semibold text-ink">
+            Glisser un reçu ou <span className="text-elec underline underline-offset-2">parcourir</span>
+          </span>
+          <span className="num text-xs text-ink-4">jpg, png, webp</span>
+        </span>
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/gif"
+          hidden
+          onChange={(e) => {
+            onReceiptFile(e.target.files?.[0]);
+            e.currentTarget.value = "";
+          }}
+        />
+      </label>
+    ) : (
+      <div className="flex items-center gap-3 rounded-md border border-line bg-background p-2 pr-2.5">
+        {receiptPreview && (
+          <Image
+            src={receiptPreview}
+            alt=""
+            width={44}
+            height={44}
+            className="size-11 shrink-0 rounded-md object-cover"
+            unoptimized
+          />
+        )}
+        <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-sm font-semibold text-ink">{receiptFile.name}</span>
+          <span className="num text-xs text-ink-4">{humanSize(receiptFile.size)}</span>
+        </span>
+        <button
+          type="button"
+          onClick={clearReceipt}
+          aria-label="Retirer le reçu"
+          className="grid size-8 shrink-0 place-items-center rounded-md border border-line bg-bg-hi text-ink-3 transition-colors hover:border-[oklch(0.55_0.15_25)] hover:text-neg"
+        >
+          <X className="size-4" />
+        </button>
+      </div>
+    )}
+  </div>
+);
+
+export default ReceiptField;

--- a/front/src/components/spendings/common/spendingModal/helpers.ts
+++ b/front/src/components/spendings/common/spendingModal/helpers.ts
@@ -1,0 +1,20 @@
+export const FALLBACK_COLOR = "#94a3b8";
+
+export const humanSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} o`;
+  if (bytes < 1_048_576) return `${Math.round(bytes / 1024)} Ko`;
+  return `${(bytes / 1_048_576).toFixed(1)} Mo`;
+};
+
+export const getRandomHexColor = () => {
+  const r = Math.floor(Math.random() * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const g = Math.floor(Math.random() * 255)
+    .toString(16)
+    .padStart(2, "0");
+  const b = Math.floor(Math.random() * 255)
+    .toString(16)
+    .padStart(2, "0");
+  return `#${r}${g}${b}`;
+};

--- a/front/src/components/spendings/common/spendingModal/schema.ts
+++ b/front/src/components/spendings/common/spendingModal/schema.ts
@@ -1,0 +1,12 @@
+import type { SpendingCategoryInputSchema } from "@src/schemas/spendings";
+import { z } from "zod";
+
+export const spendingSchema = z.object({
+  spendingLabel: z.string().min(1, "Label requis"),
+  spendingAmount: z.string().min(1, "Montant requis"),
+  spendingDate: z.string().optional(),
+  categoryName: z.string().optional(),
+});
+
+export type SpendingForm = z.infer<typeof spendingSchema>;
+export type CategoryOption = z.infer<typeof SpendingCategoryInputSchema>;

--- a/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
+++ b/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
@@ -1,0 +1,137 @@
+import type { AuthUser } from "@auth/types";
+import { getRandomHexColor } from "@components/spendings/common/spendingModal/helpers";
+import type { CategoryOption, SpendingForm } from "@components/spendings/common/spendingModal/schema";
+import type { SpendingListItem } from "@components/spendings/types";
+import type { SpendingMutationPayload } from "@src/schemas/spendings";
+import endOfMonth from "date-fns/endOfMonth";
+import format from "date-fns/format";
+import startOfMonth from "date-fns/startOfMonth";
+import Mexp from "math-expression-evaluator";
+
+interface MutationLike<TPayload> {
+  mutate: (payload: TPayload) => void;
+}
+
+interface CreateRecurringPayload {
+  spendingEdited: SpendingMutationPayload;
+  formattedMonth: { start: string; end: string };
+}
+
+interface UseSpendingSubmitOptions {
+  user: AuthUser | null;
+  spending: SpendingListItem | null;
+  isEditing: boolean;
+  recurringType: boolean;
+  asRecurring: boolean;
+  recurringMonth: Date;
+  categoryOptions: CategoryOption[];
+  selectedCategory: CategoryOption | null;
+  comboboxQuery: string;
+  createSpending: MutationLike<SpendingMutationPayload>;
+  updateSpending: MutationLike<SpendingMutationPayload>;
+  createRecurring: MutationLike<CreateRecurringPayload>;
+  updateRecurring: MutationLike<SpendingMutationPayload>;
+  closeModal: () => void;
+}
+
+const useSpendingSubmit = ({
+  user,
+  spending,
+  isEditing,
+  recurringType,
+  asRecurring,
+  recurringMonth,
+  categoryOptions,
+  selectedCategory,
+  comboboxQuery,
+  createSpending,
+  updateSpending,
+  createRecurring,
+  updateRecurring,
+  closeModal,
+}: UseSpendingSubmitOptions) => {
+  const onSubmit = (values: SpendingForm) => {
+    if (!user) {
+      console.error("User is not available");
+      return;
+    }
+
+    let amountEvaluatedExpr: number;
+    try {
+      const mexp = new Mexp();
+      const lexed = mexp.lex(values.spendingAmount.trim());
+      const postfixed = mexp.toPostfix(lexed);
+      amountEvaluatedExpr = mexp.postfixEval(postfixed);
+    } catch (error) {
+      console.error("Invalid amount expression", error);
+      return;
+    }
+
+    if (Number.isNaN(amountEvaluatedExpr)) {
+      return;
+    }
+
+    // Category resolution (legacy behaviour): an explicit pick wins; otherwise
+    // whatever was typed in the combobox becomes the category — an existing one
+    // if it matches, else a brand-new one created on the fly at submit. No
+    // separate "create category" step.
+    const trimmedQuery = comboboxQuery.trim();
+    const resolvedCategory: CategoryOption | null = selectedCategory
+      ? selectedCategory
+      : trimmedQuery
+        ? (categoryOptions.find((c) => c.name.toLowerCase() === trimmedQuery.toLowerCase()) ?? {
+            ID: null,
+            userID: user.id,
+            name: trimmedQuery,
+            color: getRandomHexColor(),
+          })
+        : null;
+
+    const categoryPayload: CategoryOption = resolvedCategory ?? {
+      ID: null,
+      userID: user.id,
+      name: "",
+      color: null,
+    };
+
+    const spendingDateStr = !asRecurring ? values.spendingDate || format(new Date(), "yyyy-MM-dd") : null;
+
+    const spendingEdited = {
+      date: spendingDateStr,
+      label: values.spendingLabel,
+      amount: Number(amountEvaluatedExpr),
+      category: categoryPayload,
+      currency: user.baseCurrency,
+      userID: user.id,
+      id: spending?.ID,
+    };
+
+    // NOTE: a receiptFile attached here is NOT uploaded — receipt-at-creation is
+    // visual only (see the MOCK note on the receipt state in SpendingModal.tsx).
+    // De-mock tracked in COS-24.
+
+    if (isEditing) {
+      if (recurringType) {
+        updateRecurring.mutate(spendingEdited);
+      } else {
+        updateSpending.mutate(spendingEdited);
+      }
+    } else {
+      if (asRecurring) {
+        const formattedMonth = {
+          start: format(startOfMonth(recurringMonth), "yyyy-MM-dd"),
+          end: format(endOfMonth(recurringMonth), "yyyy-MM-dd"),
+        };
+        createRecurring.mutate({ spendingEdited, formattedMonth });
+      } else {
+        createSpending.mutate(spendingEdited);
+      }
+    }
+
+    closeModal();
+  };
+
+  return onSubmit;
+};
+
+export default useSpendingSubmit;


### PR DESCRIPTION
…-58)

Pure refactor of the ~730-line SpendingModal.tsx into a readable shell that composes sub-components — zero behaviour/render change.

- fields/: DateField, LabelField, AmountField, CategoryField, ReceiptField
- Toggle, useSpendingSubmit (amount eval + category resolution + dispatch)
- schema.ts (spendingSchema, SpendingForm, CategoryOption), helpers.ts
- shared state stays in the shell (register RHF, selectedCategory, combobox, receipt) and is passed by props, preserving persist-across-toggle behaviour

Cleanup on the touched files: drop manual useMemo (React Compiler), collapse optional chains, receipt preview <img> -> next/image, remove dead eslint-disable. MOCK notes now reference their de-mock tickets (COS-24/23/22).