### PR TITLE
refactor(spendings): adopt design tokens (COS-65)

### DIFF
--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -179,13 +179,13 @@ const SpendingModal = ({
       onOpenChange={(isOpen) => !isOpen && closeModal()}
     >
       <DialogContent className="gap-0 overflow-hidden border-line bg-bg-elev p-0 sm:max-w-[480px]">
-        <DialogHeader className="flex-row items-center justify-between space-y-0 border-b border-line-soft px-[22px] py-[18px] text-left">
-          <DialogTitle className="pr-8 text-[15px] font-semibold tracking-[-0.01em] text-ink">{title}</DialogTitle>
+        <DialogHeader className="flex-row items-center justify-between space-y-0 border-b border-line-soft px-5.5 py-4.5 text-left">
+          <DialogTitle className="pr-8 text-base font-semibold tracking-normal text-ink">{title}</DialogTitle>
         </DialogHeader>
 
         <form
           onSubmit={handleSubmit(onSubmit)}
-          className="flex max-h-[min(78vh,720px)] flex-col gap-[18px] overflow-y-auto px-[22px] py-[22px]"
+          className="flex max-h-[min(78vh,720px)] flex-col gap-4.5 overflow-y-auto px-5.5 py-5.5"
         >
           <DateField
             register={register}

--- a/front/src/components/spendings/common/spendingModal/Toggle.tsx
+++ b/front/src/components/spendings/common/spendingModal/Toggle.tsx
@@ -27,8 +27,8 @@ const Toggle = ({
   >
     <span
       className={cn(
-        "grid size-3.5 place-items-center rounded-[3px] border",
-        active ? "border-accent-strong bg-accent-strong text-[oklch(0.15_0.02_180)]" : "border-line bg-bg-hi",
+        "grid size-3.5 place-items-center rounded-xs border",
+        active ? "border-accent-strong bg-accent-strong text-primary-foreground" : "border-line bg-bg-hi",
       )}
     >
       {active && (

--- a/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
@@ -12,7 +12,7 @@ const AmountField = ({ register, errors }: AmountFieldProps) => (
   <div className="flex flex-col gap-2">
     <Label
       htmlFor="spendingAmount"
-      className="text-[13px] text-ink-2"
+      className="text-sm text-ink-2"
     >
       Montant
     </Label>

--- a/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
@@ -50,7 +50,7 @@ const CategoryField = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <Label className="text-[13px] text-ink-2">Catégorie</Label>
+      <Label className="text-sm text-ink-2">Catégorie</Label>
       <Popover
         open={comboboxOpen}
         onOpenChange={(isOpen) => {
@@ -96,7 +96,7 @@ const CategoryField = ({
             {selectedCategory?.name ? (
               <>
                 <span
-                  className="size-2.5 shrink-0 rounded-[3px]"
+                  className="size-2.5 shrink-0 rounded-xs"
                   style={{
                     backgroundColor: selectedCategory.color ?? FALLBACK_COLOR,
                   }}
@@ -146,7 +146,7 @@ const CategoryField = ({
                     }}
                   >
                     <span
-                      className="mr-1 size-2.5 rounded-[3px]"
+                      className="mr-1 size-2.5 rounded-xs"
                       style={{
                         backgroundColor: category.color ?? FALLBACK_COLOR,
                       }}
@@ -163,7 +163,7 @@ const CategoryField = ({
                     value={`__new-${comboboxQuery.trim()}`}
                     onSelect={() => onCreateCategory(comboboxQuery.trim())}
                   >
-                    <span className="mr-1 size-2.5 rounded-[3px] bg-ink-4" />
+                    <span className="mr-1 size-2.5 rounded-xs bg-ink-4" />
                     <span className="flex-1 capitalize">{comboboxQuery.trim()}</span>
                   </CommandItem>
                 )}
@@ -175,7 +175,7 @@ const CategoryField = ({
 
       {frequentCategories.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="mr-1 text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-4">Fréquentes</span>
+          <span className="mr-1 text-2xs font-medium uppercase tracking-caps text-ink-4">Fréquentes</span>
           {frequentCategories.map((c) => {
             const active = selectedCategory?.name === c.name;
             return (
@@ -191,7 +191,7 @@ const CategoryField = ({
                 )}
               >
                 <span
-                  className="size-[7px] shrink-0 rounded-[2px]"
+                  className="size-2 shrink-0 rounded-xs"
                   style={{ backgroundColor: c.color ?? FALLBACK_COLOR }}
                 />
                 {c.name}

--- a/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
@@ -33,7 +33,7 @@ const DateField = ({ register, getValues, setValue, asRecurring }: DateFieldProp
     <div className="flex flex-col gap-2">
       <Label
         htmlFor="spendingDate"
-        className="text-[13px] text-ink-2"
+        className="text-sm text-ink-2"
       >
         Date
       </Label>

--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -26,7 +26,7 @@ const LabelField = ({
   <div className="flex flex-col gap-2">
     <Label
       htmlFor="spendingLabel"
-      className="text-[13px] text-ink-2"
+      className="text-sm text-ink-2"
     >
       Label
     </Label>
@@ -48,7 +48,7 @@ const LabelField = ({
             key={s.label}
             type="button"
             onClick={() => applySuggestion(s)}
-            className="rounded-md border border-line bg-bg-hi px-2 py-1 text-[11px] text-ink-2 transition-colors hover:border-ink-4 hover:text-ink"
+            className="rounded-md border border-line bg-bg-hi px-2 py-1 text-2xs text-ink-2 transition-colors hover:border-ink-4 hover:text-ink"
           >
             {s.label}
             <span className="text-ink-4"> — {s.category}</span>

--- a/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
@@ -49,7 +49,7 @@ const ReceiptField = ({
           isReceiptDragging ? "border-elec bg-elec/[0.06]" : "border-line hover:border-elec hover:bg-elec/[0.06]",
         )}
       >
-        <span className="grid size-10 shrink-0 place-items-center rounded-[10px] bg-elec/10 text-elec">
+        <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-elec/10 text-elec">
           <Upload className="size-5" />
         </span>
         <span className="flex min-w-0 flex-col gap-0.5">
@@ -88,7 +88,7 @@ const ReceiptField = ({
           type="button"
           onClick={clearReceipt}
           aria-label="Retirer le reçu"
-          className="grid size-8 shrink-0 place-items-center rounded-md border border-line bg-bg-hi text-ink-3 transition-colors hover:border-[oklch(0.55_0.15_25)] hover:text-neg"
+          className="grid size-8 shrink-0 place-items-center rounded-md border border-line bg-bg-hi text-ink-3 transition-colors hover:border-neg hover:text-neg"
         >
           <X className="size-4" />
         </button>

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -206,16 +206,16 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
         onOpenChange={(isOpen) => !isOpen && handleClickOutside()}
       >
         <DialogContent className="max-h-[92vh] gap-0 overflow-y-auto border-line bg-bg-elev p-0 sm:max-w-[600px]">
-          <DialogHeader className="flex-row items-center gap-3 space-y-0 pb-4 pl-[22px] pr-14 pt-5 text-left">
+          <DialogHeader className="flex-row items-center gap-3 space-y-0 pb-4 pl-5.5 pr-14 pt-5 text-left">
             <DialogTitle
-              className="min-w-0 flex-1 truncate pr-8 text-[21px] font-semibold tracking-[-0.02em] text-ink"
+              className="min-w-0 flex-1 truncate pr-8 text-xl font-semibold tracking-tight text-ink"
               title={spending.label}
             >
               {spending.label}
             </DialogTitle>
             {category && (
               <span
-                className="shrink-0 rounded-md px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.06em]"
+                className="shrink-0 rounded-md px-2.5 py-1 text-2xs font-semibold uppercase tracking-wider"
                 style={{
                   backgroundColor: `${categoryColor}30`,
                   color: categoryColor,
@@ -224,7 +224,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
                 {category}
               </span>
             )}
-            <span className="num shrink-0 whitespace-nowrap text-[19px] font-semibold tracking-[-0.02em] text-elec">
+            <span className="num shrink-0 whitespace-nowrap text-lg font-semibold tracking-tight text-elec">
               {Number(spending.amount).toFixed(2)} €
             </span>
           </DialogHeader>
@@ -234,7 +234,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
               palette token. */}
           <div
             className={cn(
-              "mx-[22px] overflow-hidden rounded-[14px] border border-line",
+              "mx-5.5 overflow-hidden rounded-xl border border-line",
               invoiceImage || pendingPreview ? "bg-[#b3ada4]" : "bg-background",
             )}
           >
@@ -268,13 +268,13 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
                 unoptimized
               />
             ) : (
-              <div className="grid min-h-[300px] place-items-center text-base tracking-[-0.01em] text-ink-4">
+              <div className="grid min-h-[300px] place-items-center text-base tracking-normal text-ink-4">
                 {invoiceModalTexts.noInvoice}
               </div>
             )}
           </div>
 
-          <div className="flex flex-col gap-2 px-[22px] pb-[22px] pt-[18px]">
+          <div className="flex flex-col gap-2 px-5.5 pb-5.5 pt-4.5">
             {isFileTooBig && <p className="text-center text-sm text-neg">{invoiceModalTexts.fileTooBig}</p>}
             {isInvalidFile && <p className="text-center text-sm text-neg">{invoiceModalTexts.invalidFileType}</p>}
 
@@ -292,7 +292,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
               <button
                 type="button"
                 onClick={() => setShowConfirmDeleteImage(true)}
-                className="inline-flex items-center justify-center gap-2.5 rounded-[10px] border border-[oklch(0.55_0.15_25)] bg-[oklch(0.47_0.14_25)] px-[18px] py-3.5 text-[15px] font-semibold text-[oklch(0.98_0.02_25)] transition-[filter] hover:brightness-110"
+                className="inline-flex items-center justify-center gap-2.5 rounded-lg border border-[oklch(0.55_0.15_25)] bg-[oklch(0.47_0.14_25)] px-4.5 py-3.5 text-base font-semibold text-[oklch(0.98_0.02_25)] transition-[filter] hover:brightness-110"
               >
                 <Trash2 className="size-4" />
                 {invoiceModalTexts.delete}
@@ -304,7 +304,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
                   variant="outline"
                   size="lg"
                   onClick={clearPending}
-                  className="flex-1 border-line bg-background text-[15px] text-ink-2 hover:bg-bg-hi"
+                  className="flex-1 border-line bg-background text-base text-ink-2 hover:bg-bg-hi"
                 >
                   Annuler
                 </Button>
@@ -313,7 +313,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
                   variant="primary"
                   size="lg"
                   onClick={sendInvoice}
-                  className="flex-1 text-[15px]"
+                  className="flex-1 text-base"
                 >
                   {invoiceModalTexts.send}
                 </Button>
@@ -352,13 +352,13 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
                   className={cn(
                     // children are pointer-events-none so drag events target the
                     // label itself (no flicker when hovering child elements)
-                    "flex cursor-pointer flex-col items-center gap-1.5 rounded-[14px] border-[1.5px] border-dashed px-[22px] py-[30px] text-center transition-colors [&_*]:pointer-events-none",
+                    "flex cursor-pointer flex-col items-center gap-1.5 rounded-xl border-[1.5px] border-dashed px-5.5 py-7.5 text-center transition-colors [&_*]:pointer-events-none",
                     isDragging ? "border-elec bg-elec/[0.06]" : "border-line hover:border-elec hover:bg-elec/[0.06]",
                   )}
                 >
-                  <Upload className="size-[30px] text-elec" />
-                  <span className="text-[17px] font-semibold text-ink">{invoiceModalTexts.chooseFile}</span>
-                  <span className="num text-[13px] text-ink-4">{invoiceModalTexts.fileTypeWarning}</span>
+                  <Upload className="size-7.5 text-elec" />
+                  <span className="text-base font-semibold text-ink">{invoiceModalTexts.chooseFile}</span>
+                  <span className="num text-sm text-ink-4">{invoiceModalTexts.fileTypeWarning}</span>
                 </label>
               </>
             ) : null}

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -39,7 +39,7 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
   return (
     <section className="sp-catrep">
       <div className="mb-4.5 flex items-baseline justify-between">
-        <h2 className="text-[15px] font-semibold tracking-[-0.01em] text-ink">Répartition par catégorie</h2>
+        <h2 className="text-base font-semibold tracking-normal text-ink">Répartition par catégorie</h2>
         <span className="text-xs text-ink-4">{rangeLabel} · semaine</span>
       </div>
 
@@ -65,12 +65,12 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
             className="sp-cat-row w-full text-left"
           >
             <span
-              className="size-2 rounded-[2px]"
+              className="size-2 rounded-xs"
               style={{ background: r.color }}
             />
             <span className="flex min-w-0 items-baseline gap-2">
               <span className="truncate capitalize text-ink">{r.name}</span>
-              <span className="num shrink-0 rounded-full border border-line-soft bg-background px-1.75 text-[10.5px] leading-[1.55] text-ink-3">
+              <span className="num shrink-0 rounded-full border border-line-soft bg-background px-1.75 text-2xs leading-normal text-ink-3">
                 {r.count}
               </span>
             </span>

--- a/front/src/components/spendings/view/SpendingCategoryFilter.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryFilter.tsx
@@ -41,12 +41,12 @@ const Chip = ({
   >
     {color && (
       <span
-        className="size-[7px] shrink-0 rounded-[2px]"
+        className="size-2 shrink-0 rounded-xs"
         style={{ background: color }}
       />
     )}
     {label}
-    <span className={cn("num text-[11px]", active ? "text-accent-strong/80" : "text-ink-4")}>{count}</span>
+    <span className={cn("num text-2xs", active ? "text-accent-strong/80" : "text-ink-4")}>{count}</span>
   </button>
 );
 
@@ -61,7 +61,7 @@ const SpendingCategoryFilter = ({ categories, total, selected, onSelect }: Spend
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="mr-1 text-[11px] font-medium uppercase tracking-[0.1em] text-ink-4">Filtrer</span>
+      <span className="mr-1 text-2xs font-medium uppercase tracking-widest text-ink-4">Filtrer</span>
       <Chip
         active={selected === null}
         onClick={() => onSelect(null)}

--- a/front/src/components/spendings/view/SpendingSummary.tsx
+++ b/front/src/components/spendings/view/SpendingSummary.tsx
@@ -22,7 +22,7 @@ const Amount = ({ value, unit = " €" }: { value: number; unit?: string }) => {
   return (
     <>
       {int}
-      <span className="text-[18px] font-normal text-ink-3">
+      <span className="text-lg font-normal text-ink-3">
         ,{dec}
         {unit}
       </span>
@@ -49,8 +49,8 @@ interface SpendingSummaryProps {
 
 const Cell = ({ label, value, sub }: { label: string; value: ReactNode; sub: ReactNode }) => (
   <div className="bg-card px-5 py-4">
-    <span className="mb-2 block text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">{label}</span>
-    <div className="num text-[24px] font-medium leading-none tracking-[-0.02em] text-ink">{value}</div>
+    <span className="mb-2 block text-2xs font-medium uppercase tracking-caps text-ink-4">{label}</span>
+    <div className="num text-2xl font-medium leading-none tracking-tight text-ink">{value}</div>
     <div className="mt-1.5 text-xs text-ink-3">{sub}</div>
   </div>
 );
@@ -95,22 +95,20 @@ const SpendingSummary = ({
     );
 
   return (
-    <section className="grid grid-cols-2 gap-px overflow-hidden rounded-[10px] border border-line-soft bg-line-soft min-[760px]:grid-cols-5">
+    <section className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-line-soft bg-line-soft min-[760px]:grid-cols-5">
       {/* Hero — full-width banner on mobile, one equal-width cell (1/5) on desktop
           like the other four. Its font stays big; the four keep theirs too. */}
       <div className="col-span-2 bg-card px-5 py-4 min-[760px]:col-span-1">
-        <span className="mb-2 block text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">
-          Budget restant
-        </span>
+        <span className="mb-2 block text-2xs font-medium uppercase tracking-caps text-ink-4">Budget restant</span>
         <div
           className={cn(
-            "num text-[34px] font-medium leading-none tracking-[-0.02em] min-[1100px]:text-[46px]",
+            "num text-4xl font-medium leading-none tracking-tight min-[1100px]:text-5xl",
             over ? "text-neg" : "text-ink",
           )}
         >
           {over && "−"}
           <AnimatedNumber value={remainingIntValue} />
-          <span className="text-[18px] font-normal text-ink-3 min-[1100px]:text-[26px]">,{remainingDec} €</span>
+          <span className="text-lg font-normal text-ink-3 min-[1100px]:text-2xl">,{remainingDec} €</span>
         </div>
       </div>
       <Cell

--- a/front/src/components/spendings/view/SpendingToolbar.tsx
+++ b/front/src/components/spendings/view/SpendingToolbar.tsx
@@ -17,7 +17,7 @@ const SpendingToolbar = ({ search, onSearchChange }: SpendingToolbarProps) => (
         value={search}
         onChange={(e) => onSearchChange(e.target.value)}
         placeholder="Rechercher une dépense…"
-        className="w-full rounded-md border border-line bg-bg-elev py-2 pl-8 pr-3 text-[13px] text-ink outline-none transition-colors placeholder:text-ink-4 focus:border-accent-d"
+        className="w-full rounded-md border border-line bg-bg-elev py-2 pl-8 pr-3 text-sm text-ink outline-none transition-colors placeholder:text-ink-4 focus:border-accent-d"
       />
     </div>
 


### PR DESCRIPTION
Replace arbitrary Tailwind values across the Dépenses tree (view/, spendingModal/, invoiceModal/) with scale tokens: text-*, rounded-*, tracking-*, and .5-step spacing. Map two inline oklch colours to tokens (Toggle active text → text-primary-foreground; ReceiptField hover border → border-neg).

Kept as justified one-offs: the InvoiceModal delete button (bespoke dark-danger, opposite polarity to destructive tokens), two unique elevation shadows, the tan receipt backdrop, the 1.5px dashed dropzone borders, and structural viewport dimensions. No behaviour or DOM change.