### PR TITLE
refactor(ui): Button muted + FilterChip (COS-90)

### DIFF
--- a/front/src/components/exceptionals/ExceptionalFilters.tsx
+++ b/front/src/components/exceptionals/ExceptionalFilters.tsx
@@ -1,8 +1,8 @@
 "use client";
 
+import { FilterChip } from "@components/shared/FilterChip";
 import { Overline } from "@components/shared/Overline";
 import { Button } from "@components/ui/button";
-import { cn } from "@lib/utils";
 import { Plus } from "lucide-react";
 
 interface CategoryChip {
@@ -21,18 +21,14 @@ interface ExceptionalFiltersProps {
 }
 
 const YearChip = ({ active, label, onClick }: { active: boolean; label: string; onClick: () => void }) => (
-  <button
-    type="button"
+  <FilterChip
+    active={active}
     onClick={onClick}
-    className={cn(
-      "inline-flex items-center rounded-full border px-3 py-1 text-xs transition-colors",
-      active
-        ? "border-exc/60 bg-exc/10 text-exc"
-        : "border-line bg-surface-hi text-ink-2 hover:bg-surface-hover hover:text-ink",
-    )}
+    accent="exc"
+    className="rounded-full px-3"
   >
     {label}
-  </button>
+  </FilterChip>
 );
 
 const ExceptionalFilters = ({
@@ -75,45 +71,30 @@ const ExceptionalFilters = ({
     {categories.length > 0 && (
       <div className="flex flex-wrap items-center gap-2">
         <Overline className="mr-1">Catégorie</Overline>
-        <button
-          type="button"
+        <FilterChip
+          active={activeCategory === null}
           onClick={() => onSelectCategory(null)}
-          className={cn(
-            "inline-flex items-center rounded-full border px-2.5 py-1 text-xs transition-colors",
-            activeCategory === null
-              ? "border-exc/60 bg-exc/10 text-exc"
-              : "border-line bg-surface-hi text-ink-2 hover:bg-surface-hover hover:text-ink",
-          )}
+          accent="exc"
+          className="rounded-full px-2.5"
         >
           Toutes
-        </button>
+        </FilterChip>
         {categories.map((cat) => {
           const active = activeCategory === cat.name;
           return (
-            <button
+            <FilterChip
               key={cat.name}
-              type="button"
+              active={active}
+              accentColor={cat.color}
               onClick={() => onSelectCategory(active ? null : cat.name)}
-              className={cn(
-                "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs capitalize transition-colors",
-                active ? "text-ink" : "border-line bg-surface-hi text-ink-2 hover:bg-surface-hover hover:text-ink",
-              )}
-              style={
-                active
-                  ? {
-                      borderColor: cat.color,
-                      backgroundColor: `${cat.color}1f`,
-                      color: cat.color,
-                    }
-                  : undefined
-              }
+              className="gap-1.5 rounded-full px-2.5 capitalize"
             >
               <span
                 className="size-[7px] shrink-0 rounded-[2px]"
                 style={{ backgroundColor: cat.color }}
               />
               {cat.name}
-            </button>
+            </FilterChip>
           );
         })}
       </div>

--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -325,9 +325,8 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
           <DialogFooter className="gap-2.5 border-t border-line-soft pt-4 sm:gap-2.5">
             <Button
               type="button"
-              variant="outline"
+              variant="muted"
               onClick={closeModal}
-              className="border-line bg-background text-ink-2 hover:bg-surface-hi"
             >
               Annuler
             </Button>

--- a/front/src/components/shared/ConfirmDeleteDialog.tsx
+++ b/front/src/components/shared/ConfirmDeleteDialog.tsx
@@ -55,9 +55,7 @@ const ConfirmDeleteDialog = ({
         <AlertDialogDescription className="text-ink-3">{description}</AlertDialogDescription>
       </AlertDialogHeader>
       <AlertDialogFooter>
-        <AlertDialogCancel className="border-line bg-background text-ink-2 hover:bg-surface-hi">
-          {cancelLabel}
-        </AlertDialogCancel>
+        <AlertDialogCancel>{cancelLabel}</AlertDialogCancel>
         <AlertDialogAction
           onClick={onConfirm}
           className="bg-danger-solid text-on-danger hover:bg-danger-solid hover:brightness-110"

--- a/front/src/components/shared/FilterChip.tsx
+++ b/front/src/components/shared/FilterChip.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@lib/utils";
+
+type FilterChipAccent = "accent" | "exc";
+
+interface FilterChipProps extends Omit<React.ComponentProps<"button">, "type"> {
+  active: boolean;
+  /** Active-state accent when no dynamic colour is given. Defaults to the green accent. */
+  accent?: FilterChipAccent;
+  /** Per-item colour (e.g. a category colour) that tints the active state; overrides `accent`. */
+  accentColor?: string;
+}
+
+const ACTIVE_ACCENT: Record<FilterChipAccent, string> = {
+  accent: "border-accent-d bg-accent-bg text-accent-strong",
+  exc: "border-exc/60 bg-exc/10 text-exc",
+};
+
+const INACTIVE = "border-line bg-surface-hi text-ink-2 hover:bg-surface-hover hover:text-ink";
+
+/**
+ * Toggle filter chip shared by the filter bars. The inactive recipe is identical
+ * everywhere; the active state is tinted either by a semantic `accent` (green /
+ * exceptionnels orange) or by a dynamic `accentColor` (e.g. a category colour).
+ * Shape/spacing (`rounded-*`, `px-*`, `gap-*`, `capitalize`) is passed via `className`.
+ */
+function FilterChip({ active, accent = "accent", accentColor, className, children, ...props }: FilterChipProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center border py-1 text-xs transition-colors",
+        active ? (accentColor ? "text-ink" : ACTIVE_ACCENT[accent]) : INACTIVE,
+        className,
+      )}
+      {...props}
+      style={
+        active && accentColor
+          ? { borderColor: accentColor, backgroundColor: `${accentColor}1f`, color: accentColor }
+          : undefined
+      }
+    >
+      {children}
+    </button>
+  );
+}
+
+export { FilterChip };

--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -262,7 +262,7 @@ const SpendingModal = ({
             // discard the entry the user is mid-creating.
             <Button
               type="button"
-              variant="outline"
+              variant="muted"
               onClick={() => {
                 if (!user) {
                   console.error("User is not available");
@@ -281,7 +281,6 @@ const SpendingModal = ({
                   },
                 });
               }}
-              className="border-line bg-background text-ink-2 hover:bg-surface-hi"
             >
               <Copy className="size-4" />
               Copier les dépenses fixes du mois précédent
@@ -291,9 +290,8 @@ const SpendingModal = ({
           <DialogFooter className="gap-2.5 border-t border-line-soft pt-4 sm:gap-2.5">
             <Button
               type="button"
-              variant="outline"
+              variant="muted"
               onClick={closeModal}
-              className="border-line bg-background text-ink-2 hover:bg-surface-hi"
             >
               Annuler
             </Button>

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -293,10 +293,10 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
               <div className="flex gap-2.5">
                 <Button
                   type="button"
-                  variant="outline"
+                  variant="muted"
                   size="lg"
                   onClick={clearPending}
-                  className="flex-1 border-line bg-background text-base text-ink-2 hover:bg-surface-hi"
+                  className="flex-1 text-base"
                 >
                   Annuler
                 </Button>

--- a/front/src/components/spendings/view/SpendingCategoryFilter.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryFilter.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { FilterChip } from "@components/shared/FilterChip";
 import { Overline } from "@components/shared/Overline";
 import { cn } from "@lib/utils";
 
@@ -30,15 +31,10 @@ const Chip = ({
   label: string;
   count: number;
 }) => (
-  <button
-    type="button"
+  <FilterChip
+    active={active}
     onClick={onClick}
-    className={cn(
-      "inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs capitalize transition-colors",
-      active
-        ? "border-accent-d bg-accent-bg text-accent-strong"
-        : "border-line bg-surface-hi text-ink-2 hover:bg-surface-hover hover:text-ink",
-    )}
+    className="gap-1.5 rounded-lg px-2.5 capitalize"
   >
     {color && (
       <span
@@ -48,7 +44,7 @@ const Chip = ({
     )}
     {label}
     <span className={cn("num text-2xs", active ? "text-accent-strong/80" : "text-ink-4")}>{count}</span>
-  </button>
+  </FilterChip>
 );
 
 /**

--- a/front/src/components/ui/alert-dialog.tsx
+++ b/front/src/components/ui/alert-dialog.tsx
@@ -115,7 +115,7 @@ function AlertDialogAction({ className, ...props }: React.ComponentProps<typeof 
 function AlertDialogCancel({ className, ...props }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: "outline" }), className)}
+      className={cn(buttonVariants({ variant: "muted" }), className)}
       {...props}
     />
   );

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -14,6 +14,10 @@ const buttonVariants = cva(
         outline:
           "border bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        // Secondary / cancel button. Encapsulates the muted look the modals hand-rolled
+        // as `variant="outline"` + a repeated override (which in dark mode rendered the
+        // outline's translucent `input` fill, i.e. `line/30`). Reproduced faithfully here.
+        muted: "border border-line bg-line/30 text-ink-2 hover:bg-line/50 hover:text-ink",
         ghost: "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
         accent:


### PR DESCRIPTION
Controls kit for the design-system retrofit (#7a).

- Button: add `muted` variant for secondary/cancel buttons, replacing the `variant="outline"` + repeated `border-line bg-background text-ink-2 hover:bg-surface-hi` override. The variant reproduces the look the old classes actually rendered in dark mode (the outline `dark:bg-input/30` leftover won over `bg-background`, i.e. a translucent `line/30`). Adopted in SpendingModal (x2), ExceptionalModal, InvoiceModal, and ConfirmDeleteDialog via AlertDialogCancel's default.
- FilterChip: shared toggle chip. Identical inactive recipe everywhere; active state tinted by a semantic accent (green / exc orange) or a dynamic per-item colour. Adopted in SpendingCategoryFilter and ExceptionalFilters.

Net -24 lines. StatisticsFilters removable pills and ExportButton left as-is (distinct patterns). CategoryFormModal's ghost cancel unchanged.