### PR TITLE
feat(spendings): category bar tooltip (COS-33)

### DIFF
--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowDown, ArrowUp } from "lucide-react";
 import { mockCategoryTrend } from "@components/spendings/view/helpers/mockSpending";
 import SpendingsListModal from "@components/spendings/spendingsListModal/SpendingsListModal";
 import { WEEKLY } from "@components/spendings/config/constants";
-import { cn } from "@lib/utils";
+import { CategoryBarTooltip, CategoryTrend } from "@lib/dataviz";
 
 export interface BreakdownRow {
   key: string;
@@ -23,28 +22,20 @@ const formatAmount = (amount: number) =>
     maximumFractionDigits: 2,
   });
 
-const Trend = ({ name }: { name: string }) => {
-  // MOCK — needs previous-week data (see mockSpending.ts)
-  const { direction, label } = mockCategoryTrend(name);
-  return (
-    <span
-      className={cn(
-        "num flex items-center justify-end gap-1 text-[11.5px]",
-        direction === "up" && "text-neg",
-        direction === "down" && "text-accent-strong",
-        direction === "flat" && "text-ink-4",
-      )}
-    >
-      {direction === "up" && <ArrowUp className="size-2.5" />}
-      {direction === "down" && <ArrowDown className="size-2.5" />}
-      {label}
-    </span>
-  );
-};
+// MOCK — needs previous-week data (see mockSpending.ts). De-mocks with COS-35.
+const Trend = ({ name }: { name: string }) => (
+  <CategoryTrend {...mockCategoryTrend(name)} />
+);
 
 interface SpendingCategoryBreakdownProps {
   rows: BreakdownRow[];
   rangeLabel: string;
+}
+
+interface BarHover {
+  row: BreakdownRow;
+  x: number;
+  y: number;
 }
 
 /**
@@ -57,6 +48,7 @@ const SpendingCategoryBreakdown = ({
   rangeLabel,
 }: SpendingCategoryBreakdownProps) => {
   const [selected, setSelected] = useState<BreakdownRow | null>(null);
+  const [hover, setHover] = useState<BarHover | null>(null);
 
   if (rows.length === 0) {
     return null;
@@ -71,11 +63,15 @@ const SpendingCategoryBreakdown = ({
         <span className="text-xs text-ink-4">{rangeLabel} · semaine</span>
       </div>
 
-      <div className="sp-cat-bar mb-[18px]" title="Répartition de la semaine">
+      <div className="sp-cat-bar mb-[18px]">
         {rows.map((r) => (
           <span
             key={r.key}
+            role="img"
+            aria-label={`${r.name} : ${r.pct.toFixed(1).replace(".", ",")} % (${formatAmount(r.total)} €)`}
             style={{ width: `${r.pct.toFixed(2)}%`, background: r.color }}
+            onMouseMove={(e) => setHover({ row: r, x: e.clientX, y: e.clientY })}
+            onMouseLeave={() => setHover(null)}
           />
         ))}
       </div>
@@ -108,6 +104,13 @@ const SpendingCategoryBreakdown = ({
           </button>
         ))}
       </div>
+
+      {hover && (
+        <CategoryBarTooltip
+          point={{ x: hover.x, y: hover.y }}
+          datum={{ ...hover.row, trend: mockCategoryTrend(hover.row.name) }}
+        />
+      )}
 
       {selected && (
         <SpendingsListModal

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import CategoryTrend from "@lib/dataviz/CategoryTrend";
+
+import type { CategoryTrendData } from "@lib/dataviz/CategoryTrend";
+
+// Measure-then-position must run before paint to clamp the tooltip at the
+// viewport edge without a flash; fall back to useEffect on the server, where
+// layout effects warn (and never run) anyway.
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+const formatAmount = (amount: number) =>
+  Number(amount).toLocaleString("fr-FR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+/** One category's display data — mirrors its list row. */
+export interface CategoryTooltipDatum {
+  color: string;
+  name: string;
+  count: number;
+  /** Share of the total, 0-100 (already computed — the tooltip only formats). */
+  pct: number;
+  /** Amount in euros. */
+  total: number;
+  /** Trend data — the page computes it from its own source (weekly vs monthly). */
+  trend: CategoryTrendData;
+}
+
+export interface CategoryBarTooltipProps {
+  /** Cursor position in viewport coords, or null when the tooltip is hidden. */
+  point: { x: number; y: number } | null;
+  datum: CategoryTooltipDatum;
+}
+
+/**
+ * Mouse-following tooltip for a stacked category bar. Follows the cursor,
+ * clamps inside the viewport, and mirrors the list row (swatch / name / count
+ * / % / amount / trend). Shared by the Dépenses and Dashboard breakdowns.
+ */
+const CategoryBarTooltip = ({ point, datum }: CategoryBarTooltipProps) => {
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Follow the cursor while clamping the floating tooltip inside the viewport.
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    if (!point || !el) {
+      return;
+    }
+    const { width, height } = el.getBoundingClientRect();
+    const GAP = 16;
+    const EDGE = 12;
+    let left = point.x + GAP;
+    if (left + width + EDGE > window.innerWidth) {
+      left = point.x - GAP - width;
+    }
+    let top = point.y + GAP;
+    if (top + height + EDGE > window.innerHeight) {
+      top = point.y - GAP - height;
+    }
+    setPos({
+      left: Math.max(EDGE, left),
+      top: Math.max(EDGE, top),
+    });
+  }, [point]);
+
+  if (!point) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="cat-tooltip"
+      style={{
+        // Layout-critical → inline so the portaled tooltip stays out of normal
+        // flow even if the .cat-tooltip stylesheet is missing/stale.
+        position: "fixed",
+        zIndex: 60,
+        pointerEvents: "none",
+        left: pos ? pos.left : point.x + 16,
+        top: pos ? pos.top : point.y + 16,
+      }}
+    >
+      <div className="mb-2 flex items-center gap-2">
+        <span
+          className="size-2 shrink-0 rounded-[2px]"
+          style={{ background: datum.color }}
+        />
+        <span className="truncate text-[13px] font-medium capitalize text-ink">
+          {datum.name}
+        </span>
+        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-background px-[7px] text-[10.5px] leading-[1.55] text-ink-3">
+          {datum.count}
+        </span>
+      </div>
+      <div className="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-1 text-[12px]">
+        <span className="text-ink-4">Part</span>
+        <span className="num text-right text-ink-2">
+          {datum.pct.toFixed(1).replace(".", ",")} %
+        </span>
+        <span className="text-ink-4">Montant</span>
+        <span className="num text-right text-ink">
+          {formatAmount(datum.total)} €
+        </span>
+        <span className="text-ink-4">Tendance</span>
+        <CategoryTrend {...datum.trend} />
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default CategoryBarTooltip;

--- a/front/src/lib/dataviz/CategoryTrend.tsx
+++ b/front/src/lib/dataviz/CategoryTrend.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { ArrowDown, ArrowUp } from "lucide-react";
+
+import { cn } from "@lib/utils";
+
+export type TrendDirection = "up" | "down" | "flat";
+
+export interface CategoryTrendData {
+  direction: TrendDirection;
+  label: string;
+}
+
+/**
+ * Per-category trend badge (arrow + % / label). Shared by the Dépenses and
+ * Dashboard breakdowns and their hover tooltips, so the trend renders
+ * identically everywhere. Colours: hausse = rouge, baisse = vert,
+ * stable/nouv. = gris. Pure presentation — the caller computes
+ * `direction`/`label` from its own source (weekly vs monthly).
+ */
+const CategoryTrend = ({ direction, label }: CategoryTrendData) => (
+  <span
+    className={cn(
+      "num flex items-center justify-end gap-1 text-[11.5px]",
+      direction === "up" && "text-neg",
+      direction === "down" && "text-accent-strong",
+      direction === "flat" && "text-ink-4",
+    )}
+  >
+    {direction === "up" && <ArrowUp className="size-2.5" />}
+    {direction === "down" && <ArrowDown className="size-2.5" />}
+    {label}
+  </span>
+);
+
+export default CategoryTrend;

--- a/front/src/lib/dataviz/index.ts
+++ b/front/src/lib/dataviz/index.ts
@@ -3,6 +3,8 @@ export { default as Donut } from "@lib/dataviz/Donut";
 export { default as LineChart } from "@lib/dataviz/LineChart";
 export { default as BarChart } from "@lib/dataviz/BarChart";
 export { default as StackedBar } from "@lib/dataviz/StackedBar";
+export { default as CategoryBarTooltip } from "@lib/dataviz/CategoryBarTooltip";
+export { default as CategoryTrend } from "@lib/dataviz/CategoryTrend";
 export { default as ProgressTrack } from "@lib/dataviz/ProgressTrack";
 export { default as AnimatedNumber } from "@lib/dataviz/AnimatedNumber";
 export { default as useCountUp } from "@lib/dataviz/useCountUp";
@@ -23,3 +25,10 @@ export type {
   AxisMarker,
   SeriesDot,
 } from "@lib/dataviz/types";
+
+export type {
+  TrendDirection,
+  CategoryTrendData,
+} from "@lib/dataviz/CategoryTrend";
+
+export type { CategoryTooltipDatum } from "@lib/dataviz/CategoryBarTooltip";

--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -683,6 +683,22 @@ input:-webkit-autofill, input:-webkit-autofill:hover, input:-webkit-autofill:foc
     justify-self: end;
   }
 }
+/* mouse-following tooltip over category stacked-bar segments (shared:
+   Dépenses + Dashboard breakdowns — see @lib/dataviz/CategoryBarTooltip).
+   Layout-critical props (position/left/top/z-index/pointer-events) are set
+   INLINE on the element so a floating, portaled tooltip can never fall into
+   normal flow if this stylesheet is missing/stale — here we only skin it. */
+.cat-tooltip {
+  min-width: 172px;
+  max-width: 240px;
+  padding: 10px 12px;
+  background: var(--bg-elev);
+  border: 1px solid var(--line);
+  border-radius: var(--r-md);
+  box-shadow:
+    0 16px 40px oklch(0 0 0 / 0.5),
+    inset 0 1px 0 oklch(1 0 0 / 0.05);
+}
 
 /* ---- Timeline grid ---- */
 .sp-timeline {


### PR DESCRIPTION
Mouse-following tooltip on each segment of the weekly « Répartition par catégorie » bar — name / count / % / amount / trend, mirroring the list row. Follows the cursor and clamps at the viewport edge.

Extracted as reusable @lib/dataviz components for the dashboard (COS-76):
- CategoryBarTooltip: takes { point, datum }; positioning (fixed/left/top/ z-index/pointer-events) is inline so the portaled tooltip can never fall into normal flow if .cat-tooltip is missing/stale.
- CategoryTrend: shared trend badge ({ direction, label } -> markup), used by both the list and the tooltip so the trend renders identically.