### PR TITLE
refactor(ui): elevation scale (COS-92)

### DIFF
--- a/front/src/components/auth/AuthCard.tsx
+++ b/front/src/components/auth/AuthCard.tsx
@@ -14,7 +14,7 @@ export default function AuthCard({ children, className }: { children: React.Reac
         className="pointer-events-none absolute -inset-x-[90px] -inset-y-[70px] -z-10 blur-[20px] [background:radial-gradient(60%_55%_at_50%_40%,oklch(0.55_0.13_185/0.20)_0%,transparent_70%),radial-gradient(45%_45%_at_60%_70%,oklch(0.60_0.14_150/0.14)_0%,transparent_70%)]"
       />
       {/* gradient border */}
-      <div className="rounded-[26px] p-px shadow-[0_40px_100px_oklch(0_0_0/0.60),0_0_80px_oklch(0.60_0.13_180/0.10)] [background:linear-gradient(165deg,oklch(0.75_0.10_200/0.55)_0%,oklch(0.40_0.03_250/0.18)_28%,oklch(0.30_0.02_250/0.14)_62%,oklch(0.72_0.13_155/0.45)_100%)]">
+      <div className="rounded-[26px] p-px shadow-hero [background:linear-gradient(165deg,oklch(0.75_0.10_200/0.55)_0%,oklch(0.40_0.03_250/0.18)_28%,oklch(0.30_0.02_250/0.14)_62%,oklch(0.72_0.13_155/0.45)_100%)]">
         {/* glass */}
         <div
           className={cn(

--- a/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
+++ b/front/src/components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal.tsx
@@ -22,7 +22,7 @@ const InvoiceImageModal = ({ image, closeImage: closeImageProp }: InvoiceImageMo
     >
       <DialogContent className="w-auto max-w-none sm:max-w-none border-0 bg-transparent p-0 shadow-none">
         <DialogTitle className="sr-only">Facture — aperçu</DialogTitle>
-        <div className="overflow-hidden rounded-xl border border-elec/30 shadow-[0_24px_80px_oklch(0_0_0/0.6)] leading-[0]">
+        <div className="overflow-hidden rounded-xl border border-elec/30 shadow-lightbox leading-[0]">
           <Image
             src={image}
             alt="facture"

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -211,7 +211,7 @@ const SpendingView = () => {
         type="button"
         variant="primary"
         onClick={() => setIsQuickAddOpen(true)}
-        className="fixed bottom-6 right-6 z-30 shadow-[0_10px_30px_oklch(0_0_0/0.35)]"
+        className="fixed bottom-6 right-6 z-30 shadow-float"
       >
         <Plus className="size-4" />
         Nouvelle dépense

--- a/front/src/components/statistics/StatisticsFilters.tsx
+++ b/front/src/components/statistics/StatisticsFilters.tsx
@@ -26,7 +26,7 @@ interface StatisticsFiltersProps {
   maxCategories: number;
 }
 
-const popContent = "rounded-[10px] border border-line bg-surface-elev p-1.5 shadow-[0_20px_48px_oklch(0_0_0/0.55)]";
+const popContent = "rounded-[10px] border border-line bg-surface-elev p-1.5 shadow-popover";
 
 const YearMenu = ({
   years,

--- a/front/src/components/ui/button.tsx
+++ b/front/src/components/ui/button.tsx
@@ -24,7 +24,7 @@ const buttonVariants = cva(
           "bg-gradient-to-br from-cyan-600 to-blue-600 text-white shadow-lg shadow-cyan-500/20 hover:from-cyan-500 hover:to-blue-500",
         cyan: "bg-cyan-600 text-white hover:bg-cyan-700 shadow-lg shadow-cyan-500/20",
         primary:
-          "border-0 font-semibold text-[oklch(0.15_0.02_180)] shadow-[0_4px_18px_oklch(0.75_0.14_165/0.25),inset_0_1px_0_oklch(1_0_0/0.30)] [background:linear-gradient(100deg,oklch(0.84_0.14_148)_0%,oklch(0.82_0.13_175)_55%,oklch(0.80_0.12_210)_100%)] hover:brightness-[1.07] active:translate-y-px",
+          "border-0 font-semibold text-[oklch(0.15_0.02_180)] shadow-primary [background:linear-gradient(100deg,oklch(0.84_0.14_148)_0%,oklch(0.82_0.13_175)_55%,oklch(0.80_0.12_210)_100%)] hover:brightness-[1.07] active:translate-y-px",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",

--- a/front/styles/components/category-detail.css
+++ b/front/styles/components/category-detail.css
@@ -49,9 +49,7 @@
         oklch(0.68 0.11 160 / 0.28) 100%
       )
       border-box;
-  box-shadow:
-    0 34px 90px oklch(0 0 0 / 0.62),
-    inset 0 1px 0 oklch(1 0 0 / 0.05);
+  box-shadow: var(--shadow-modal);
   animation: catdRise 0.2s cubic-bezier(0.2, 0.7, 0.3, 1);
 }
 @keyframes catdRise {

--- a/front/styles/components/chrome.css
+++ b/front/styles/components/chrome.css
@@ -21,9 +21,7 @@
         oklch(0.68 0.11 160 / 0.34) 100%
       )
       border-box;
-  box-shadow:
-    0 14px 36px oklch(0 0 0 / 0.32),
-    inset 0 1px 0 oklch(1 0 0 / 0.06);
+  box-shadow: var(--shadow-header);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
 }
@@ -42,9 +40,7 @@
         oklch(0.68 0.11 160 / 0.28) 100%
       )
       border-box;
-  box-shadow:
-    0 12px 32px oklch(0 0 0 / 0.26),
-    inset 0 1px 0 oklch(1 0 0 / 0.045);
+  box-shadow: var(--shadow-card);
 }
 
 /* Stronger glow + lift on hover (category cards) */
@@ -67,9 +63,7 @@
         oklch(0.72 0.14 160 / 0.6) 100%
       )
       border-box;
-  box-shadow:
-    0 18px 42px oklch(0 0 0 / 0.36),
-    inset 0 1px 0 oklch(1 0 0 / 0.07);
+  box-shadow: var(--shadow-card-hover);
 }
 
 /* Mobile nav drawer + scrim */
@@ -85,7 +79,7 @@
   padding: 14px 14px calc(20px + env(safe-area-inset-bottom, 0px));
   background: oklch(0.155 0.006 250);
   border-right: 1px solid oklch(1 0 0 / 0.08);
-  box-shadow: 24px 0 70px oklch(0 0 0 / 0.55);
+  box-shadow: var(--shadow-drawer);
   overflow-y: auto;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;

--- a/front/styles/components/daypicker.css
+++ b/front/styles/components/daypicker.css
@@ -20,9 +20,7 @@
   border: 1px solid var(--line);
   border-radius: 12px;
   padding: 12px 12px 13px;
-  box-shadow:
-    0 20px 48px oklch(0 0 0 / 0.55),
-    inset 0 1px 0 oklch(1 0 0 / 0.05);
+  box-shadow: var(--shadow-popover), inset 0 1px 0 oklch(1 0 0 / 0.05);
   font-family: "Geist", system-ui, -apple-system, sans-serif;
   font-size: 14px;
   color: var(--ink);

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -118,9 +118,7 @@
         oklch(0.68 0.11 160 / 0.26) 100%
       )
       border-box;
-  box-shadow:
-    0 12px 30px oklch(0 0 0 / 0.24),
-    inset 0 1px 0 oklch(1 0 0 / 0.045);
+  box-shadow: var(--shadow-card);
   /* Keep a scrolled-to day card clear of the sticky .pfa-hdr (COS-38). Below md
      the header stacks the date-picker + "Aujourd'hui" button onto their own
      full-width row, so it is much taller than the single-row desktop header. */

--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -10,6 +10,7 @@ layer(base);
 @import './tokens/colors.css';
 @import './tokens/radius.css';
 @import './tokens/typography.css';
+@import './tokens/elevation.css';
 
 /* Base layer + animations */
 @import './base.css';

--- a/front/styles/tokens/elevation.css
+++ b/front/styles/tokens/elevation.css
@@ -1,0 +1,17 @@
+/* Elevation scale — one vocabulary for the app's shadows. Each token is a full
+ * box-shadow value (soft black drop + a subtle top highlight where present),
+ * ramped by depth. Exposed by `@theme` as both a `shadow-*` utility (TSX) and a
+ * `--shadow-*` custom property (the CSS partials use `var(--shadow-*)`). */
+@theme {
+  --shadow-float: 0 10px 30px oklch(0 0 0 / 0.35);
+  --shadow-card: 0 12px 32px oklch(0 0 0 / 0.26), inset 0 1px 0 oklch(1 0 0 / 0.045);
+  --shadow-header: 0 14px 36px oklch(0 0 0 / 0.32), inset 0 1px 0 oklch(1 0 0 / 0.06);
+  --shadow-card-hover: 0 18px 42px oklch(0 0 0 / 0.36), inset 0 1px 0 oklch(1 0 0 / 0.07);
+  --shadow-popover: 0 20px 48px oklch(0 0 0 / 0.55);
+  --shadow-drawer: 24px 0 70px oklch(0 0 0 / 0.55);
+  --shadow-modal: 0 34px 90px oklch(0 0 0 / 0.62), inset 0 1px 0 oklch(1 0 0 / 0.05);
+  --shadow-lightbox: 0 24px 80px oklch(0 0 0 / 0.6);
+  --shadow-hero: 0 40px 100px oklch(0 0 0 / 0.6), 0 0 80px oklch(0.6 0.13 180 / 0.1);
+  /* Accent glow — the primary CTA (green→blue). */
+  --shadow-primary: 0 4px 18px oklch(0.75 0.14 165 / 0.25), inset 0 1px 0 oklch(1 0 0 / 0.3);
+}


### PR DESCRIPTION
Add a --shadow-* elevation scale (new styles/tokens/elevation.css, @theme) exposing shadow-* utilities + CSS vars. Replace the scattered inline oklch shadows with tokens:

- TSX: AuthCard (hero), InvoiceImageModal (lightbox), SpendingView FAB (float), StatisticsFilters popover (popover), Button primary (primary).
- CSS: chrome.css (card/header/card-hover/drawer), spendings day-card, category-detail modal, daypicker (popover + inset).

Values kept faithful; day-card snaps to the shared card token (invisible). Focus rings and colored accent glows deferred (concern #9 / later).