### PR TITLE
feat(spendings): auto-scroll to day card (COS-38)

### DIFF
--- a/front/src/components/datePickerWrapper/helpers/useDatePickerState.ts
+++ b/front/src/components/datePickerWrapper/helpers/useDatePickerState.ts
@@ -25,7 +25,7 @@ const useDatePickerState = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const { setFrom, setTo, setRange, setSelectedDateIso } = useDatePickerWrapperStore();
+  const { setFrom, setTo, setRange, setSelectedDateIso, setScrollToDayIso } = useDatePickerWrapperStore();
 
   const normalizePath = (path: string): string => {
     const normalized = path.replace(/\/+$/, "");
@@ -44,6 +44,13 @@ const useDatePickerState = () => {
 
   const handleDayChange = (date: Date, updateUrl = true) => {
     const dateISO = formatISO(date, { representation: "date" });
+    // A deliberate week pick (updateUrl is only true for a user calendar click,
+    // never the programmatic URL sync) supersedes any pending "scroll to a day"
+    // request — e.g. an "Aujourd'hui" scroll that never got consumed — so it
+    // can't fire later on an unrelated navigation (COS-38).
+    if (updateUrl) {
+      setScrollToDayIso(null);
+    }
     if (updateUrl && normalizePath(pathname) === SPENDINGS_PATH) {
       const dateInUrl = searchParams.get(DATE_QUERY_PARAM);
       if (dateInUrl !== dateISO) {

--- a/front/src/components/datePickerWrapper/store.ts
+++ b/front/src/components/datePickerWrapper/store.ts
@@ -7,10 +7,15 @@ export interface DatePickerWrapperStoreProps {
   to: Date | null;
   range: Date[] | null;
   selectedDateIso: string | null;
+  // Cross-tree "scroll the Dépenses timeline to this day" request (COS-38). Set
+  // by the NavBar "Aujourd'hui" button and by a fresh spending creation; read
+  // and consumed (reset to null) by SpendingView once the matching card mounts.
+  scrollToDayIso: string | null;
   setFrom: (from: Date) => void;
   setTo: (from: Date) => void;
   setRange: (from: Date[]) => void;
   setSelectedDateIso: (dateIso: string | null) => void;
+  setScrollToDayIso: (dateIso: string | null) => void;
 }
 
 // This store is intentionally NOT persisted. The selected week is carried by the
@@ -25,6 +30,7 @@ const useStore = create<DatePickerWrapperStoreProps>()(
     to: null,
     range: null,
     selectedDateIso: null,
+    scrollToDayIso: null,
     setFrom: (from: Date) =>
       set(
         produce((draft: DatePickerWrapperStoreProps) => {
@@ -47,6 +53,12 @@ const useStore = create<DatePickerWrapperStoreProps>()(
       set(
         produce((draft: DatePickerWrapperStoreProps) => {
           draft.selectedDateIso = dateIso;
+        })
+      ),
+    setScrollToDayIso: (dateIso: string | null) =>
+      set(
+        produce((draft: DatePickerWrapperStoreProps) => {
+          draft.scrollToDayIso = dateIso;
         })
       ),
   }))

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -60,7 +60,7 @@ const normalizePath = (path: string): string => {
 const NavBar = () => {
   const { user } = useAuth();
   const { isCalendarVisible } = useGlobalStore();
-  const { selectedDateIso } = useDatePickerWrapperStore();
+  const { selectedDateIso, setScrollToDayIso } = useDatePickerWrapperStore();
   const pathname = usePathname();
   const router = useRouter();
   const isClientHydrated = useSyncExternalStore(
@@ -100,6 +100,11 @@ const NavBar = () => {
 
   const handleGoToToday = () => {
     const today = getTodayIsoDate();
+    // Ask the timeline to scroll to today's card. Set this before the
+    // early-return below: when we are already on the current week no navigation
+    // happens, so the scroll request is the only thing that recenters the view
+    // (COS-38). Shared by both the desktop and mobile "Aujourd'hui" buttons.
+    setScrollToDayIso(today);
     if (normalizePath(pathname) === SPENDINGS_PATH && selectedDateIso === today) {
       return;
     }

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "react-query";
 import getDate from "date-fns/getDate";
+import format from "date-fns/format";
 import parseISO from "date-fns/parseISO";
 import startOfMonth from "date-fns/startOfMonth";
 import endOfMonth from "date-fns/endOfMonth";
@@ -25,7 +26,7 @@ const useSpendings = () => {
   const { privateRequest } = useRequestHelper();
   const { user } = useAuth();
   const userID = user?.id;
-  const { from, to, range } = useDatePickerWrapperStore();
+  const { from, to, range, setScrollToDayIso } = useDatePickerWrapperStore();
   const monthStart = from ? startOfMonth(from) : undefined;
   const monthEnd = to ? endOfMonth(to) : undefined;
   const monthBeginning = monthStart;
@@ -115,7 +116,21 @@ const useSpendings = () => {
   const createSpending = useMutation<unknown, AxiosError, SpendingMutationPayload>((spending) => {
     return createSpendingService(spending);
   }, {
-    onSuccess: () => { spendingsActionOnSuccess("créée") },
+    onSuccess: async (_data, variables) => {
+      await spendingsActionOnSuccess("créée");
+      // COS-38: once the list has refreshed, recenter the timeline on the day of
+      // the spending just created — but only when that day belongs to the week
+      // CURRENTLY on screen. We read the live range from the store rather than the
+      // closure `range` (react-query snapshots the callback at mutate() time, so
+      // the closure can be stale if the user changed week while the POST was in
+      // flight). Creating a spending for another week must not yank the view to
+      // it (product decision on the ticket's open edge case).
+      const createdDate = variables?.date;
+      const currentRange = useDatePickerWrapperStore.getState().range;
+      if (createdDate && currentRange?.some((day) => format(day, "yyyy-MM-dd") === createdDate)) {
+        setScrollToDayIso(createdDate);
+      }
+    },
     onError: (e) => {
       console.log("error creating spendings : ", e);
     }

--- a/front/src/components/spendings/view/SpendingDayCard.tsx
+++ b/front/src/components/spendings/view/SpendingDayCard.tsx
@@ -143,7 +143,7 @@ const SpendingDayCard = ({
   const emptyLabel = items.length === 0 ? "Aucune dépense" : "Aucun résultat";
 
   return (
-    <div className={cn("sp-day", isToday && "sp-day--today")}>
+    <div className={cn("sp-day", isToday && "sp-day--today")} data-sp-day={format(date, "yyyy-MM-dd")}>
       <div className="sp-day-h">
         <div className="sp-day-h-top">
           <div className="sp-date">

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { endOfMonth, isSameDay } from "date-fns";
 import startOfMonth from "date-fns/startOfMonth";
 import format from "date-fns/format";
@@ -44,7 +44,7 @@ interface CategoryAggregate {
  * timeline. Reuses the existing data layer (useSpendings / useDashboard).
  */
 const SpendingView = () => {
-  const { from, to, range } = useDatePickerWrapperStore();
+  const { from, to, range, scrollToDayIso, setScrollToDayIso } = useDatePickerWrapperStore();
   const [now] = useState(() => new Date());
   const [search, setSearch] = useState("");
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
@@ -99,6 +99,28 @@ const SpendingView = () => {
       categoryAgg: Array.from(map.values()).sort((a, b) => b.total - a.total),
     };
   }, [groups]);
+
+  // Auto-scroll the timeline to a requested day card (COS-38). Both the NavBar
+  // "Aujourd'hui" button and a fresh spending creation set `scrollToDayIso`; we
+  // scroll as soon as the matching `[data-sp-day]` card is in the DOM. That can
+  // be immediately (already the right week) or after a re-render triggered by a
+  // week navigation (`range`) or the initial data load (`isLoading`), so the
+  // effect re-runs on those. The request is consumed (reset to null) once used.
+  useEffect(() => {
+    if (!scrollToDayIso || !range || isLoading) {
+      return;
+    }
+    const card = document.querySelector<HTMLElement>(`[data-sp-day="${scrollToDayIso}"]`);
+    if (!card) {
+      return;
+    }
+    card.scrollIntoView({ behavior: "smooth", block: "start" });
+    setScrollToDayIso(null);
+  }, [scrollToDayIso, range, isLoading, setScrollToDayIso]);
+
+  // Drop any pending scroll request when leaving the page so it can't fire on a
+  // later visit (COS-38).
+  useEffect(() => () => setScrollToDayIso(null), [setScrollToDayIso]);
 
   if (error) {
     throw error;

--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -718,10 +718,19 @@ input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:foc
   box-shadow:
     0 12px 30px oklch(0 0 0 / 0.24),
     inset 0 1px 0 oklch(1 0 0 / 0.045);
+  /* Keep a scrolled-to day card clear of the sticky .pfa-hdr (COS-38). Below md
+     the header stacks the date-picker + "Aujourd'hui" button onto their own
+     full-width row, so it is much taller than the single-row desktop header. */
+  scroll-margin-top: 168px;
 }
 @media (min-width: 760px) {
   .sp-day {
     height: 464px;
+  }
+}
+@media (min-width: 768px) {
+  .sp-day {
+    scroll-margin-top: 88px;
   }
 }
 .sp-day--today {


### PR DESCRIPTION
Scroll the weekly timeline to a day card in two cases:
- clicking "Aujourd'hui" — including when already on the current week, where handleGoToToday early-returns without navigating
- after creating a spending, once the list has refreshed

A shared store flag (scrollToDayIso) carries the target day across the NavBar and SpendingView trees; SpendingView scrollIntoView()s the matching [data-sp-day] card. A responsive scroll-margin-top clears the sticky header, which is taller on mobile. Creating a spending outside the displayed week does nothing (product choice). Pending requests are cancelled on a manual week pick and on unmount so they cannot fire on a later, unrelated navigation.