### PR TITLE
refactor(ui): category primitives (COS-89)

### DIFF
--- a/front/src/components/categories/CategoryColorDot.tsx
+++ b/front/src/components/categories/CategoryColorDot.tsx
@@ -1,0 +1,21 @@
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+import { cn } from "@lib/utils";
+
+interface CategoryColorDotProps {
+  /** Category colour (hex); falls back to the neutral grey when absent. */
+  color?: string | null;
+  /** Override the default `size-2` square (e.g. `h-5 w-1` bar, `size-2.5`). */
+  className?: string;
+}
+
+/** Small coloured swatch of a category's colour. */
+function CategoryColorDot({ color, className }: CategoryColorDotProps) {
+  return (
+    <span
+      className={cn("size-2 shrink-0 rounded-xs", className)}
+      style={{ background: color || CATEGORY_FALLBACK }}
+    />
+  );
+}
+
+export { CategoryColorDot };

--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CategoryColorDot } from "@components/categories/CategoryColorDot";
 import CategoryFormModal from "@components/categories/CategoryFormModal";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { IconButton } from "@components/shared/IconButton";
@@ -30,9 +31,9 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
     <>
       <div className="pfa-card pfa-card-hover flex flex-col gap-2.5 rounded-[10px] px-[15px] pb-3 pt-[13px]">
         <div className="flex items-center gap-2.5">
-          <span
-            className="h-5 w-1 flex-none rounded-[2px]"
-            style={{ background: category.color || "#94a3b8" }}
+          <CategoryColorDot
+            color={category.color}
+            className="h-5 w-1 flex-none"
           />
           <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium capitalize text-ink">{category.name}</span>
           <span className="flex flex-none gap-1.5">

--- a/front/src/components/categories/CategoryTag.tsx
+++ b/front/src/components/categories/CategoryTag.tsx
@@ -1,0 +1,29 @@
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+import { cn } from "@lib/utils";
+
+import type { ReactNode } from "react";
+
+interface CategoryTagProps {
+  /** Category colour (hex); falls back to the neutral grey when absent. */
+  color?: string | null;
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * Coloured category pill — the category colour tints the text, a translucent
+ * background and a border (hex + alpha suffix). Falls back to the neutral grey.
+ */
+function CategoryTag({ color, className, children }: CategoryTagProps) {
+  const accent = color || CATEGORY_FALLBACK;
+  return (
+    <span
+      className={cn("shrink-0 rounded px-1.5 py-0.5 text-2xs font-semibold uppercase tracking-wide", className)}
+      style={{ color: accent, backgroundColor: `${accent}22`, border: `1px solid ${accent}44` }}
+    >
+      {children}
+    </span>
+  );
+}
+
+export { CategoryTag };

--- a/front/src/components/categories/helpers/categoryColors.ts
+++ b/front/src/components/categories/helpers/categoryColors.ts
@@ -5,6 +5,9 @@
  * normalize any CSS color (oklch/hex) to hex for the native color input.
  */
 
+/** Neutral grey used when a category has no colour (or a colour fails to resolve). */
+export const CATEGORY_FALLBACK = "#94a3b8";
+
 export const PALETTE_HUES = [5, 25, 60, 80, 110, 140, 175, 210, 250, 290, 320, 350] as const;
 
 export const catColorOklch = (hue: number): string => `oklch(0.80 0.09 ${hue})`;
@@ -28,7 +31,7 @@ const getCtx = (): CanvasRenderingContext2D | null => {
 export const cssColorToHex = (css: string): string => {
   if (/^#[0-9a-fA-F]{6}$/.test(css)) return css.toLowerCase();
   const ctx = getCtx();
-  if (!ctx) return "#94a3b8";
+  if (!ctx) return CATEGORY_FALLBACK;
   ctx.fillStyle = "#000000";
   ctx.fillStyle = css;
   ctx.fillRect(0, 0, 1, 1);

--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { CategoryColorDot } from "@components/categories/CategoryColorDot";
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import { EmptyState } from "@components/shared/EmptyState";
@@ -16,7 +18,7 @@ import { useMemo, useState } from "react";
 import type { BarHover, CategoryTrendData } from "@lib/dataviz";
 import type { ChartsCategory } from "@src/schemas/stats";
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 // MOCK — the month-over-month trend needs the previous month's per-category
 // totals (not fetched here). Deterministic placeholder derived from the label.
@@ -93,10 +95,7 @@ const CategoryBreakdown = () => {
                 onClick={() => setSelected(row.category)}
                 className="grid cursor-pointer grid-cols-[10px_minmax(0,1fr)_auto] items-center gap-3 border-b border-line-soft px-1 py-3 text-left text-sm transition-colors last:border-b-0 hover:bg-surface-hi sm:grid-cols-[10px_minmax(0,1fr)_58px_84px_58px]"
               >
-                <span
-                  className="size-2 rounded-xs"
-                  style={{ background: row.color }}
-                />
+                <CategoryColorDot color={row.color} />
                 <span className="flex items-center gap-2 truncate">
                   <span className="truncate capitalize text-ink">{row.name}</span>
                   {row.count > 0 && (

--- a/front/src/components/exceptionals/ExceptionalItem.tsx
+++ b/front/src/components/exceptionals/ExceptionalItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CategoryTag } from "@components/categories/CategoryTag";
 import useExceptionals from "@components/exceptionals/services/useExceptionals";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { IconButton } from "@components/shared/IconButton";
@@ -12,8 +13,6 @@ import { useState } from "react";
 
 import type { ExceptionalItem as ExceptionalItemType } from "@src/schemas/exceptionals";
 
-const FALLBACK_COLOR = "#94a3b8";
-
 interface ExceptionalItemProps {
   item: ExceptionalItemType;
   onEdit: (item: ExceptionalItemType) => void;
@@ -24,7 +23,6 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
   const { deleteExceptional } = useExceptionals();
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
-  const accent = item.categoryColor ?? FALLBACK_COLOR;
   const dateLabel = format(parseISO(item.date), "dd MMM", { locale: fr });
   const amount = euro(item.amount);
   const budgetMonths = monthlyAverage > 0 ? (Number(item.amount) / monthlyAverage).toFixed(1) : null;
@@ -47,18 +45,7 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
             >
               {item.label}
             </span>
-            {item.categoryName && (
-              <span
-                className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
-                style={{
-                  color: accent,
-                  backgroundColor: `${accent}22`,
-                  border: `1px solid ${accent}44`,
-                }}
-              >
-                {item.categoryName}
-              </span>
-            )}
+            {item.categoryName && <CategoryTag color={item.categoryColor}>{item.categoryName}</CategoryTag>}
           </div>
           {item.description && (
             <span

--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@auth/context/AuthContext";
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import useExceptionals from "@components/exceptionals/services/useExceptionals";
 import { Button } from "@components/ui/button";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@components/ui/command";
@@ -39,7 +40,7 @@ interface ExceptionalModalProps {
   existingCategories: CategoryOption[];
 }
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 const getRandomHexColor = () => {
   const r = Math.floor(Math.random() * 255)

--- a/front/src/components/exceptionals/Exceptionals.tsx
+++ b/front/src/components/exceptionals/Exceptionals.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import Spinner from "@components/common/Spinner";
 import ExceptionalFilters from "@components/exceptionals/ExceptionalFilters";
 import ExceptionalModal from "@components/exceptionals/ExceptionalModal";
@@ -35,7 +36,7 @@ const Exceptionals = () => {
     const seen = new Map<string, string>();
     for (const item of exceptionals) {
       if (item.categoryName && !seen.has(item.categoryName)) {
-        seen.set(item.categoryName, item.categoryColor ?? "#94a3b8");
+        seen.set(item.categoryName, item.categoryColor ?? CATEGORY_FALLBACK);
       }
     }
     return Array.from(seen.entries()).map(([name, color]) => ({ name, color }));

--- a/front/src/components/spendings/common/spendingModal/helpers.ts
+++ b/front/src/components/spendings/common/spendingModal/helpers.ts
@@ -1,4 +1,6 @@
-export const FALLBACK_COLOR = "#94a3b8";
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+
+export const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 export const humanSize = (bytes: number) => {
   if (bytes < 1024) return `${bytes} o`;

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useAuth } from "@auth/context/AuthContext";
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import Spinner from "@components/common/Spinner";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { QUERY_KEYS } from "@components/spendings/config/constants";
@@ -28,7 +29,7 @@ interface InvoiceModalProps {
 }
 
 const FILE_SIZE_LIMIT = 32_097_152;
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: InvoiceModalProps) => {
   const [open, setOpen] = useState(true);

--- a/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
+++ b/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { DATE_FORMAT, MONTHLY } from "@components/spendings/config/constants";
 import texts from "@components/spendings/config/text";
@@ -24,7 +25,7 @@ interface SpendingsListModalProps {
   total: number;
 }
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 const groupByDate = (spendings: SpendingItem[]): Record<string, SpendingItem[]> => {
   return spendings.reduce((acc: Record<string, SpendingItem[]>, curr) => {

--- a/front/src/components/spendings/view/SpendingDayCard.tsx
+++ b/front/src/components/spendings/view/SpendingDayCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import useSpendingDayItem from "@components/spendings/spendingDayItem/spendingItem/helpers/useSpendingDayItem";
 import useDaySort from "@components/spendings/view/helpers/useDaySort";
@@ -15,7 +16,7 @@ import type { MonthRange } from "@components/spendings/interfaces/spendingDashbo
 import type { SpendingItem, SpendingListItem } from "@components/spendings/types";
 import type { DaySortField } from "@components/spendings/view/helpers/useDaySort";
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 const UNCATEGORIZED_KEY = "none";
 
 interface DayCategory {

--- a/front/src/components/spendings/view/SpendingTxRow.tsx
+++ b/front/src/components/spendings/view/SpendingTxRow.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import { IconButton } from "@components/shared/IconButton";
 import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import useSpendings from "@components/spendings/services/useSpendings";
@@ -9,7 +10,7 @@ import { useState } from "react";
 
 import type { SpendingItem } from "@components/spendings/types";
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 
 interface SpendingTxRowProps {
   spending: SpendingItem;

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import dailyRemainingBudget from "@components/spendings/helpers/dailyBudget";
@@ -26,7 +27,7 @@ import type { MonthRange } from "@components/spendings/interfaces/spendingDashbo
 import type { SpendingDayGroup } from "@components/spendings/types";
 import type { FilterCategory } from "@components/spendings/view/SpendingCategoryFilter";
 
-const FALLBACK_COLOR = "#94a3b8";
+const FALLBACK_COLOR = CATEGORY_FALLBACK;
 const UNCATEGORIZED_KEY = "none";
 
 interface CategoryAggregate {

--- a/front/src/components/statistics/helpers/statisticsData.ts
+++ b/front/src/components/statistics/helpers/statisticsData.ts
@@ -1,3 +1,5 @@
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+
 import type { StatisticsResponse } from "@src/schemas/stats";
 
 /** French month abbreviations, matching the labels the /statistics API returns. */
@@ -88,7 +90,7 @@ export const perCategoryTotals = (
     });
   });
   return Array.from(totals.entries())
-    .map(([name, value]) => ({ name, value, color: colors[name] ?? "#94a3b8" }))
+    .map(([name, value]) => ({ name, value, color: colors[name] ?? CATEGORY_FALLBACK }))
     .sort((a, b) => b.value - a.value);
 };
 


### PR DESCRIPTION
- CATEGORY_FALLBACK: the neutral grey category fallback (#94a3b8) was hardcoded in 12 live files; now a single shared const in categoryColors.ts. Dead files (SpendingItem/SpendingDayItem, COS-84) and lib/dataviz/adapters.ts (avoid a lib->components import) left as-is.
- CategoryTag: the coloured category pill; adopted in ExceptionalItem.
- CategoryColorDot: the category colour swatch; adopted in CategoryItem and CategoryBreakdown.

Structure-only; render unchanged (bar the Exceptionnels pill snapping text-[10px] -> text-2xs). The differently-styled tags elsewhere were left as-is (unifying them is a separate visual decision).