### PR TITLE
fix(dashboard): equal-height cards with filling lists (COS-62)

### DIFF
--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -53,7 +53,7 @@ const CategoryBreakdown = () => {
   const monthLabel = format(from ?? new Date(), "MMMM yyyy", { locale: fr });
 
   return (
-    <section className="pfa-card flex flex-col gap-4 px-6 py-5">
+    <section className="pfa-card flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5">
       <div className="flex items-baseline justify-between">
         <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">
           Répartition par catégorie
@@ -69,7 +69,7 @@ const CategoryBreakdown = () => {
             radius={4}
             ariaLabel="Répartition mensuelle par catégorie"
           />
-          <div className="charts-categories-list flex max-h-[340px] flex-col overflow-y-auto pr-1">
+          <div className="charts-categories-list flex min-h-0 flex-1 flex-col overflow-y-auto pr-1">
             {list.map((c, i) => {
               const color = c.categoryColor ?? FALLBACK_COLOR;
               const name = c.category ?? "sans catégorie";

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -68,7 +68,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
   const upcomingSum = upcoming.reduce((a, r) => a + Number(r.amount), 0);
 
   return (
-    <section className="pfa-card flex h-full flex-col gap-4 px-6 py-5">
+    <section className="pfa-card flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5">
       <div className="flex items-start justify-between">
         <div>
           <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">
@@ -124,7 +124,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
         </div>
       )}
 
-      <div className="recurrings-list-container flex flex-1 flex-col overflow-y-auto">
+      <div className="recurrings-list-container flex min-h-0 flex-1 flex-col overflow-y-auto pr-1">
         {list.map((r) => {
           if (pendingDelete === r.ID) {
             return (


### PR DESCRIPTION
The category breakdown list was capped at max-h-[340px] while its card stretched to match the taller fixed-expenses card, leaving an internal scrollbar with empty space below the list.

Bound both cards to a shared height (min-h-[320px]/max-h-[550px]) and let each list fill it via flex-1 + min-h-0, so the cards stay aligned and a scrollbar appears only on real overflow. Add pr-1 to the recurrings list so its scrollbar clears the amounts.