### PR TITLE
fix(spendings): land on the current week regardless of server timezon…

### DIFF
--- a/front/src/app/(private)/spendings/page.tsx
+++ b/front/src/app/(private)/spendings/page.tsx
@@ -1,34 +1,9 @@
-import { redirect } from "next/navigation";
 import SpendingPageClient from "@components/spendings/view/SpendingPageClient";
-import {
-  DATE_QUERY_PARAM,
-  buildSpendingsPath,
-  isValidIsoDate,
-} from "@helpers/dateRoute";
 
-interface SpendingsPageProps {
-  searchParams:
-    | Promise<Record<string, string | string[] | undefined>>
-    | Record<string, string | string[] | undefined>;
-}
-
-const resolveSearchParams = async (
-  searchParams: SpendingsPageProps["searchParams"],
-): Promise<Record<string, string | string[] | undefined>> => {
-  if (searchParams instanceof Promise) {
-    return await searchParams;
-  }
-  return searchParams;
-};
-
-export default async function SpendingsPage({ searchParams }: SpendingsPageProps) {
-  const params = await resolveSearchParams(searchParams);
-  const rawDate = params[DATE_QUERY_PARAM];
-  const date = typeof rawDate === "string" ? rawDate : undefined;
-
-  if (!isValidIsoDate(date)) {
-    redirect(buildSpendingsPath());
-  }
-
+// "Today" for the weekly Dépenses view is resolved in the browser
+// (SpendingPageClient), never here: the server's timezone can differ from the
+// user's and would otherwise bake the wrong day into ?date= (COS-73). The
+// client reads/writes the ?date= param, so this page just renders it.
+export default function SpendingsPage() {
   return <SpendingPageClient />;
 }

--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -13,6 +13,7 @@ import format from "date-fns/format";
 import { Calendar as CalendarIcon, ChevronDown } from "lucide-react";
 import { WEEKDAYS_LONG, WEEKDAYS_SHORT, MONTHS } from "./locale-fr";
 import useDatePickerState from "@components/datePickerWrapper/helpers/useDatePickerState";
+import { parseDateParam } from "@components/datePickerWrapper/helpers";
 import { DATE_QUERY_PARAM } from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
 import type { Modifiers } from "react-day-picker";
@@ -55,7 +56,7 @@ const DatePickerWrapper = () => {
 
   useEffect(() => {
     if (selectedDateParam) {
-      const date = new Date(selectedDateParam);
+      const date = parseDateParam(selectedDateParam);
       if (
         !Number.isNaN(date.getTime())
         && (selectedDays.length === 0

--- a/front/src/components/datePickerWrapper/__tests__/helpers.test.ts
+++ b/front/src/components/datePickerWrapper/__tests__/helpers.test.ts
@@ -1,0 +1,45 @@
+import { getWeekRange, parseDateParam } from "@components/datePickerWrapper/helpers";
+
+import format from "date-fns/format";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// The Dépenses week bug (COS-73) only surfaces in timezones WEST of UTC, where
+// `new Date("2026-07-12")` (parsed as UTC midnight) rolls back to the previous
+// local day. Force such a timezone so the regression is caught regardless of the
+// CI machine's timezone. Node honours runtime `process.env.TZ` changes.
+const originalTz = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = "America/New_York";
+});
+afterAll(() => {
+  process.env.TZ = originalTz;
+});
+
+const iso = (date: Date) => format(date, "yyyy-MM-dd");
+
+describe("parseDateParam", () => {
+  it("parses a date-only ISO param as a LOCAL date (no UTC day shift)", () => {
+    // Sunday 12 July 2026 — must stay the 12th, a Sunday, even west of UTC.
+    const date = parseDateParam("2026-07-12");
+    expect(date.getFullYear()).toBe(2026);
+    expect(date.getMonth()).toBe(6); // July
+    expect(date.getDate()).toBe(12);
+    expect(date.getDay()).toBe(0); // Sunday (week start)
+  });
+});
+
+describe("getWeekRange from a date-only param", () => {
+  it("returns the week CONTAINING the param date (Sun 12 → Sat 18)", () => {
+    const range = getWeekRange(parseDateParam("2026-07-12"));
+    expect(iso(range.from)).toBe("2026-07-12");
+    expect(iso(range.to)).toBe("2026-07-18");
+  });
+
+  it("regression guard: naive `new Date(param)` yields the PREVIOUS week west of UTC", () => {
+    // Documents exactly the reported bug — kept so a revert to `new Date` is
+    // visibly wrong here rather than silently shipping.
+    const buggy = getWeekRange(new Date("2026-07-12"));
+    expect(iso(buggy.from)).toBe("2026-07-05");
+    expect(iso(buggy.to)).toBe("2026-07-11");
+  });
+});

--- a/front/src/components/datePickerWrapper/helpers.ts
+++ b/front/src/components/datePickerWrapper/helpers.ts
@@ -10,7 +10,17 @@ import getDate from "date-fns/getDate";
 import getDay from "date-fns/getDay";
 import lastDayOfMonth from "date-fns/lastDayOfMonth";
 import setHours from "date-fns/setHours";
+import parseISO from "date-fns/parseISO";
 
+
+/**
+ * Parse a date-only ISO string (e.g. the `?date=` URL param "2026-07-12") as a
+ * LOCAL date. `new Date("2026-07-12")` parses it as UTC midnight, which rolls
+ * back to the previous calendar day in timezones west of UTC and then makes
+ * getWeekRange return the previous week (COS-73). parseISO keeps it local,
+ * consistent with the rest of the app's date handling.
+ */
+export const parseDateParam = (isoDate: string): Date => parseISO(isoDate);
 
 export const getWeekDays = (weekStart: Date, date: Date): Date[] => {
   const days: Date[] = [weekStart];

--- a/front/src/components/datePickerWrapper/store.ts
+++ b/front/src/components/datePickerWrapper/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import produce from "immer";
-import { devtools, persist } from "zustand/middleware";
+import { devtools } from "zustand/middleware";
 
 export interface DatePickerWrapperStoreProps {
   from: Date | null;
@@ -13,45 +13,43 @@ export interface DatePickerWrapperStoreProps {
   setSelectedDateIso: (dateIso: string | null) => void;
 }
 
+// This store is intentionally NOT persisted. The selected week is carried by the
+// `?date=` URL param (see SpendingPageClient), so it already survives reloads —
+// and the picker is only shown on Dépenses. Persisting `selectedDateIso` in
+// localStorage leaked a stale day across sessions, which made the NavBar
+// "Dépenses" link reopen a past week instead of today (COS-73). "Today" must be
+// resolved fresh, client-side, on each new visit.
 const useStore = create<DatePickerWrapperStoreProps>()(
-  devtools(
-    persist(
-      (set) => ({
-        from: null,
-        to: null,
-        range: null,
-        selectedDateIso: null,
-        setFrom: (from: Date) =>
-          set(
-            produce((draft: DatePickerWrapperStoreProps) => {
-              draft.from = from;
-            })
-          ),
-        setTo: (to: Date) =>
-          set(
-            produce((draft: DatePickerWrapperStoreProps) => {
-              draft.to = to;
-            })
-          ),
-        setRange: (range: Date[]) =>
-          set(
-            produce((draft: DatePickerWrapperStoreProps) => {
-              draft.range = range;
-            })
-          ),
-        setSelectedDateIso: (dateIso: string | null) =>
-          set(
-            produce((draft: DatePickerWrapperStoreProps) => {
-              draft.selectedDateIso = dateIso;
-            })
-          ),
-      }),
-      {
-        name: "date-picker-preferences",
-        partialize: (state) => ({ selectedDateIso: state.selectedDateIso }),
-      }
-    )
-  )
+  devtools((set) => ({
+    from: null,
+    to: null,
+    range: null,
+    selectedDateIso: null,
+    setFrom: (from: Date) =>
+      set(
+        produce((draft: DatePickerWrapperStoreProps) => {
+          draft.from = from;
+        })
+      ),
+    setTo: (to: Date) =>
+      set(
+        produce((draft: DatePickerWrapperStoreProps) => {
+          draft.to = to;
+        })
+      ),
+    setRange: (range: Date[]) =>
+      set(
+        produce((draft: DatePickerWrapperStoreProps) => {
+          draft.range = range;
+        })
+      ),
+    setSelectedDateIso: (dateIso: string | null) =>
+      set(
+        produce((draft: DatePickerWrapperStoreProps) => {
+          draft.selectedDateIso = dateIso;
+        })
+      ),
+  }))
 );
 
 export default useStore;

--- a/front/src/components/spendings/view/SpendingPageClient.tsx
+++ b/front/src/components/spendings/view/SpendingPageClient.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { useEffect } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import SpendingView from "@components/spendings/view/SpendingView";
 import useGlobalStore from "@components/shared/globalStore";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { DATE_QUERY_PARAM, isValidIsoDate } from "@helpers/dateRoute";
+import { DATE_QUERY_PARAM, buildSpendingsPath, getTodayIsoDate, isValidIsoDate } from "@helpers/dateRoute";
 
 export default function SpendingPageClient() {
   const { setIsCalendarVisible } = useGlobalStore();
   const { setSelectedDateIso } = useDatePickerWrapperStore();
+  const router = useRouter();
   const searchParams = useSearchParams();
 
   useEffect(() => {
@@ -20,8 +21,13 @@ export default function SpendingPageClient() {
     const date = searchParams.get(DATE_QUERY_PARAM) ?? undefined;
     if (isValidIsoDate(date)) {
       setSelectedDateIso(date);
+      return;
     }
-  }, [searchParams, setSelectedDateIso]);
+    // No/invalid ?date= → default to the BROWSER-LOCAL today and canonicalise the
+    // URL. "Today" must be resolved client-side: the server timezone can differ
+    // from the user's, so it must never decide the day (COS-73).
+    router.replace(buildSpendingsPath(getTodayIsoDate()));
+  }, [searchParams, setSelectedDateIso, router]);
 
   return <SpendingView />;
 }


### PR DESCRIPTION
…e (COS-73)

The Dépenses weekly view could open on the previous week (e.g. 5–11 Jul instead of 12–18 Jul on Sunday 12 Jul) because "today" was resolved through three timezone/state-dependent paths instead of the browser's local day:

- page.tsx redirected via getTodayIsoDate() executed on the server, whose timezone can differ from the user's, baking the wrong day into ?date=.
- DatePickerWrapper parsed the ?date= param with new Date("2026-07-12") (UTC midnight), which rolls back a day west of UTC.
- the datePickerWrapper store persisted selectedDateIso in localStorage, and NavBar builds the "Dépenses" link from it, so a stale day reopened a past week across sessions.

Resolve "today" client-side only: the server no longer computes it, SpendingPageClient canonicalises a missing/invalid ?date= to the browser-local today via router.replace, the param is parsed with parseISO (new parseDateParam helper), and the store drops persistence (the week already lives in the URL and the picker only shows on Dépenses). Add a Vitest regression covering the local parse + week range under a west-of-UTC timezone.