### PR TITLE
refactor(dashboard): adopt design tokens (COS-64)

### DIFF
--- a/front/src/components/dashboard/MonthSelector.tsx
+++ b/front/src/components/dashboard/MonthSelector.tsx
@@ -31,7 +31,7 @@ const MonthSelector = () => {
 
   return (
     <div className="flex items-center gap-2.5">
-      <div className="flex items-center gap-1.5 rounded-[6px] border border-line bg-bg-elev px-2.5 py-[7px] text-[13px] text-ink-2">
+      <div className="flex items-center gap-1.5 rounded-sm border border-line bg-bg-elev px-2.5 py-2 text-sm text-ink-2">
         <Calendar className="size-3.5 text-ink-4" />
         <button
           type="button"
@@ -43,7 +43,7 @@ const MonthSelector = () => {
         </button>
         {/* fixed width (fits the longest month, "septembre") so the control
             never resizes as the month changes */}
-        <span className="num w-[116px] text-center capitalize tracking-[-0.01em]">
+        <span className="num w-[116px] text-center capitalize tracking-normal">
           {format(month, "MMMM yyyy", { locale: fr })}
         </span>
         <button

--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -81,21 +81,21 @@ const BudgetHero = () => {
     <section className="pfa-card flex flex-col px-7 py-6">
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col">
-          <span className="text-[12px] font-medium uppercase tracking-[0.1em] text-ink-3">
+          <span className="text-xs font-medium uppercase tracking-widest text-ink-3">
             {monthLabel} — budget restant
           </span>
           <div
             className={cn(
-              "num mt-3.5 text-[40px] font-medium leading-none tracking-[-0.025em] sm:text-[56px]",
+              "num mt-3.5 text-display font-medium leading-none tracking-tight sm:text-display-lg",
               over ? "text-neg" : "text-ink",
             )}
           >
             {over && "−"}
             {amountInt}
-            <span className="text-[26px] font-normal text-ink-3 sm:text-[36px]">,{amountDec} €</span>
+            <span className="text-2xl font-normal text-ink-3 sm:text-4xl">,{amountDec} €</span>
           </div>
 
-          <div className="mt-2.5 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[13px] text-ink-3">
+          <div className="mt-2.5 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm text-ink-3">
             {!editing ? (
               <span className="inline-flex items-center gap-1.5">
                 sur
@@ -107,7 +107,7 @@ const BudgetHero = () => {
                   title="Modifier le montant initial"
                 >
                   <span className="num text-ink-2">{euro0(initialAmount)} €</span>
-                  <EditGlyph className="size-[11px] text-ink-4 transition-colors group-hover:text-accent-strong" />
+                  <EditGlyph className="size-3 text-ink-4 transition-colors group-hover:text-accent-strong" />
                 </button>
                 alloués
               </span>
@@ -159,20 +159,20 @@ const BudgetHero = () => {
             ariaLabel="Répartition du budget consommé"
           >
             <div>
-              <div className="num text-[32px] font-medium leading-none tracking-[-0.02em] text-ink">
+              <div className="num text-3xl font-medium leading-none tracking-tight text-ink">
                 {Math.round(animatedPct)}
-                <span className="text-[18px] text-ink-3">%</span>
+                <span className="text-lg text-ink-3">%</span>
               </div>
-              <div className="mt-0.5 text-[10px] uppercase tracking-widest text-ink-4">utilisé</div>
+              <div className="mt-0.5 text-2xs uppercase tracking-widest text-ink-4">utilisé</div>
             </div>
           </Donut>
-          <div className="flex gap-4 text-[11px] text-ink-3">
+          <div className="flex gap-4 text-2xs text-ink-3">
             <span className="inline-flex items-center gap-1.5">
-              <span className="size-2 rounded-[2px] bg-accent-d" />
+              <span className="size-2 rounded-xs bg-accent-d" />
               Fixes <span className="num text-ink-2">{euro0(fixed)}</span>
             </span>
             <span className="inline-flex items-center gap-1.5">
-              <span className="size-2 rounded-[2px] bg-accent-strong" />
+              <span className="size-2 rounded-xs bg-accent-strong" />
               Variables <span className="num text-ink-2">{euro0(variable)}</span>
             </span>
           </div>

--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -69,7 +69,7 @@ const CategoryBreakdown = () => {
   return (
     <section className="pfa-card flex max-h-137.5 min-h-80 flex-col gap-4 px-6 py-5">
       <div className="flex items-baseline justify-between">
-        <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">Répartition par catégorie</h2>
+        <h2 className="text-base font-semibold tracking-normal text-ink">Répartition par catégorie</h2>
         <span className="text-xs text-ink-4">{monthLabel} · part des variables</span>
       </div>
 
@@ -89,16 +89,16 @@ const CategoryBreakdown = () => {
                 key={row.name}
                 type="button"
                 onClick={() => setSelected(row.category)}
-                className="grid cursor-pointer grid-cols-[10px_minmax(0,1fr)_auto] items-center gap-3 border-b border-line-soft px-1 py-3 text-left text-[13.5px] transition-colors last:border-b-0 hover:bg-bg-hi sm:grid-cols-[10px_minmax(0,1fr)_58px_84px_58px]"
+                className="grid cursor-pointer grid-cols-[10px_minmax(0,1fr)_auto] items-center gap-3 border-b border-line-soft px-1 py-3 text-left text-sm transition-colors last:border-b-0 hover:bg-bg-hi sm:grid-cols-[10px_minmax(0,1fr)_58px_84px_58px]"
               >
                 <span
-                  className="size-2 rounded-[2px]"
+                  className="size-2 rounded-xs"
                   style={{ background: row.color }}
                 />
                 <span className="flex items-center gap-2 truncate">
                   <span className="truncate capitalize text-ink">{row.name}</span>
                   {row.count > 0 && (
-                    <span className="num shrink-0 rounded bg-bg-hi px-1.5 text-[10px] text-ink-4">{row.count}</span>
+                    <span className="num shrink-0 rounded bg-bg-hi px-1.5 text-2xs text-ink-4">{row.count}</span>
                   )}
                 </span>
                 <span className="num hidden text-right text-ink-2 sm:block">{pct1(row.pct)} %</span>
@@ -112,7 +112,7 @@ const CategoryBreakdown = () => {
           </div>
         </>
       ) : (
-        <div className="py-10 text-center text-[12.5px] text-ink-4">Aucune dépense ce mois.</div>
+        <div className="py-10 text-center text-xs text-ink-4">Aucune dépense ce mois.</div>
       )}
 
       {hover && (

--- a/front/src/components/dashboard/sections/DailySparkline.tsx
+++ b/front/src/components/dashboard/sections/DailySparkline.tsx
@@ -86,10 +86,10 @@ const DailySparkline = () => {
   const curveKey = `${format(monthRef, "yyyy-MM")}-${peak > 0 ? "d" : "e"}`;
 
   return (
-    <div className="mt-6 border-t border-line-soft pt-[18px]">
+    <div className="mt-6 border-t border-line-soft pt-4.5">
       <div className="mb-2.5 flex items-baseline justify-between">
-        <h3 className="text-[12px] font-medium tracking-[-0.005em] text-ink-2">Consommation jour par jour</h3>
-        <div className="flex gap-5 text-[12px] text-ink-3">
+        <h3 className="text-xs font-medium tracking-normal text-ink-2">Consommation jour par jour</h3>
+        <div className="flex gap-5 text-xs text-ink-3">
           <span>
             Moyenne <span className="num text-ink">{euro(avg)} €</span>/jour
           </span>
@@ -126,7 +126,7 @@ const DailySparkline = () => {
           ariaLabel="Consommation quotidienne"
         />
         <span
-          className="num pointer-events-none absolute right-2 text-[9px] text-ink-4"
+          className="num pointer-events-none absolute right-2 text-3xs text-ink-4"
           style={{ top: `calc(${avgTopPct}% - 18px)` }}
         >
           moy. {euro(avg)} €
@@ -134,7 +134,7 @@ const DailySparkline = () => {
         {showToday && (
           <>
             <span
-              className="num pointer-events-none absolute top-0.5 pl-1.5 text-[9px] tracking-[0.03em] text-ink-2"
+              className="num pointer-events-none absolute top-0.5 pl-1.5 text-3xs tracking-wide text-ink-2"
               style={{ left: `${dotLeftPct}%` }}
             >
               {todayLabel}
@@ -142,14 +142,14 @@ const DailySparkline = () => {
             {/* HTML overlay dot → stays perfectly round regardless of the
                 non-uniform SVG scaling (unlike an in-SVG <circle>). */}
             <span
-              className="pointer-events-none absolute box-border size-[7px] -translate-x-1/2 -translate-y-1/2 rounded-full border-[1.75px] border-accent-strong bg-bg-elev"
+              className="pointer-events-none absolute box-border size-2 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-accent-strong bg-bg-elev"
               style={{ left: `${dotLeftPct}%`, top: `${dotTopPct}%` }}
             />
           </>
         )}
       </div>
 
-      <div className="num mt-1 flex justify-between text-[9px] text-ink-4">
+      <div className="num mt-1 flex justify-between text-3xs text-ink-4">
         {ticks.map((d) => (
           <span key={d}>{String(d).padStart(2, "0")}</span>
         ))}

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -61,7 +61,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
     <section className="pfa-card flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5">
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">Dépenses fixes</h2>
+          <h2 className="text-base font-semibold tracking-normal text-ink">Dépenses fixes</h2>
           <span className="text-xs text-ink-4">
             {list.length} lignes · échéancier {format(month.start, "MMMM", { locale: fr })}
           </span>
@@ -78,17 +78,17 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
 
       <div className="flex items-start justify-between">
         <div>
-          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">Mensuel</div>
-          <div className="num text-[26px] font-medium tracking-[-0.02em] text-ink">
+          <div className="text-2xs font-medium uppercase tracking-caps text-ink-4">Mensuel</div>
+          <div className="num text-2xl font-medium tracking-tight text-ink">
             {totalInt}
-            <span className="text-[18px] text-ink-3">,{totalDec} €</span>
+            <span className="text-lg text-ink-3">,{totalDec} €</span>
           </div>
         </div>
         <div className="text-right">
-          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">Annualisé</div>
-          <div className="num text-[18px] font-medium tracking-[-0.01em] text-ink-2">
+          <div className="text-2xs font-medium uppercase tracking-caps text-ink-4">Annualisé</div>
+          <div className="num text-lg font-medium tracking-normal text-ink-2">
             {annualInt}
-            <span className="text-[14px] text-ink-3">,{annualDec} €</span>
+            <span className="text-sm text-ink-3">,{annualDec} €</span>
           </div>
         </div>
       </div>
@@ -141,10 +141,10 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
           return (
             <div
               key={r.ID}
-              className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 border-b border-line-soft py-[9px] last:border-b-0"
+              className="group grid grid-cols-[minmax(0,1fr)_auto] items-center gap-x-2 border-b border-line-soft py-2.5 last:border-b-0"
             >
               <span
-                className="truncate text-[13px] text-ink"
+                className="truncate text-sm text-ink"
                 title={r.label}
               >
                 {r.label}
@@ -184,21 +184,19 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
                 {day != null && (
                   <span
                     className={cn(
-                      "num w-5 text-right text-[11px] tabular-nums",
+                      "num w-5 text-right text-2xs tabular-nums",
                       isUpcoming ? "text-accent-strong" : "text-ink-4",
                     )}
                   >
                     {String(day).padStart(2, "0")}
                   </span>
                 )}
-                <span className="num min-w-[76px] text-right text-[13px] font-medium text-ink">{euro(r.amount)} €</span>
+                <span className="num min-w-[76px] text-right text-sm font-medium text-ink">{euro(r.amount)} €</span>
               </span>
             </div>
           );
         })}
-        {list.length === 0 && (
-          <div className="py-6 text-center text-[12.5px] text-ink-4">Aucune dépense fixe ce mois.</div>
-        )}
+        {list.length === 0 && <div className="py-6 text-center text-xs text-ink-4">Aucune dépense fixe ce mois.</div>}
       </div>
 
       {isModalVisible && (

--- a/front/src/components/dashboard/sections/ForecastStrip.tsx
+++ b/front/src/components/dashboard/sections/ForecastStrip.tsx
@@ -40,14 +40,14 @@ const ForecastStrip = () => {
   return (
     <section className="pfa-card grid grid-cols-1 items-center gap-6 px-6 py-5 sm:grid-cols-[200px_1fr_200px] sm:gap-8">
       <div className="flex flex-col gap-1">
-        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">
+        <span className="text-2xs font-medium uppercase tracking-caps text-ink-4">
           Dépensé · {format(asOf, "d MMM", { locale: fr })}
         </span>
         <AnimatedNumber
           value={monthlyTotal}
           decimals={0}
           suffix=" €"
-          className="num text-[22px] font-medium tracking-[-0.01em] text-ink"
+          className="num text-xl font-medium tracking-normal text-ink"
         />
         <span className="text-xs text-ink-3">{spentPct}% du budget</span>
       </div>
@@ -65,12 +65,12 @@ const ForecastStrip = () => {
           height={36}
           radius={8}
         />
-        <div className="mt-2 flex items-center justify-between text-[11px] text-ink-4">
+        <div className="mt-2 flex items-center justify-between text-2xs text-ink-4">
           <span className="num">0 €</span>
           <span className="flex items-center gap-4 text-ink-3">
             <span className="inline-flex items-center gap-1.5">
               <span
-                className="inline-block h-2 w-3 rounded-[2px]"
+                className="inline-block h-2 w-3 rounded-xs"
                 style={{
                   background: "linear-gradient(90deg,var(--accent-d),var(--accent-strong))",
                   opacity: 0.55,
@@ -80,7 +80,7 @@ const ForecastStrip = () => {
             </span>
             <span className="inline-flex items-center gap-1.5">
               <span
-                className="inline-block h-2 w-3 rounded-[2px] border border-accent-d"
+                className="inline-block h-2 w-3 rounded-xs border border-accent-d"
                 style={{
                   background: "repeating-linear-gradient(45deg,transparent 0 3px,var(--accent-d) 3px 6px)",
                 }}
@@ -93,13 +93,13 @@ const ForecastStrip = () => {
       </div>
 
       <div className="flex flex-col items-start gap-1 sm:items-end sm:text-right">
-        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">Projection fin de mois</span>
+        <span className="text-2xs font-medium uppercase tracking-caps text-ink-4">Projection fin de mois</span>
         <AnimatedNumber
           value={projection}
           decimals={0}
           suffix=" €"
           color={delta > 0 ? "var(--neg)" : "var(--accent-strong)"}
-          className="num text-[22px] font-medium tracking-[-0.01em]"
+          className="num text-xl font-medium tracking-normal"
         />
         <span className="text-xs text-ink-3">
           <span className={delta > 0 ? "text-neg" : "text-accent-strong"}>

--- a/front/src/components/dashboard/sections/InsightsRibbon.tsx
+++ b/front/src/components/dashboard/sections/InsightsRibbon.tsx
@@ -33,11 +33,11 @@ const Insight = ({
   label: string;
   children: ReactNode;
 }) => (
-  <div className="flex items-start gap-3 bg-card px-[18px] py-3.5">
-    <span className={cn("mt-0.5 grid size-7 shrink-0 place-items-center rounded-[7px]", tone)}>{icon}</span>
+  <div className="flex items-start gap-3 bg-card px-4.5 py-3.5">
+    <span className={cn("mt-0.5 grid size-7 shrink-0 place-items-center rounded-md", tone)}>{icon}</span>
     <div className="flex flex-col gap-0.5">
-      <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-3">{label}</span>
-      <span className="text-[13px] text-ink-2">{children}</span>
+      <span className="text-2xs font-medium uppercase tracking-caps text-ink-3">{label}</span>
+      <span className="text-sm text-ink-2">{children}</span>
     </div>
   </div>
 );
@@ -65,7 +65,7 @@ const InsightsRibbon = () => {
   const lastDayLabel = format(endOfMonth(monthRef), "d MMMM", { locale: fr });
 
   return (
-    <section className="grid grid-cols-1 gap-px overflow-hidden rounded-[10px] border border-line-soft bg-line-soft sm:grid-cols-3">
+    <section className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-line-soft bg-line-soft sm:grid-cols-3">
       <Insight
         tone="bg-accent-strong/10 text-accent-strong"
         icon={<TrendingUp className="size-3.5" />}

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -77,22 +77,20 @@ const WeeklyCeiling = () => {
   return (
     <section className="pfa-card flex flex-col gap-4 px-6 py-5">
       <div className="flex items-center justify-between">
-        <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">Plafond hebdomadaire</h2>
+        <h2 className="text-base font-semibold tracking-normal text-ink">Plafond hebdomadaire</h2>
         {!editing ? (
           <button
             type="button"
             disabled={!canEdit}
             onClick={() => canEdit && setEditing(true)}
             className={cn(
-              "group inline-flex items-center gap-1 border-b border-dashed pb-px text-[12px] transition-colors",
+              "group inline-flex items-center gap-1 border-b border-dashed pb-px text-xs transition-colors",
               canEdit ? "border-ink-4 text-ink-2 hover:border-accent-strong" : "border-transparent opacity-50",
             )}
             title="Modifier le plafond"
           >
             <span className="num">{euro0(ceiling)} €/sem.</span>
-            {canEdit && (
-              <EditGlyph className="size-[11px] text-ink-4 transition-colors group-hover:text-accent-strong" />
-            )}
+            {canEdit && <EditGlyph className="size-3 text-ink-4 transition-colors group-hover:text-accent-strong" />}
           </button>
         ) : (
           <form
@@ -124,11 +122,11 @@ const WeeklyCeiling = () => {
             <div
               key={`${monthKey}-${weekLabel}`}
               className={cn(
-                "grid grid-cols-[52px_1fr_74px] items-center gap-3 border-b border-line-soft py-[11px] text-[13px] last:border-b-0",
+                "grid grid-cols-[52px_1fr_74px] items-center gap-3 border-b border-line-soft py-3 text-sm last:border-b-0",
                 current && "font-semibold",
               )}
             >
-              <span className="num text-[12px] text-ink-2">{slices[i] ?? `S${i + 1}`}</span>
+              <span className="num text-xs text-ink-2">{slices[i] ?? `S${i + 1}`}</span>
               <ProgressTrack
                 key={`${monthKey}-${weekLabel}-${weekTotal > 0 ? "d" : "e"}`}
                 value={weekTotal}
@@ -145,10 +143,10 @@ const WeeklyCeiling = () => {
                   {future ? "—" : `${euro(weekTotal)} €`}
                 </span>
                 {future ? (
-                  <span className="block text-[11px] text-ink-4">à venir</span>
+                  <span className="block text-2xs text-ink-4">à venir</span>
                 ) : (
                   ceiling > 0 && (
-                    <span className={cn("num block text-[11px]", delta > 0 ? "text-neg" : "text-accent-strong")}>
+                    <span className={cn("num block text-2xs", delta > 0 ? "text-neg" : "text-accent-strong")}>
                       {delta > 0 ? `+${euro0(delta)} €` : `${euro0(delta)} €`}
                     </span>
                   )
@@ -157,10 +155,10 @@ const WeeklyCeiling = () => {
             </div>
           );
         })}
-        {stats.length === 0 && <div className="py-6 text-center text-[12.5px] text-ink-4">Pas encore de données.</div>}
+        {stats.length === 0 && <div className="py-6 text-center text-xs text-ink-4">Pas encore de données.</div>}
       </div>
 
-      <div className="flex items-center justify-between border-t border-line pt-3.5 text-[12px] text-ink-3">
+      <div className="flex items-center justify-between border-t border-line pt-3.5 text-xs text-ink-3">
         <span>Moyenne hebdo</span>
         <span className="num text-ink">
           {euro(avg)} €
@@ -169,18 +167,18 @@ const WeeklyCeiling = () => {
       </div>
 
       {ceiling > 0 && (
-        <div className="flex flex-wrap items-center gap-2 text-[11.5px] text-ink-3">
+        <div className="flex flex-wrap items-center gap-2 text-2xs text-ink-3">
           <span className="inline-block h-2.5 w-0.5 rounded-sm bg-ink-2" />
           <span className="num">Plafond {euro0(ceiling)} €</span>
           <span className="text-ink-4">·</span>
           <span
-            className="inline-block size-2.5 rounded-[2px]"
+            className="inline-block size-2.5 rounded-xs"
             style={{ background: "var(--accent-strong)", opacity: 0.92 }}
           />
           dans le budget
           <span className="text-ink-4">·</span>
           <span
-            className="inline-block size-2.5 rounded-[2px]"
+            className="inline-block size-2.5 rounded-xs"
             style={{ background: "var(--neg)", opacity: 0.95 }}
           />
           dépassement

--- a/front/styles/tokens/typography.css
+++ b/front/styles/tokens/typography.css
@@ -3,8 +3,12 @@
 }
 
 @theme {
-  --text-2xs: 0.7rem;
-  --text-3xs: 0.5rem;
+  --text-2xs: 0.7rem; /* 11px — compact label */
+  --text-3xs: 0.5rem; /* 8px — micro label */
+  --text-display: 2.5rem; /* 40px — hero display number */
+  --text-display-lg: 3.5rem; /* 56px — hero display, wide screens */
+
+  --tracking-caps: 0.08em; /* uppercase micro-labels */
 
   --font-smooch: Smooch Sans, sans-serif;
   --font-poppins: Poppins, sans-serif;


### PR DESCRIPTION
Replace 84 arbitrary Tailwind values across the 8 Dashboard components with scale tokens (text-*, rounded-*, tracking-*, spacing steps). Add three foundation tokens in typography.css: --text-display / --text-display-lg (the 40/56px hero number, now named) and --tracking-caps (0.08em uppercase micro-labels).

16 structural one-offs kept deliberately (grid templates, the month-fit width, the 1000px breakpoint, three oklch danger/ink colours). Purely visual token adoption, no behaviour change.