### PR TITLE
refactor(ui): chart-chrome primitives (COS-87)

### DIFF
--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -3,6 +3,7 @@
 import EditGlyph from "@components/dashboard/EditGlyph";
 import DailySparkline from "@components/dashboard/sections/DailySparkline";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { LegendItem } from "@components/shared/LegendItem";
 import { MoneyAmount } from "@components/shared/MoneyAmount";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useReccurings from "@components/spendings/services/useReccurings";
@@ -169,14 +170,12 @@ const BudgetHero = () => {
             </div>
           </Donut>
           <div className="flex gap-4 text-2xs text-ink-3">
-            <span className="inline-flex items-center gap-1.5">
-              <span className="size-2 rounded-xs bg-accent-d" />
+            <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-d" />}>
               Fixes <span className="num text-ink-2">{euro0(fixed)}</span>
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span className="size-2 rounded-xs bg-accent-strong" />
+            </LegendItem>
+            <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-strong" />}>
               Variables <span className="num text-ink-2">{euro0(variable)}</span>
-            </span>
+            </LegendItem>
           </div>
         </div>
       </div>

--- a/front/src/components/dashboard/sections/ForecastStrip.tsx
+++ b/front/src/components/dashboard/sections/ForecastStrip.tsx
@@ -4,6 +4,7 @@
 // (spent / days-elapsed × days-in-month). Spent + budget are real.
 
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { LegendItem } from "@components/shared/LegendItem";
 import { Overline } from "@components/shared/Overline";
 import useDashboard from "@components/spendings/services/useDashboard";
 import { AnimatedNumber, ProgressTrack } from "@lib/dataviz";
@@ -67,25 +68,31 @@ const ForecastStrip = () => {
         <div className="mt-2 flex items-center justify-between text-2xs text-ink-4">
           <span className="num">0 €</span>
           <span className="flex items-center gap-4 text-ink-3">
-            <span className="inline-flex items-center gap-1.5">
-              <span
-                className="inline-block h-2 w-3 rounded-xs"
-                style={{
-                  background: "linear-gradient(90deg,var(--accent-d),var(--accent-strong))",
-                  opacity: 0.55,
-                }}
-              />
+            <LegendItem
+              swatch={
+                <span
+                  className="inline-block h-2 w-3 rounded-xs"
+                  style={{
+                    background: "var(--bar-fill)",
+                    opacity: 0.55,
+                  }}
+                />
+              }
+            >
               réalisé
-            </span>
-            <span className="inline-flex items-center gap-1.5">
-              <span
-                className="inline-block h-2 w-3 rounded-xs border border-accent-d"
-                style={{
-                  background: "repeating-linear-gradient(45deg,transparent 0 3px,var(--accent-d) 3px 6px)",
-                }}
-              />
+            </LegendItem>
+            <LegendItem
+              swatch={
+                <span
+                  className="inline-block h-2 w-3 rounded-xs border border-accent-d"
+                  style={{
+                    background: "repeating-linear-gradient(45deg,transparent 0 3px,var(--accent-d) 3px 6px)",
+                  }}
+                />
+              }
+            >
               projection
-            </span>
+            </LegendItem>
           </span>
           <span className="num">{euro0(budget)} € budget</span>
         </div>

--- a/front/src/components/shared/LegendItem.tsx
+++ b/front/src/components/shared/LegendItem.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@lib/utils";
+
+import type { ReactNode } from "react";
+
+interface LegendItemProps {
+  /** The colour swatch (solid dot, gradient, hatch…) rendered before the label. */
+  swatch: ReactNode;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * One chart-legend entry: a swatch followed by its label. The swatch itself
+ * stays per-site (fills vary — solid token, gradient, hatch); this only owns the
+ * `inline-flex items-center gap-1.5` row.
+ */
+function LegendItem({ swatch, className, children }: LegendItemProps) {
+  return (
+    <span className={cn("inline-flex items-center gap-1.5", className)}>
+      {swatch}
+      {children}
+    </span>
+  );
+}
+
+export { LegendItem };

--- a/front/src/components/shared/MeterBar.tsx
+++ b/front/src/components/shared/MeterBar.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@lib/utils";
+
+interface MeterBarProps {
+  /** Fill width as a 0–100 percentage. */
+  value: number;
+  /** CSS background of the fill; defaults to the accent `--bar-fill` gradient. */
+  fill?: string;
+  /** Track height in px. */
+  height: number;
+  /** Fill opacity (the bars sit slightly translucent over the track). */
+  opacity?: number;
+  /** Extra classes for the track. */
+  className?: string;
+}
+
+/**
+ * Horizontal meter/progress bar: a rounded `bg-surface-hi` track with a
+ * percentage-width fill. Single-fill only — multi-segment bars stay bespoke.
+ */
+function MeterBar({ value, fill = "var(--bar-fill)", height, opacity = 1, className }: MeterBarProps) {
+  return (
+    <div
+      className={cn("overflow-hidden rounded-[4px] bg-surface-hi", className)}
+      style={{ height }}
+    >
+      <span
+        className="block h-full rounded-[4px]"
+        style={{ width: `${value}%`, background: fill, opacity }}
+      />
+    </div>
+  );
+}
+
+export { MeterBar };

--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -2,6 +2,7 @@
 
 import { CardTitle } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { LegendItem } from "@components/shared/LegendItem";
 import { MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
 import useElementWidth from "@lib/dataviz/useElementWidth";
 import { euro0 } from "@lib/format";
@@ -73,16 +74,18 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
         </div>
         <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">
           {series.map((s) => (
-            <span
+            <LegendItem
               key={s.name}
-              className="inline-flex items-center gap-1.5 capitalize"
+              className="capitalize"
+              swatch={
+                <i
+                  className="inline-block size-2.5 rounded-xs"
+                  style={{ background: s.color }}
+                />
+              }
             >
-              <i
-                className="inline-block size-2.5 rounded-[2px]"
-                style={{ background: s.color }}
-              />
               {s.name}
-            </span>
+            </LegendItem>
           ))}
         </div>
       </div>

--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -5,6 +5,7 @@
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { MeterBar } from "@components/shared/MeterBar";
 
 interface DayRow {
   day: string;
@@ -24,7 +25,7 @@ const ROWS: DayRow[] = [
   { day: "Dimanche", width: 78, amount: "71,20 €", transactions: "4,4 transactions/j", weekend: true },
 ];
 
-const WEEKDAY_FILL = "linear-gradient(90deg, var(--accent-d), var(--accent-strong))";
+const WEEKDAY_FILL = "var(--bar-fill)";
 const WEEKEND_FILL = "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.16 25))";
 
 /** "Dépenses par jour de la semaine" — weekly spending rhythm (MOCK). */
@@ -45,16 +46,12 @@ const StatisticsDayOfWeek = () => (
           className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-[13px]"
         >
           <span className={row.weekend ? "text-ink" : "text-ink-2"}>{row.day}</span>
-          <div className="h-[22px] overflow-hidden rounded-[4px] bg-surface-hi">
-            <span
-              className="block h-full rounded-[4px]"
-              style={{
-                width: `${row.width}%`,
-                background: row.weekend ? WEEKEND_FILL : WEEKDAY_FILL,
-                opacity: 0.85,
-              }}
-            />
-          </div>
+          <MeterBar
+            value={row.width}
+            fill={row.weekend ? WEEKEND_FILL : WEEKDAY_FILL}
+            height={22}
+            opacity={0.85}
+          />
           <span className="num text-right font-medium text-ink">
             {row.amount}
             <small className="block text-[10.5px] font-normal text-ink-4">{row.transactions}</small>

--- a/front/src/components/statistics/StatisticsFixedExpenses.tsx
+++ b/front/src/components/statistics/StatisticsFixedExpenses.tsx
@@ -7,6 +7,7 @@
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { MeterBar } from "@components/shared/MeterBar";
 import { Overline } from "@components/shared/Overline";
 import { euro, splitAmount } from "@lib/format";
 import format from "date-fns/format";
@@ -117,16 +118,11 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
                   {euro(annual)} €<small className="ml-1.5 text-[11px] font-normal text-ink-4">{share}%</small>
                 </span>
               </div>
-              <div className="h-[7px] overflow-hidden rounded-[4px] bg-surface-hi">
-                <span
-                  className="block h-full rounded-[4px]"
-                  style={{
-                    width: `${barWidth}%`,
-                    background: "linear-gradient(90deg, var(--accent-d), var(--accent-strong))",
-                    opacity: 0.9,
-                  }}
-                />
-              </div>
+              <MeterBar
+                value={barWidth}
+                height={7}
+                opacity={0.9}
+              />
             </div>
           );
         })}

--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -7,6 +7,7 @@
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { LegendItem } from "@components/shared/LegendItem";
 import getDayOfYear from "date-fns/getDayOfYear";
 
 interface StatisticsHeatmapProps {
@@ -205,13 +206,16 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
           </span>
           <span>210 €/j</span>
           <span className="flex-1" />
-          <span className="flex items-center gap-1.5">
-            <span
-              className="size-2.5 rounded-[2px]"
-              style={{ background: "var(--exc)" }}
-            />
+          <LegendItem
+            swatch={
+              <span
+                className="size-2.5 rounded-xs"
+                style={{ background: "var(--exc)" }}
+              />
+            }
+          >
             Pic exceptionnel
-          </span>
+          </LegendItem>
         </div>
       </div>
 

--- a/front/src/components/statistics/StatisticsMonthlyChart.tsx
+++ b/front/src/components/statistics/StatisticsMonthlyChart.tsx
@@ -8,6 +8,7 @@
 
 import { CardTitle } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { LegendItem } from "@components/shared/LegendItem";
 import { MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
 import useElementWidth from "@lib/dataviz/useElementWidth";
 import { euro0 } from "@lib/format";
@@ -125,29 +126,25 @@ const StatisticsMonthlyChart = ({
           <p className="mt-0.5 text-[12px] text-ink-4">{subtitle}</p>
         </div>
         <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">
-          <span className="inline-flex items-center gap-1.5">
-            <i className="inline-block size-2.5 rounded-[2px] bg-accent-strong" />
-            {year}
-          </span>
+          <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-accent-strong" />}>{year}</LegendItem>
           {showExceptionals && (
-            <span className="inline-flex items-center gap-1.5">
-              <i className="inline-block size-2.5 rounded-[2px] bg-exc" />
+            <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-exc" />}>
               Achat exceptionnel
-            </span>
+            </LegendItem>
           )}
           {compareEnabled && (
-            <span className="inline-flex items-center gap-1.5">
-              <DashSwatch
-                color="var(--accent-strong)"
-                opacity={0.85}
-              />
+            <LegendItem
+              swatch={
+                <DashSwatch
+                  color="var(--accent-strong)"
+                  opacity={0.85}
+                />
+              }
+            >
               {compareYear}
-            </span>
+            </LegendItem>
           )}
-          <span className="inline-flex items-center gap-1.5">
-            <DashSwatch color="var(--ink-3)" />
-            Budget mensuel
-          </span>
+          <LegendItem swatch={<DashSwatch color="var(--ink-3)" />}>Budget mensuel</LegendItem>
         </div>
       </div>
 

--- a/front/src/lib/dataviz/ProgressTrack.tsx
+++ b/front/src/lib/dataviz/ProgressTrack.tsx
@@ -100,7 +100,7 @@ const ProgressTrack = ({
           className="absolute inset-y-0 left-0"
           style={{
             width: asPct(fBudget),
-            background: gradient ? "linear-gradient(90deg, var(--accent-d), var(--accent-strong))" : color,
+            background: gradient ? "var(--bar-fill)" : color,
             opacity: gradient ? 0.45 : 0.92,
           }}
         />

--- a/front/styles/tokens/colors.css
+++ b/front/styles/tokens/colors.css
@@ -60,6 +60,8 @@
   --accent-strong: oklch(0.84 0.14 148);
   --accent-d:      oklch(0.55 0.10 148);
   --accent-bg:     oklch(0.84 0.14 148 / 0.10);
+  /* Meter/progress bar fill — the accent gradient used by bars & legends */
+  --bar-fill:      linear-gradient(90deg, var(--accent-d), var(--accent-strong));
   --neg:           oklch(0.72 0.17 25);
   --neg-bg:        oklch(0.72 0.17 25 / 0.12);
 


### PR DESCRIPTION
The chart half of the value-display work.

- --bar-fill token: the accent bar gradient, was inline in 4 places (ProgressTrack, StatisticsDayOfWeek, StatisticsFixedExpenses, ForecastStrip). Now referenced via var(--bar-fill).
- MeterBar: rounded track + percentage-width fill; adopted at the two single-fill statistics bars (fill defaults to --bar-fill).
- LegendItem: the inline-flex legend row + swatch slot; adopted at 10 legends across statistics charts, BudgetHero and ForecastStrip.

Pure structure extraction — render unchanged. Left bespoke: the multi-segment KPI / heatmap-distribution bars, the projection hatch swatch, heatmap scale-cells and the flat WeeklyCeiling legend.