### PR TITLE
refactor(ui): unify danger system (COS-82)

### DIFF
--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import CategoryFormModal from "@components/categories/CategoryFormModal";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@components/ui/alert-dialog";
+import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { cn } from "@lib/utils";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -92,28 +83,14 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
         onSubmit={onSave}
       />
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={isDeleteOpen}
         onOpenChange={setIsDeleteOpen}
-      >
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle className="capitalize">Supprimer la catégorie « {category.name} » ?</AlertDialogTitle>
-            <AlertDialogDescription>
-              Cette action est irréversible. Les dépenses associées n&apos;auront plus de catégorie.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Annuler</AlertDialogCancel>
-            <AlertDialogAction
-              onClick={onDelete}
-              className="bg-destructive text-white hover:bg-destructive/90"
-            >
-              Supprimer
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        title={`Supprimer la catégorie « ${category.name} » ?`}
+        titleClassName="capitalize"
+        description="Cette action est irréversible. Les dépenses associées n'auront plus de catégorie."
+        onConfirm={onDelete}
+      />
     </>
   );
 };

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -109,11 +109,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
             return (
               <div
                 key={r.ID}
-                className="flex items-center gap-2 rounded-md px-2.5 py-2 text-sm"
-                style={{
-                  background: "color-mix(in oklch, var(--neg) 15%, var(--surface-elev))",
-                  border: "1px solid color-mix(in oklch, var(--neg) 55%, transparent)",
-                }}
+                className="flex items-center gap-2 rounded-md border border-danger-border-soft bg-danger-surface px-2.5 py-2 text-sm"
               >
                 <span className="flex-1 truncate text-ink">Supprimer&nbsp;?</span>
                 <button
@@ -129,7 +125,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
                     deleteRecurring.mutate({ recurring: r });
                     setPendingDelete(null);
                   }}
-                  className="rounded bg-[oklch(0.6_0.23_25)] px-2 py-1 text-xs text-[oklch(0.99_0.01_25)]"
+                  className="rounded bg-danger-solid px-2 py-1 text-xs text-on-danger hover:brightness-110"
                 >
                   Confirmer
                 </button>

--- a/front/src/components/exceptionals/ExceptionalItem.tsx
+++ b/front/src/components/exceptionals/ExceptionalItem.tsx
@@ -1,16 +1,7 @@
 "use client";
 
 import useExceptionals from "@components/exceptionals/services/useExceptionals";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@components/ui/alert-dialog";
+import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import format from "date-fns/format";
 import { fr } from "date-fns/locale";
 import parseISO from "date-fns/parseISO";
@@ -109,28 +100,12 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
         </span>
       </div>
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={isDeleteOpen}
         onOpenChange={setIsDeleteOpen}
-      >
-        <AlertDialogContent className="border-line bg-surface-elev">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-ink">Supprimer {item.label}&nbsp;?</AlertDialogTitle>
-            <AlertDialogDescription className="text-ink-3">Cette action est irréversible.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="border-line bg-background text-ink-2 hover:bg-surface-hi">
-              Annuler
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={onDelete}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Supprimer
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        title={`Supprimer ${item.label} ?`}
+        onConfirm={onDelete}
+      />
     </>
   );
 };

--- a/front/src/components/shared/ConfirmDeleteDialog.tsx
+++ b/front/src/components/shared/ConfirmDeleteDialog.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@components/ui/alert-dialog";
+import { cn } from "@lib/utils";
+
+import type { ReactNode } from "react";
+
+interface ConfirmDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: ReactNode;
+  /** Defaults to the standard irreversible-action warning. */
+  description?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Extra classes on the title (e.g. `capitalize`). */
+  titleClassName?: string;
+  onConfirm: () => void;
+}
+
+/**
+ * Shared delete-confirmation modal: title + irreversible warning + cancel / danger
+ * action. Unifies the near-identical AlertDialogs across Catégories, Exceptionnels
+ * and the invoice modal so the destructive action reads the same everywhere.
+ *
+ * The action overrides the AlertDialogAction default variant with the danger tokens
+ * (incl. `hover:bg-danger-solid` to cancel the default's `hover:bg-primary`).
+ */
+const ConfirmDeleteDialog = ({
+  open,
+  onOpenChange,
+  title,
+  description = "Cette action est irréversible.",
+  confirmLabel = "Supprimer",
+  cancelLabel = "Annuler",
+  titleClassName,
+  onConfirm,
+}: ConfirmDeleteDialogProps) => (
+  <AlertDialog
+    open={open}
+    onOpenChange={onOpenChange}
+  >
+    <AlertDialogContent className="border-line bg-surface-elev">
+      <AlertDialogHeader>
+        <AlertDialogTitle className={cn("text-ink", titleClassName)}>{title}</AlertDialogTitle>
+        <AlertDialogDescription className="text-ink-3">{description}</AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel className="border-line bg-background text-ink-2 hover:bg-surface-hi">
+          {cancelLabel}
+        </AlertDialogCancel>
+        <AlertDialogAction
+          onClick={onConfirm}
+          className="bg-danger-solid text-on-danger hover:bg-danger-solid hover:brightness-110"
+        >
+          {confirmLabel}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+export default ConfirmDeleteDialog;

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -2,19 +2,10 @@
 
 import { useAuth } from "@auth/context/AuthContext";
 import Spinner from "@components/common/Spinner";
+import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { QUERY_KEYS } from "@components/spendings/config/constants";
 import texts from "@components/spendings/config/text";
 import InvoiceImageModal from "@components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@components/ui/alert-dialog";
 import { Button } from "@components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@components/ui/dialog";
 import useRequestHelper from "@helpers/useRequestHelper";
@@ -292,7 +283,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
               <button
                 type="button"
                 onClick={() => setShowConfirmDeleteImage(true)}
-                className="inline-flex items-center justify-center gap-2.5 rounded-lg border border-[oklch(0.55_0.15_25)] bg-[oklch(0.47_0.14_25)] px-4.5 py-3.5 text-base font-semibold text-[oklch(0.98_0.02_25)] transition-[filter] hover:brightness-110"
+                className="inline-flex items-center justify-center gap-2.5 rounded-lg bg-danger-solid px-4.5 py-3.5 text-base font-semibold text-on-danger transition-[filter] hover:brightness-110"
               >
                 <Trash2 className="size-4" />
                 {invoiceModalTexts.delete}
@@ -373,31 +364,12 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
         />
       )}
 
-      <AlertDialog
+      <ConfirmDeleteDialog
         open={showConfirmDeleteImage}
         onOpenChange={setShowConfirmDeleteImage}
-      >
-        <AlertDialogContent className="border-line bg-surface-elev">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-ink">Supprimer la facture&nbsp;?</AlertDialogTitle>
-            <AlertDialogDescription className="text-ink-3">Cette action est irréversible.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel className="border-line bg-background text-ink-2 hover:bg-surface-hi">
-              Annuler
-            </AlertDialogCancel>
-            <AlertDialogAction
-              onClick={() => {
-                deleteImage();
-                setShowConfirmDeleteImage(false);
-              }}
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-            >
-              Supprimer
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        title={<>Supprimer la facture&nbsp;?</>}
+        onConfirm={deleteImage}
+      />
     </>
   );
 };

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -10,8 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        destructive: "bg-danger-solid text-on-danger hover:brightness-110 focus-visible:ring-danger-solid/40",
         outline:
           "border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",

--- a/front/styles/tokens/colors.css
+++ b/front/styles/tokens/colors.css
@@ -62,6 +62,13 @@
   --accent-bg:     oklch(0.84 0.14 148 / 0.10);
   --neg:           oklch(0.72 0.17 25);
   --neg-bg:        oklch(0.72 0.17 25 / 0.12);
+
+  /* Danger — solid delete button + inline confirm affordance */
+  --danger-solid:       oklch(0.55 0.18 25); /* solid delete-button fill */
+  --on-danger:          oklch(0.98 0.02 25); /* text on --danger-solid */
+  --danger-surface:     color-mix(in oklch, var(--neg) 15%, var(--surface-elev)); /* inline confirm bar bg */
+  --danger-border-soft: color-mix(in oklch, var(--neg) 55%, transparent); /* inline confirm bar border */
+
   --exc:           oklch(0.70 0.13 240); /* achats exceptionnels (bleu calme) */
   --exc-bg:        oklch(0.70 0.13 240 / 0.14);
   --elec:          oklch(0.72 0.15 230); /* "aujourd'hui" */
@@ -158,6 +165,10 @@
   --color-accent-d: var(--accent-d);
   --color-accent-bg: var(--accent-bg);
   --color-neg: var(--neg);
+  --color-danger-solid: var(--danger-solid);
+  --color-on-danger: var(--on-danger);
+  --color-danger-surface: var(--danger-surface);
+  --color-danger-border-soft: var(--danger-border-soft);
   --color-exc: var(--exc);
   --color-exc-bg: var(--exc-bg);
   --color-elec: var(--elec);


### PR DESCRIPTION
Add danger tokens (--danger-solid, --on-danger, --danger-surface, --danger-border-soft) and reconcile the Button destructive variant onto them. Extract ConfirmDeleteDialog (shared), adopted in Categories, Exceptionnels and the invoice modal — unifying the previously inconsistent delete dialogs (white vs dark text). Tokenize the FixedExpenses inline confirm bar + invoice delete CTA. Legacy SpendingItem/SpendingTxRow rows + the ConfirmDeleteBar extraction are deferred to a follow-up.