### PR TITLE
refactor(ui): card-chrome primitives (COS-85)

### DIFF
--- a/front/src/components/categories/CategoryFormModal.tsx
+++ b/front/src/components/categories/CategoryFormModal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { cssColorToHex, paletteHex } from "@components/categories/helpers/categoryColors";
+import { Overline, overlineClass } from "@components/shared/Overline";
 import { Button } from "@components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@components/ui/dialog";
 import { cn } from "@lib/utils";
 import { useMemo, useState } from "react";
 
-const LABEL = "text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4";
+const LABEL = overlineClass;
 const INPUT =
   "w-full rounded-[6px] border border-line bg-bg px-3 py-2.5 text-[14px] text-ink outline-none transition focus:border-accent-d";
 
@@ -91,7 +92,7 @@ const CategoryFormBody = ({
         </div>
 
         <div className="flex flex-col gap-2.5">
-          <span className={LABEL}>Couleur</span>
+          <Overline>Couleur</Overline>
           <div className="flex flex-wrap gap-2.5">
             {swatches.map((hex) => (
               <button

--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -2,6 +2,8 @@
 
 import { euro, pct1 } from "@components/dashboard/format";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
+import { EmptyState } from "@components/shared/EmptyState";
 import { MONTHLY } from "@components/spendings/config/constants";
 import useCharts from "@components/spendings/services/useCharts";
 import useSpendings from "@components/spendings/services/useSpendings";
@@ -68,10 +70,10 @@ const CategoryBreakdown = () => {
 
   return (
     <section className="pfa-card flex max-h-137.5 min-h-80 flex-col gap-4 px-6 py-5">
-      <div className="flex items-baseline justify-between">
-        <h2 className="text-base font-semibold tracking-normal text-ink">Répartition par catégorie</h2>
-        <span className="text-xs text-ink-4">{monthLabel} · part des variables</span>
-      </div>
+      <CardSectionHeader
+        title="Répartition par catégorie"
+        meta={`${monthLabel} · part des variables`}
+      />
 
       {list.length > 0 ? (
         <>
@@ -112,7 +114,7 @@ const CategoryBreakdown = () => {
           </div>
         </>
       ) : (
-        <div className="py-10 text-center text-xs text-ink-4">Aucune dépense ce mois.</div>
+        <EmptyState className="py-10">Aucune dépense ce mois.</EmptyState>
       )}
 
       {hover && (

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { euro } from "@components/dashboard/format";
+import { CardTitle } from "@components/shared/CardSectionHeader";
+import { EmptyState } from "@components/shared/EmptyState";
 import { IconButton } from "@components/shared/IconButton";
+import { Overline } from "@components/shared/Overline";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import useReccurings from "@components/spendings/services/useReccurings";
@@ -62,7 +65,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
     <section className="pfa-card flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5">
       <div className="flex items-start justify-between">
         <div>
-          <h2 className="text-base font-semibold tracking-normal text-ink">Dépenses fixes</h2>
+          <CardTitle>Dépenses fixes</CardTitle>
           <span className="text-xs text-ink-4">
             {list.length} lignes · échéancier {format(month.start, "MMMM", { locale: fr })}
           </span>
@@ -80,14 +83,14 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
 
       <div className="flex items-start justify-between">
         <div>
-          <div className="text-2xs font-medium uppercase tracking-caps text-ink-4">Mensuel</div>
+          <Overline>Mensuel</Overline>
           <div className="num text-2xl font-medium tracking-tight text-ink">
             {totalInt}
             <span className="text-lg text-ink-3">,{totalDec} €</span>
           </div>
         </div>
         <div className="text-right">
-          <div className="text-2xs font-medium uppercase tracking-caps text-ink-4">Annualisé</div>
+          <Overline>Annualisé</Overline>
           <div className="num text-lg font-medium tracking-normal text-ink-2">
             {annualInt}
             <span className="text-sm text-ink-3">,{annualDec} €</span>
@@ -193,7 +196,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
             </div>
           );
         })}
-        {list.length === 0 && <div className="py-6 text-center text-xs text-ink-4">Aucune dépense fixe ce mois.</div>}
+        {list.length === 0 && <EmptyState>Aucune dépense fixe ce mois.</EmptyState>}
       </div>
 
       {isModalVisible && (

--- a/front/src/components/dashboard/sections/ForecastStrip.tsx
+++ b/front/src/components/dashboard/sections/ForecastStrip.tsx
@@ -5,6 +5,7 @@
 
 import { euro0 } from "@components/dashboard/format";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { Overline } from "@components/shared/Overline";
 import useDashboard from "@components/spendings/services/useDashboard";
 import { AnimatedNumber, ProgressTrack } from "@lib/dataviz";
 import endOfMonth from "date-fns/endOfMonth";
@@ -40,9 +41,7 @@ const ForecastStrip = () => {
   return (
     <section className="pfa-card grid grid-cols-1 items-center gap-6 px-6 py-5 sm:grid-cols-[200px_1fr_200px] sm:gap-8">
       <div className="flex flex-col gap-1">
-        <span className="text-2xs font-medium uppercase tracking-caps text-ink-4">
-          Dépensé · {format(asOf, "d MMM", { locale: fr })}
-        </span>
+        <Overline>Dépensé · {format(asOf, "d MMM", { locale: fr })}</Overline>
         <AnimatedNumber
           value={monthlyTotal}
           decimals={0}
@@ -93,7 +92,7 @@ const ForecastStrip = () => {
       </div>
 
       <div className="flex flex-col items-start gap-1 sm:items-end sm:text-right">
-        <span className="text-2xs font-medium uppercase tracking-caps text-ink-4">Projection fin de mois</span>
+        <Overline>Projection fin de mois</Overline>
         <AnimatedNumber
           value={projection}
           decimals={0}

--- a/front/src/components/dashboard/sections/InsightsRibbon.tsx
+++ b/front/src/components/dashboard/sections/InsightsRibbon.tsx
@@ -7,6 +7,7 @@
 
 import { euro0 } from "@components/dashboard/format";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { Overline } from "@components/shared/Overline";
 import { MONTHLY } from "@components/spendings/config/constants";
 import dailyRemainingBudget from "@components/spendings/helpers/dailyBudget";
 import useCharts from "@components/spendings/services/useCharts";
@@ -36,7 +37,7 @@ const Insight = ({
   <div className="flex items-start gap-3 bg-card px-4.5 py-3.5">
     <span className={cn("mt-0.5 grid size-7 shrink-0 place-items-center rounded-md", tone)}>{icon}</span>
     <div className="flex flex-col gap-0.5">
-      <span className="text-2xs font-medium uppercase tracking-caps text-ink-3">{label}</span>
+      <Overline className="text-ink-3">{label}</Overline>
       <span className="text-sm text-ink-2">{children}</span>
     </div>
   </div>

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -3,6 +3,8 @@
 import EditGlyph from "@components/dashboard/EditGlyph";
 import { euro, euro0 } from "@components/dashboard/format";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
+import { EmptyState } from "@components/shared/EmptyState";
 import useWeeklyStatsHelper from "@components/spendings/helpers/useWeeklyStatsHelper";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useWeeklyStats from "@components/spendings/services/useWeeklyStats";
@@ -76,40 +78,43 @@ const WeeklyCeiling = () => {
 
   return (
     <section className="pfa-card flex flex-col gap-4 px-6 py-5">
-      <div className="flex items-center justify-between">
-        <h2 className="text-base font-semibold tracking-normal text-ink">Plafond hebdomadaire</h2>
-        {!editing ? (
-          <button
-            type="button"
-            disabled={!canEdit}
-            onClick={() => canEdit && setEditing(true)}
-            className={cn(
-              "group inline-flex items-center gap-1 border-b border-dashed pb-px text-xs transition-colors",
-              canEdit ? "border-ink-4 text-ink-2 hover:border-accent-strong" : "border-transparent opacity-50",
-            )}
-            title="Modifier le plafond"
-          >
-            <span className="num">{euro0(ceiling)} €/sem.</span>
-            {canEdit && <EditGlyph className="size-3 text-ink-4 transition-colors group-hover:text-accent-strong" />}
-          </button>
-        ) : (
-          <form
-            key={ceiling}
-            onBlur={closeIfLeft}
-            onSubmit={handleSubmit(onSubmit)}
-          >
-            <Input
-              defaultValue={ceiling}
-              className="num h-7 w-24 border-accent-d bg-background text-ink"
-              onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
-                if (e.key === "Escape") setEditing(false);
-              }}
-              autoFocus
-              {...register("initialCeiling")}
-            />
-          </form>
-        )}
-      </div>
+      <CardSectionHeader
+        title="Plafond hebdomadaire"
+        className="items-center"
+        action={
+          !editing ? (
+            <button
+              type="button"
+              disabled={!canEdit}
+              onClick={() => canEdit && setEditing(true)}
+              className={cn(
+                "group inline-flex items-center gap-1 border-b border-dashed pb-px text-xs transition-colors",
+                canEdit ? "border-ink-4 text-ink-2 hover:border-accent-strong" : "border-transparent opacity-50",
+              )}
+              title="Modifier le plafond"
+            >
+              <span className="num">{euro0(ceiling)} €/sem.</span>
+              {canEdit && <EditGlyph className="size-3 text-ink-4 transition-colors group-hover:text-accent-strong" />}
+            </button>
+          ) : (
+            <form
+              key={ceiling}
+              onBlur={closeIfLeft}
+              onSubmit={handleSubmit(onSubmit)}
+            >
+              <Input
+                defaultValue={ceiling}
+                className="num h-7 w-24 border-accent-d bg-background text-ink"
+                onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                  if (e.key === "Escape") setEditing(false);
+                }}
+                autoFocus
+                {...register("initialCeiling")}
+              />
+            </form>
+          )
+        }
+      />
 
       <div className="flex flex-col">
         {stats.map((weekTotal, i) => {
@@ -155,7 +160,7 @@ const WeeklyCeiling = () => {
             </div>
           );
         })}
-        {stats.length === 0 && <div className="py-6 text-center text-xs text-ink-4">Pas encore de données.</div>}
+        {stats.length === 0 && <EmptyState>Pas encore de données.</EmptyState>}
       </div>
 
       <div className="flex items-center justify-between border-t border-line pt-3.5 text-xs text-ink-3">

--- a/front/src/components/exceptionals/ExceptionalFilters.tsx
+++ b/front/src/components/exceptionals/ExceptionalFilters.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Overline } from "@components/shared/Overline";
 import { Button } from "@components/ui/button";
 import { cn } from "@lib/utils";
 import { Plus } from "lucide-react";
@@ -73,7 +74,7 @@ const ExceptionalFilters = ({
 
     {categories.length > 0 && (
       <div className="flex flex-wrap items-center gap-2">
-        <span className="mr-1 text-[11px] font-medium uppercase tracking-[0.1em] text-ink-4">Catégorie</span>
+        <Overline className="mr-1">Catégorie</Overline>
         <button
           type="button"
           onClick={() => onSelectCategory(null)}

--- a/front/src/components/exceptionals/ExceptionalStatsCards.tsx
+++ b/front/src/components/exceptionals/ExceptionalStatsCards.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { computeExceptionalStats } from "@components/exceptionals/helpers/exceptionalStats";
+import { Overline } from "@components/shared/Overline";
 import format from "date-fns/format";
 import { fr } from "date-fns/locale";
 import { useState } from "react";
@@ -22,7 +23,7 @@ const fmt = (v: number) =>
 
 const Kpi = ({ label, value, sub }: { label: string; value: ReactNode; sub: ReactNode }) => (
   <div className="rounded-[14px] border border-line-soft bg-surface-elev px-5 py-[18px]">
-    <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">{label}</div>
+    <Overline className="block">{label}</Overline>
     <div className="num mt-2 text-[26px] font-medium tracking-[-0.02em] text-ink">{value}</div>
     <div className="mt-1 text-xs text-ink-3">{sub}</div>
   </div>

--- a/front/src/components/shared/CardSectionHeader.tsx
+++ b/front/src/components/shared/CardSectionHeader.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@lib/utils";
+
+import type { ReactNode } from "react";
+
+/**
+ * Card heading — the single home of the card-title type ramp. Use it directly
+ * inside cards whose header layout is bespoke (stacked subtitle, inline edit
+ * control…); use `CardSectionHeader` for the common one-row shape.
+ */
+function CardTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <h2
+      className={cn("text-base font-semibold tracking-normal text-ink", className)}
+      {...props}
+    />
+  );
+}
+
+interface CardSectionHeaderProps {
+  title: ReactNode;
+  /** Muted right-aligned meta text. */
+  meta?: ReactNode;
+  /** Right-aligned control (button/form); takes the place of `meta` when both are given. */
+  action?: ReactNode;
+  className?: string;
+}
+
+/** Common card header row: title on the left, muted meta or an action control on the right. */
+function CardSectionHeader({ title, meta, action, className }: CardSectionHeaderProps) {
+  return (
+    <div className={cn("flex items-baseline justify-between gap-3", className)}>
+      <CardTitle>{title}</CardTitle>
+      {action ?? (meta != null ? <span className="text-xs text-ink-4">{meta}</span> : null)}
+    </div>
+  );
+}
+
+export { CardSectionHeader, CardTitle };

--- a/front/src/components/shared/EmptyState.tsx
+++ b/front/src/components/shared/EmptyState.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@lib/utils";
+
+/**
+ * Centered "Aucune… / Pas encore de données" placeholder shown inside a card
+ * when a list is empty. Defaults to `py-6`; pass `className="py-10"` for the
+ * roomier variant.
+ */
+function EmptyState({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("py-6 text-center text-xs text-ink-4", className)}
+      {...props}
+    />
+  );
+}
+
+export { EmptyState };

--- a/front/src/components/shared/Overline.tsx
+++ b/front/src/components/shared/Overline.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@lib/utils";
+
+/**
+ * The uppercase micro-caption recipe, as a class string — the one place it
+ * lives. Use it directly on a semantic element that must not be a `<span>`
+ * (e.g. a `<label htmlFor>` form label); otherwise prefer the `<Overline>`
+ * component below.
+ */
+const overlineClass = "text-2xs font-medium uppercase tracking-caps text-ink-4";
+
+/**
+ * Uppercase micro-caption used as an eyebrow / label. Pass
+ * `className="text-ink-3"` for the brighter tone; `className` is merged last.
+ */
+function Overline({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(overlineClass, className)}
+      {...props}
+    />
+  );
+}
+
+export { Overline, overlineClass };

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { overlineClass } from "@components/shared/Overline";
 import { Button } from "@components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@components/ui/select";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -26,7 +27,7 @@ const buildSchema = (needEmail: boolean, needPassword: boolean, needConfirm: boo
       path: ["confirmPassword"],
     });
 
-const LABEL = "text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4";
+const LABEL = overlineClass;
 const INPUT_BASE =
   "w-full rounded-[6px] border px-[13px] py-[11px] text-[14px] text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] border-[oklch(0.30_0.010_250)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";
 

--- a/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
@@ -1,3 +1,4 @@
+import { Overline } from "@components/shared/Overline";
 import { FALLBACK_COLOR, getRandomHexColor } from "@components/spendings/common/spendingModal/helpers";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@components/ui/command";
 import { Label } from "@components/ui/label";
@@ -175,7 +176,7 @@ const CategoryField = ({
 
       {frequentCategories.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="mr-1 text-2xs font-medium uppercase tracking-caps text-ink-4">Fréquentes</span>
+          <Overline className="mr-1">Fréquentes</Overline>
           {frequentCategories.map((c) => {
             const active = selectedCategory?.name === c.name;
             return (

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import { WEEKLY } from "@components/spendings/config/constants";
 import SpendingsListModal from "@components/spendings/spendingsListModal/SpendingsListModal";
 import { mockCategoryTrend } from "@components/spendings/view/helpers/mockSpending";
@@ -38,10 +39,11 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
 
   return (
     <section className="sp-catrep">
-      <div className="mb-4.5 flex items-baseline justify-between">
-        <h2 className="text-base font-semibold tracking-normal text-ink">Répartition par catégorie</h2>
-        <span className="text-xs text-ink-4">{rangeLabel} · semaine</span>
-      </div>
+      <CardSectionHeader
+        className="mb-4.5"
+        title="Répartition par catégorie"
+        meta={`${rangeLabel} · semaine`}
+      />
 
       <div className="sp-cat-bar mb-4.5">
         {rows.map((r) => (

--- a/front/src/components/spendings/view/SpendingCategoryFilter.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryFilter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Overline } from "@components/shared/Overline";
 import { cn } from "@lib/utils";
 
 export interface FilterCategory {
@@ -61,7 +62,7 @@ const SpendingCategoryFilter = ({ categories, total, selected, onSelect }: Spend
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="mr-1 text-2xs font-medium uppercase tracking-widest text-ink-4">Filtrer</span>
+      <Overline className="mr-1">Filtrer</Overline>
       <Chip
         active={selected === null}
         onClick={() => onSelect(null)}

--- a/front/src/components/spendings/view/SpendingSummary.tsx
+++ b/front/src/components/spendings/view/SpendingSummary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Overline } from "@components/shared/Overline";
 import { AnimatedNumber } from "@lib/dataviz";
 import { cn } from "@lib/utils";
 import format from "date-fns/format";
@@ -49,7 +50,7 @@ interface SpendingSummaryProps {
 
 const Cell = ({ label, value, sub }: { label: string; value: ReactNode; sub: ReactNode }) => (
   <div className="bg-card px-5 py-4">
-    <span className="mb-2 block text-2xs font-medium uppercase tracking-caps text-ink-4">{label}</span>
+    <Overline className="mb-2 block">{label}</Overline>
     <div className="num text-2xl font-medium leading-none tracking-tight text-ink">{value}</div>
     <div className="mt-1.5 text-xs text-ink-3">{sub}</div>
   </div>
@@ -99,7 +100,7 @@ const SpendingSummary = ({
       {/* Hero — full-width banner on mobile, one equal-width cell (1/5) on desktop
           like the other four. Its font stays big; the four keep theirs too. */}
       <div className="col-span-2 bg-card px-5 py-4 min-[760px]:col-span-1">
-        <span className="mb-2 block text-2xs font-medium uppercase tracking-caps text-ink-4">Budget restant</span>
+        <Overline className="mb-2 block">Budget restant</Overline>
         <div
           className={cn(
             "num text-4xl font-medium leading-none tracking-tight min-[1100px]:text-5xl",

--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { euro0 } from "@components/dashboard/format";
+import { CardTitle } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
 import useElementWidth from "@lib/dataviz/useElementWidth";
@@ -67,7 +68,7 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
     >
       <div className="flex flex-wrap items-baseline justify-between gap-4">
         <div>
-          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Dépenses mensuelles par catégorie</h2>
+          <CardTitle>Dépenses mensuelles par catégorie</CardTitle>
           <p className="mt-0.5 text-[12px] text-ink-4">{subtitle}</p>
         </div>
         <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">

--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -3,6 +3,7 @@
 // MOCK — there is no per-transaction / day-of-week aggregation endpoint, so
 // these weekly averages are illustrative sample values.
 
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 
 interface DayRow {
@@ -32,10 +33,10 @@ const StatisticsDayOfWeek = () => (
     as="section"
     className="px-6 py-[22px]"
   >
-    <div className="flex items-baseline justify-between gap-4">
-      <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Dépenses par jour de la semaine</h2>
-      <span className="text-[12px] text-ink-4">moyenne sur 12 mois</span>
-    </div>
+    <CardSectionHeader
+      title="Dépenses par jour de la semaine"
+      meta="moyenne sur 12 mois"
+    />
 
     <div className="mt-[18px] flex flex-col gap-2">
       {ROWS.map((row) => (

--- a/front/src/components/statistics/StatisticsFixedExpenses.tsx
+++ b/front/src/components/statistics/StatisticsFixedExpenses.tsx
@@ -6,7 +6,9 @@
 // have no dedicated charge-day field, so the day-of-month of `dateFrom` is used).
 
 import { euro } from "@components/dashboard/format";
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { Overline } from "@components/shared/Overline";
 import format from "date-fns/format";
 import getDate from "date-fns/getDate";
 import fr from "date-fns/locale/fr";
@@ -45,7 +47,7 @@ const Stat = ({
   const [int, dec] = splitAmount(value);
   return (
     <div className={className}>
-      <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">{label}</div>
+      <Overline className="block">{label}</Overline>
       <div
         className={
           small
@@ -82,10 +84,10 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
       as="section"
       className="px-6 py-[22px]"
     >
-      <div className="flex items-baseline justify-between gap-4">
-        <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Dépenses fixes</h2>
-        <span className="text-[12px] text-ink-4">annualisé · {list.length} lignes récurrentes · sans catégorie</span>
-      </div>
+      <CardSectionHeader
+        title="Dépenses fixes"
+        meta={<>annualisé · {list.length} lignes récurrentes · sans catégorie</>}
+      />
 
       <div className="mt-[18px] flex flex-wrap items-baseline gap-x-10 gap-y-4 border-b border-line-soft pb-5">
         <Stat

--- a/front/src/components/statistics/StatisticsForecast.tsx
+++ b/front/src/components/statistics/StatisticsForecast.tsx
@@ -5,6 +5,7 @@
 
 import { euro, euro0 } from "@components/dashboard/format";
 import GlowCard from "@components/shared/GlowCard";
+import { Overline } from "@components/shared/Overline";
 import { exceptionalTotal } from "@components/statistics/helpers/exceptionalsData";
 import { yearTotal } from "@components/statistics/helpers/statisticsData";
 import { AnimatedNumber, ProgressTrack } from "@lib/dataviz";
@@ -53,9 +54,7 @@ const StatisticsForecast = ({
       className="grid grid-cols-1 items-center gap-6 px-6 py-5 sm:grid-cols-[220px_1fr_240px] sm:gap-8"
     >
       <div className="flex flex-col gap-1">
-        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">
-          Dépensé · 1er janv. → {asOfLabel}
-        </span>
+        <Overline>Dépensé · 1er janv. → {asOfLabel}</Overline>
         <AnimatedNumber
           value={spent}
           decimals={0}
@@ -88,9 +87,7 @@ const StatisticsForecast = ({
       </div>
 
       <div className="flex flex-col items-start gap-1 sm:items-end sm:text-right">
-        <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">
-          Projection fin d&apos;année
-        </span>
+        <Overline>Projection fin d&apos;année</Overline>
         <AnimatedNumber
           value={projection}
           decimals={0}

--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -5,6 +5,7 @@
 // sober-streak and the exceptional-pic count are all derived from that same
 // generated pattern, so the card stays internally consistent.
 
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import getDayOfYear from "date-fns/getDayOfYear";
 
@@ -135,12 +136,14 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
       as="div"
       className="flex flex-col overflow-x-auto px-6 py-[22px]"
     >
-      <div className="flex items-baseline justify-between gap-4">
-        <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Carte de chaleur — quotidienne</h2>
-        <span className="text-[12px] text-ink-4">
-          {year} · {realizedDays} jours réalisés
-        </span>
-      </div>
+      <CardSectionHeader
+        title="Carte de chaleur — quotidienne"
+        meta={
+          <>
+            {year} · {realizedDays} jours réalisés
+          </>
+        }
+      />
 
       <div className="mt-[18px] min-w-[620px]">
         {/* month axis */}

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -2,6 +2,7 @@
 
 import { euro0 } from "@components/dashboard/format";
 import GlowCard from "@components/shared/GlowCard";
+import { Overline } from "@components/shared/Overline";
 import {
   biggestExceptional,
   exceptionalMonthly,
@@ -36,7 +37,7 @@ const cap = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 
 const Card = ({ label, children }: { label: string; children: React.ReactNode }) => (
   <GlowCard className="flex flex-col px-5 py-6">
-    <span className="text-[11px] font-medium uppercase tracking-[0.08em] text-ink-4">{label}</span>
+    <Overline>{label}</Overline>
     {children}
   </GlowCard>
 );

--- a/front/src/components/statistics/StatisticsMonthlyChart.tsx
+++ b/front/src/components/statistics/StatisticsMonthlyChart.tsx
@@ -7,6 +7,7 @@
 // end-of-month projection (an average-forward estimate).
 
 import { euro0 } from "@components/dashboard/format";
+import { CardTitle } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
 import useElementWidth from "@lib/dataviz/useElementWidth";
@@ -120,7 +121,7 @@ const StatisticsMonthlyChart = ({
     >
       <div className="flex flex-wrap items-baseline justify-between gap-4">
         <div>
-          <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Dépenses mensuelles</h2>
+          <CardTitle>Dépenses mensuelles</CardTitle>
           <p className="mt-0.5 text-[12px] text-ink-4">{subtitle}</p>
         </div>
         <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">

--- a/front/src/components/statistics/StatisticsTopCategories.tsx
+++ b/front/src/components/statistics/StatisticsTopCategories.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { euro0 } from "@components/dashboard/format";
+import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
@@ -50,10 +51,10 @@ const Trend = ({ deltaPct }: { deltaPct: number | null }) => {
  *  year-over-year trend (all figures from /statistics). */
 const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesProps) => (
   <GlowCard className="flex flex-col px-6 py-[22px]">
-    <div className="flex items-baseline justify-between gap-4">
-      <h2 className="text-[14px] font-medium tracking-[-0.01em] text-ink">Top catégories</h2>
-      <span className="text-[12px] text-ink-4">tendance vs {compareYear}</span>
-    </div>
+    <CardSectionHeader
+      title="Top catégories"
+      meta={`tendance vs ${compareYear}`}
+    />
 
     <div className="mt-[18px] flex flex-col">
       <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-4">


### PR DESCRIPTION
Extract three shared card-chrome primitives and adopt them across 21 files / 6 areas, killing the copied eyebrow / card-header / empty-state recipes and their tone/spacing/size drift.

- Overline (+ overlineClass): the uppercase micro-caption; the exported class const lets <label htmlFor> field labels share the recipe without losing semantics.
- CardSectionHeader + CardTitle: one home for the card-title type ramp (CardSectionHeader for the common one-row header, bare CardTitle for bespoke stacked headers).
- EmptyState: the centered "Aucune…" placeholder (py-6, py-10 opt-in).

Statistics card titles snap from the arbitrary text-[14px] to the unified text-base font-semibold ramp (now matching the dashboard). Arbitrary text-[11px] tracking-[0.08em] eyebrows map losslessly onto text-2xs tracking-caps.

Left for later: modal DialogTitle (#9 shared shell); the few font-weight-less near-miss labels in statistics (COS-66 page pass).