### PR TITLE
fix(invoice-image-modal): remove leftover sm:max-w-lg cap that clippe…

### DIFF
--- a/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
+++ b/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
@@ -20,7 +20,7 @@ const InvoiceImageModal = ({
   };
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && closeImage()}>
-      <DialogContent className="w-auto max-w-none border-0 bg-transparent p-0 shadow-none">
+      <DialogContent className="w-auto max-w-none sm:max-w-none border-0 bg-transparent p-0 shadow-none">
         <DialogTitle className="sr-only">Facture — aperçu</DialogTitle>
         <div className="overflow-hidden rounded-xl border border-elec/30 shadow-[0_24px_80px_oklch(0_0_0/0.6)] leading-[0]">
           <Image
@@ -29,7 +29,7 @@ const InvoiceImageModal = ({
             width={1000}
             height={800}
             unoptimized
-            className="block max-h-[88vh] w-auto max-w-[min(88vw,860px)] object-contain"
+            className="block h-auto max-h-[90vh] w-auto max-w-[min(94vw,1100px)]"
           />
         </div>
       </DialogContent>


### PR DESCRIPTION
…d the enlarged preview (COS-63)

The base DialogContent ends with sm:max-w-lg (512px), which tailwind-merge did not neutralize on this modal, capping the lightbox at 512px and clipping wide invoice images. Add sm:max-w-none and raise the image ceiling to min(94vw,1100px) / 90vh.