### PR TITLE
refactor(ui): add IconButton primitive (COS-83)

### DIFF
--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -2,7 +2,7 @@
 
 import CategoryFormModal from "@components/categories/CategoryFormModal";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
-import { cn } from "@lib/utils";
+import { IconButton } from "@components/shared/IconButton";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 
@@ -20,9 +20,6 @@ interface CategoryItemProps {
   onDelete: () => void;
 }
 
-const IC =
-  "grid size-[26px] place-items-center rounded-[6px] border border-line bg-bg text-ink-4 transition-colors hover:border-ink-4 hover:bg-surface-hi hover:text-ink";
-
 const pct1 = (value: number): string => value.toFixed(1).replace(".", ",");
 
 const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: CategoryItemProps) => {
@@ -39,24 +36,24 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
           />
           <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium capitalize text-ink">{category.name}</span>
           <span className="flex flex-none gap-1.5">
-            <button
-              type="button"
+            <IconButton
+              variant="bordered"
+              size={6}
               onClick={() => setIsEditOpen(true)}
-              className={IC}
               aria-label="Modifier le nom et la couleur"
               title="Modifier le nom et la couleur"
             >
-              <Pencil className="size-3" />
-            </button>
-            <button
-              type="button"
+              <Pencil />
+            </IconButton>
+            <IconButton
+              variant="danger"
+              size={6}
               onClick={() => setIsDeleteOpen(true)}
-              className={cn(IC, "hover:border-neg hover:bg-[oklch(0.72_0.17_25/0.10)] hover:text-neg")}
               aria-label="Supprimer la catégorie"
               title="Supprimer la catégorie"
             >
-              <Trash2 className="size-3" />
-            </button>
+              <Trash2 />
+            </IconButton>
           </span>
         </div>
 

--- a/front/src/components/dashboard/MonthSelector.tsx
+++ b/front/src/components/dashboard/MonthSelector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { IconButton } from "@components/shared/IconButton";
 import addDays from "date-fns/addDays";
 import addMonths from "date-fns/addMonths";
 import eachDayOfInterval from "date-fns/eachDayOfInterval";
@@ -33,27 +34,27 @@ const MonthSelector = () => {
     <div className="flex items-center gap-2.5">
       <div className="flex items-center gap-1.5 rounded-sm border border-line bg-surface-elev px-2.5 py-2 text-sm text-ink-2">
         <Calendar className="size-3.5 text-ink-4" />
-        <button
-          type="button"
+        <IconButton
+          variant="ghost"
+          size={5}
           onClick={() => applyMonth(addMonths(month, -1))}
           aria-label="Mois précédent"
-          className="grid size-5 place-items-center rounded text-ink-4 transition-colors hover:text-ink"
         >
-          <ChevronLeft className="size-4" />
-        </button>
+          <ChevronLeft />
+        </IconButton>
         {/* fixed width (fits the longest month, "septembre") so the control
             never resizes as the month changes */}
         <span className="num w-[116px] text-center capitalize tracking-normal">
           {format(month, "MMMM yyyy", { locale: fr })}
         </span>
-        <button
-          type="button"
+        <IconButton
+          variant="ghost"
+          size={5}
           onClick={() => applyMonth(addMonths(month, 1))}
           aria-label="Mois suivant"
-          className="grid size-5 place-items-center rounded text-ink-4 transition-colors hover:text-ink"
         >
-          <ChevronRight className="size-4" />
-        </button>
+          <ChevronRight />
+        </IconButton>
       </div>
     </div>
   );

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { euro } from "@components/dashboard/format";
+import { IconButton } from "@components/shared/IconButton";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import useReccurings from "@components/spendings/services/useReccurings";
@@ -66,14 +67,15 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
             {list.length} lignes · échéancier {format(month.start, "MMMM", { locale: fr })}
           </span>
         </div>
-        <button
-          type="button"
+        <IconButton
+          variant="bordered"
+          size={8}
           onClick={addSpending}
           aria-label="Ajouter une dépense fixe"
-          className="grid size-8 shrink-0 place-items-center rounded-lg border border-line bg-surface-hi text-ink-2 transition-colors hover:border-accent-d hover:text-ink"
+          className="hover:border-accent-d"
         >
-          <Plus className="size-4" />
-        </button>
+          <Plus />
+        </IconButton>
       </div>
 
       <div className="flex items-start justify-between">
@@ -147,35 +149,34 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
               </span>
               <span className="flex items-center gap-2">
                 <span className="flex gap-1 opacity-100 transition-opacity [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100">
-                  <button
-                    type="button"
+                  <IconButton
+                    variant="bordered"
+                    size={6}
                     onClick={() => setInvoiceFor(r)}
                     title="Facture"
                     className={cn(
-                      "grid size-6 place-items-center rounded border border-line",
-                      hasInvoice(r)
-                        ? "bg-accent-strong text-[oklch(0.18_0.01_148)]"
-                        : "bg-surface-hi text-ink-3 hover:text-ink",
+                      hasInvoice(r) &&
+                        "border-accent-strong bg-accent-strong text-[oklch(0.18_0.01_148)] hover:text-[oklch(0.18_0.01_148)]",
                     )}
                   >
-                    <ImageIcon className="size-3" />
-                  </button>
-                  <button
-                    type="button"
+                    <ImageIcon />
+                  </IconButton>
+                  <IconButton
+                    variant="bordered"
+                    size={6}
                     onClick={() => editSpending(r)}
                     title="Modifier"
-                    className="grid size-6 place-items-center rounded border border-line bg-surface-hi text-ink-3 hover:text-ink"
                   >
-                    <Pencil className="size-3" />
-                  </button>
-                  <button
-                    type="button"
+                    <Pencil />
+                  </IconButton>
+                  <IconButton
+                    variant="danger"
+                    size={6}
                     onClick={() => setPendingDelete(r.ID)}
                     title="Supprimer"
-                    className="grid size-6 place-items-center rounded border border-line bg-surface-hi text-ink-3 hover:text-neg"
                   >
-                    <Trash2 className="size-3" />
-                  </button>
+                    <Trash2 />
+                  </IconButton>
                 </span>
                 {day != null && (
                   <span

--- a/front/src/components/exceptionals/ExceptionalItem.tsx
+++ b/front/src/components/exceptionals/ExceptionalItem.tsx
@@ -2,6 +2,7 @@
 
 import useExceptionals from "@components/exceptionals/services/useExceptionals";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
+import { IconButton } from "@components/shared/IconButton";
 import format from "date-fns/format";
 import { fr } from "date-fns/locale";
 import parseISO from "date-fns/parseISO";
@@ -79,24 +80,24 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
         <span className="exc-amt">{amount} €</span>
 
         <span className="exc-acts">
-          <button
-            type="button"
-            className="exc-ic"
+          <IconButton
+            variant="bordered"
+            size={7}
             onClick={() => onEdit(item)}
             aria-label="Modifier"
             title="Modifier"
           >
-            <Pencil className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            className="exc-ic exc-ic-del"
+            <Pencil />
+          </IconButton>
+          <IconButton
+            variant="danger"
+            size={7}
             onClick={() => setIsDeleteOpen(true)}
             aria-label="Supprimer"
             title="Supprimer"
           >
-            <Trash2 className="size-3.5" />
-          </button>
+            <Trash2 />
+          </IconButton>
         </span>
       </div>
 

--- a/front/src/components/shared/IconButton.tsx
+++ b/front/src/components/shared/IconButton.tsx
@@ -1,0 +1,60 @@
+import { cn } from "@lib/utils";
+import { cva } from "class-variance-authority";
+
+import type { VariantProps } from "class-variance-authority";
+
+/**
+ * Square icon-only action button — the single primitive behind every hand-rolled
+ * `grid size-N place-items-center rounded …` button scattered across the app
+ * (and the twin `.ic` / `.exc-ic` CSS classes it replaced).
+ *
+ * - `variant` sets the resting/hover chrome.
+ * - `size` sets the box, its corner radius and the child icon size in one step,
+ *   so call sites never restyle the `<svg>` child.
+ *
+ * The `danger` variant reuses the COS-82 danger tokens for its hover state. Pass
+ * `className` for the rare intentional deviation (e.g. an "active" accent state);
+ * it is merged last so it wins.
+ */
+const iconButtonVariants = cva(
+  "grid shrink-0 cursor-pointer place-items-center border transition-colors [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        ghost: "border-transparent text-ink-4 hover:bg-surface-hi hover:text-ink",
+        bordered: "border-line bg-surface-hi text-ink-3 hover:text-ink",
+        danger:
+          "border-line bg-surface-hi text-ink-3 hover:border-danger-border-soft hover:bg-danger-surface hover:text-neg",
+      },
+      size: {
+        5: "size-5 rounded-sm [&_svg]:size-4",
+        6: "size-6 rounded-sm [&_svg]:size-3.5",
+        7: "size-7 rounded-sm [&_svg]:size-3.5",
+        8: "size-8 rounded-lg [&_svg]:size-4",
+        9: "size-9 rounded-lg [&_svg]:size-5",
+      },
+    },
+    defaultVariants: {
+      variant: "bordered",
+      size: 6,
+    },
+  },
+);
+
+function IconButton({
+  className,
+  variant,
+  size,
+  type = "button",
+  ...props
+}: React.ComponentProps<"button"> & VariantProps<typeof iconButtonVariants>) {
+  return (
+    <button
+      type={type}
+      className={cn(iconButtonVariants({ variant, size }), className)}
+      {...props}
+    />
+  );
+}
+
+export { IconButton, iconButtonVariants };

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -7,6 +7,7 @@ import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import Logo from "@components/shared/brand/Logo";
 import { ROUTES } from "@components/shared/config/constants";
 import useGlobalStore from "@components/shared/globalStore";
+import { IconButton } from "@components/shared/IconButton";
 import UserMenu from "@components/shared/navBar/userMenu/UserMenu";
 import { buildSpendingsPath, getTodayIsoDate, isValidIsoDate, SPENDINGS_PATH } from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
@@ -109,14 +110,15 @@ const NavBar = () => {
   return (
     <>
       <header className="pfa-hdr sticky top-0 z-40 mb-7 flex flex-wrap items-center gap-x-3 gap-y-2.5 px-3.5 py-2.5">
-        <button
-          type="button"
+        <IconButton
+          variant="ghost"
+          size={9}
           onClick={() => setDrawerOpen(true)}
           aria-label="Ouvrir le menu"
-          className="grid size-[38px] flex-shrink-0 place-items-center rounded-[9px] border border-transparent text-ink-2 transition-colors hover:border-line hover:bg-surface-hi hover:text-ink lg:hidden"
+          className="hover:border-line lg:hidden"
         >
-          <Menu className="size-5" />
-        </button>
+          <Menu />
+        </IconButton>
 
         {brand}
 
@@ -192,14 +194,15 @@ const NavBar = () => {
       >
         <div className="mb-1.5 flex items-center justify-between border-b border-white/[0.07] px-1.5 pb-3">
           {brand}
-          <button
-            type="button"
+          <IconButton
+            variant="ghost"
+            size={9}
             onClick={() => setDrawerOpen(false)}
             aria-label="Fermer le menu"
-            className="grid size-9 place-items-center rounded-[9px] border border-transparent text-ink-3 transition-colors hover:border-line hover:bg-surface-hi hover:text-ink"
+            className="hover:border-line"
           >
-            <X className="size-5" />
-          </button>
+            <X />
+          </IconButton>
         </div>
         <nav className="flex flex-col gap-0.5">
           {NAV_ROUTES.map((route) => {

--- a/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
@@ -1,3 +1,4 @@
+import { IconButton } from "@components/shared/IconButton";
 import { humanSize } from "@components/spendings/common/spendingModal/helpers";
 import { cn } from "@lib/utils";
 import { Upload, X } from "lucide-react";
@@ -84,14 +85,14 @@ const ReceiptField = ({
           <span className="truncate text-sm font-semibold text-ink">{receiptFile.name}</span>
           <span className="num text-xs text-ink-4">{humanSize(receiptFile.size)}</span>
         </span>
-        <button
-          type="button"
+        <IconButton
+          variant="danger"
+          size={8}
           onClick={clearReceipt}
           aria-label="Retirer le reçu"
-          className="grid size-8 shrink-0 place-items-center rounded-md border border-line bg-surface-hi text-ink-3 transition-colors hover:border-neg hover:text-neg"
         >
-          <X className="size-4" />
-        </button>
+          <X />
+        </IconButton>
       </div>
     )}
   </div>

--- a/front/src/components/spendings/view/SpendingTxRow.tsx
+++ b/front/src/components/spendings/view/SpendingTxRow.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { IconButton } from "@components/shared/IconButton";
 import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import useSpendings from "@components/spendings/services/useSpendings";
-import { cn } from "@lib/utils";
 import { ImageIcon, Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
 
@@ -108,30 +108,35 @@ const SpendingTxRow = ({ spending, onEdit }: SpendingTxRowProps) => {
           </span>
 
           <span className="sp-t-actions">
-            <button
-              type="button"
-              className={cn("ic ic-img", hasInvoice && "has-img")}
+            <IconButton
+              variant="bordered"
+              size={7}
               title={hasInvoice ? "Voir le reçu" : "Ajouter un reçu"}
               onClick={() => setInvoiceOpen(true)}
+              className={
+                hasInvoice
+                  ? "border-accent-strong bg-accent-strong text-[oklch(0.18_0.01_148)] hover:text-[oklch(0.18_0.01_148)] hover:brightness-[1.06]"
+                  : undefined
+              }
             >
-              <ImageIcon className="size-3.5" />
-            </button>
-            <button
-              type="button"
-              className="ic"
+              <ImageIcon />
+            </IconButton>
+            <IconButton
+              variant="bordered"
+              size={7}
               title="Modifier"
               onClick={() => onEdit(spending)}
             >
-              <Pencil className="size-3" />
-            </button>
-            <button
-              type="button"
-              className="ic ic-del"
+              <Pencil />
+            </IconButton>
+            <IconButton
+              variant="danger"
+              size={7}
               title="Supprimer"
               onClick={() => setConfirming(true)}
             >
-              <Trash2 className="size-3" />
-            </button>
+              <Trash2 />
+            </IconButton>
           </span>
         </>
       )}

--- a/front/styles/components/exceptionals.css
+++ b/front/styles/components/exceptionals.css
@@ -62,30 +62,6 @@
 .exc-item:hover .exc-acts {
   opacity: 1;
 }
-.exc-ic {
-  width: 28px;
-  height: 28px;
-  background: var(--surface-hi);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  color: var(--ink-3);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition:
-    color 0.12s,
-    border-color 0.12s,
-    background 0.12s;
-}
-.exc-ic:hover {
-  color: var(--ink);
-  border-color: var(--ink-4);
-}
-.exc-ic-del:hover {
-  color: var(--neg);
-  border-color: color-mix(in oklch, var(--neg) 55%, transparent);
-  background: oklch(0.72 0.17 25 / 0.12);
-}
 @media (max-width: 759px) {
   .exc-item {
     grid-template-columns: 64px 1fr auto;

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -406,41 +406,6 @@
 .sp-tx:hover .sp-t-actions {
   display: flex;
 }
-.sp-t-actions .ic {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  background: var(--surface-hi);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  color: var(--ink-3);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  transition:
-    color 0.12s,
-    border-color 0.12s,
-    background 0.12s;
-}
-.sp-t-actions .ic:hover {
-  color: var(--ink);
-  border-color: var(--ink-4);
-  background: var(--surface-hover);
-}
-.sp-t-actions .ic-img.has-img {
-  background: var(--accent-strong);
-  border-color: var(--accent-strong);
-  color: oklch(0.18 0.01 148);
-}
-.sp-t-actions .ic-img.has-img:hover {
-  filter: brightness(1.06);
-  background: var(--accent-strong);
-}
-.sp-t-actions .ic-del:hover {
-  color: oklch(0.78 0.16 25);
-  border-color: oklch(0.55 0.15 25);
-  background: oklch(0.72 0.17 25 / 0.12);
-}
 
 /* inline delete confirmation (replaces the row content in React) */
 .sp-tx-confirm {
@@ -594,9 +559,5 @@
     justify-self: end;
     background: none;
     padding: 0;
-  }
-  .sp-t-actions .ic {
-    width: 30px;
-    height: 30px;
   }
 }


### PR DESCRIPTION
Collapse ~15 hand-rolled `grid size-N place-items-center rounded …` icon buttons and their twin CSS classes (.ic/.ic-del/.ic-img, .exc-ic/.exc-ic-del) into one <IconButton size variant> (cva).

- variants: ghost | bordered | danger (danger reuses the COS-82 danger tokens for its hover state)
- size (5/6/7/8/9) drives box, radius and the child icon size in one step, so call sites no longer restyle the <svg>
- normalises divergent resting/hover colours and sizes to one canonical behaviour per variant (snap <=2px)

Migrated: MonthSelector, FixedExpenses (add/invoice/edit/delete), ReceiptField, CategoryItem, ExceptionalItem, SpendingTxRow, NavBar (burger + drawer close). Deleted the now-dead .ic*/.exc-ic* CSS.

Deferred by design: DateField steppers (segmented input), the cyan Dialog close (#9), login eye toggles and the StatisticsFilters chip-remove (#7). SpendingItem is dead code (unmounted) and left for a separate deletion.