### PR TITLE
fix(spending-modal): harmonise Label bg and Amount sizing with other …

### DIFF
--- a/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
@@ -12,15 +12,15 @@ const AmountField = ({ register, errors }: AmountFieldProps) => (
     <Label htmlFor="spendingAmount" className="text-[13px] text-ink-2">
       Montant
     </Label>
-    <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-4 py-3 transition-colors focus-within:border-accent-d">
+    <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-3 py-2.5 transition-colors focus-within:border-accent-d">
       <input
         id="spendingAmount"
         inputMode="decimal"
         placeholder="0,00"
-        className="num min-w-0 flex-1 bg-transparent text-[28px] font-medium tracking-[-0.02em] text-ink outline-none placeholder:text-ink-5"
+        className="num min-w-0 flex-1 bg-transparent text-sm font-medium tracking-tight text-ink outline-none placeholder:text-ink-5"
         {...register("spendingAmount")}
       />
-      <span className="num text-[18px] text-ink-3">€</span>
+      <span className="num text-sm text-ink-3">€</span>
     </div>
     {errors.spendingAmount && <p className="text-xs text-neg">{errors.spendingAmount.message}</p>}
   </div>

--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -29,7 +29,7 @@ const LabelField = ({
     <Input
       id="spendingLabel"
       placeholder="Ex : Boulangerie du coin"
-      className="border-line bg-background text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0"
+      className="border-line bg-background dark:bg-background text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0"
       {...register("spendingLabel", {
         onChange: (e) => setLabelQuery(e.target.value),
       })}


### PR DESCRIPTION
…fields (COS-21)

- Label Input: add dark:bg-background so it matches Date/Amount/Category (the shared Input's dark:bg-input/30 was overriding the bg-background prop in dark mode).
- Amount field: bring padding (px-3 py-2.5), input and € font (text-sm) down to the same gauge as the other fields; replace tracking-[-0.02em] with base tracking-tight.