### PR TITLE
refactor(ui): categories tokens (COS-67)

### DIFF
--- a/front/src/components/categories/CategoriesListcontainer.tsx
+++ b/front/src/components/categories/CategoriesListcontainer.tsx
@@ -78,8 +78,8 @@ const CategoriesListcontainer = () => {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-center gap-3">
-        <h1 className="text-[18px] font-semibold tracking-[-0.01em] text-ink">Catégories</h1>
-        <span className="num rounded-full border border-line-soft bg-surface-elev px-2.5 py-[3px] text-[12px] text-ink-3">
+        <h1 className="text-lg font-semibold tracking-snug text-ink">Catégories</h1>
+        <span className="num rounded-full border border-line-soft bg-surface-elev px-2.5 py-1 text-xs text-ink-3">
           {allCats.length}
         </span>
 
@@ -92,7 +92,7 @@ const CategoriesListcontainer = () => {
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder="Rechercher une catégorie…"
-            className="w-full rounded-[6px] border border-line bg-surface-elev py-2 pl-8 pr-2.5 text-[13px] text-ink outline-none transition placeholder:text-ink-4 focus:border-accent-d"
+            className="w-full rounded-sm border border-line bg-surface-elev py-2 pl-8 pr-2.5 text-sm text-ink outline-none transition placeholder:text-ink-4 focus:border-accent-d"
           />
         </div>
 
@@ -110,7 +110,7 @@ const CategoriesListcontainer = () => {
         </Button>
       </div>
 
-      <p className="text-[12.5px] text-ink-4">
+      <p className="text-xs text-ink-4">
         Gérer tes catégories · part et fréquence <b className="font-medium text-ink-3">sur tout l&apos;historique</b>
       </p>
 
@@ -119,7 +119,7 @@ const CategoriesListcontainer = () => {
           <Spinner />
         </div>
       ) : visible.length === 0 ? (
-        <p className="py-6 text-[13px] text-ink-4">Aucune catégorie ne correspond.</p>
+        <p className="py-6 text-sm text-ink-4">Aucune catégorie ne correspond.</p>
       ) : (
         <div className="grid grid-cols-[repeat(auto-fill,minmax(238px,1fr))] gap-3">
           {visible.map((cat) => {

--- a/front/src/components/categories/CategoryFormModal.tsx
+++ b/front/src/components/categories/CategoryFormModal.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from "react";
 
 const LABEL = overlineClass;
 const INPUT =
-  "w-full rounded-[6px] border border-line bg-bg px-3 py-2.5 text-[14px] text-ink outline-none transition focus:border-accent-d";
+  "w-full rounded-sm border border-line bg-bg px-3 py-2.5 text-sm text-ink outline-none transition focus:border-accent-d";
 
 interface CategoryFormModalProps {
   open: boolean;
@@ -100,7 +100,7 @@ const CategoryFormBody = ({
                 type="button"
                 onClick={() => setColor(hex)}
                 className={cn(
-                  "size-[30px] rounded-[8px] border-2 transition-transform hover:scale-110",
+                  "size-[30px] rounded-md border-2 transition-transform hover:scale-110",
                   color.toLowerCase() === hex.toLowerCase() ? "border-ink" : "border-transparent",
                 )}
                 style={{ background: hex }}
@@ -109,19 +109,19 @@ const CategoryFormBody = ({
             ))}
           </div>
           <div className="mt-1 flex items-center gap-3">
-            <span className="text-[12.5px] text-ink-3">Personnalisée</span>
+            <span className="text-xs text-ink-3">Personnalisée</span>
             <input
               type="color"
               value={color}
               onChange={(e) => setColor(e.target.value)}
-              className="h-[30px] w-[46px] cursor-pointer rounded-[8px] border border-line bg-transparent p-0"
+              className="h-[30px] w-[46px] cursor-pointer rounded-md border border-line bg-transparent p-0"
               aria-label="Couleur personnalisée"
             />
-            <span className="font-mono text-[12.5px] text-ink-4">{color}</span>
+            <span className="font-mono text-xs text-ink-4">{color}</span>
           </div>
         </div>
 
-        {error && <p className="text-[12.5px] text-neg">{error}</p>}
+        {error && <p className="text-xs text-neg">{error}</p>}
       </div>
 
       <DialogFooter>

--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -29,13 +29,13 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
 
   return (
     <>
-      <div className="pfa-card pfa-card-hover flex flex-col gap-2.5 rounded-[10px] px-[15px] pb-3 pt-[13px]">
+      <div className="pfa-card pfa-card-hover flex flex-col gap-2.5 rounded-lg px-4 pb-3 pt-3.5">
         <div className="flex items-center gap-2.5">
           <CategoryColorDot
             color={category.color}
             className="h-5 w-1 flex-none"
           />
-          <span className="min-w-0 flex-1 truncate text-[13.5px] font-medium capitalize text-ink">{category.name}</span>
+          <span className="min-w-0 flex-1 truncate text-sm font-medium capitalize text-ink">{category.name}</span>
           <span className="flex flex-none gap-1.5">
             <IconButton
               variant="bordered"
@@ -58,7 +58,7 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
           </span>
         </div>
 
-        <span className="font-mono text-[11.5px] text-ink-4">
+        <span className="font-mono text-2xs text-ink-4">
           {used === 0 ? (
             "nouvelle catégorie · jamais utilisée"
           ) : (

--- a/front/styles/tokens/typography.css
+++ b/front/styles/tokens/typography.css
@@ -8,6 +8,7 @@
   --text-display: 2.5rem; /* 40px — hero display number */
   --text-display-lg: 3.5rem; /* 56px — hero display, wide screens */
 
+  --tracking-snug: -0.01em; /* titles/labels — subtle tighten (native `tight` = -0.025em is 2.5× too much) */
   --tracking-caps: 0.08em; /* uppercase micro-labels */
 
   --font-smooch: Smooch Sans, sans-serif;


### PR DESCRIPTION
Replace 16 arbitrary values with scale tokens across the Catégories page: radius 6/8/10px -> rounded-sm/md/lg (exact), text 18/12/14px -> lg/xs/sm (exact), 13.5/13px -> text-sm, 12.5px -> text-xs, 11.5px -> text-2xs, py-[3px]/px-[15px]/pt-[13px] -> py-1/px-4/pt-3.5.

Add --tracking-snug (-0.01em) rather than snapping to the native tracking-tight (-0.025em, 2.5x too tight): a repeated design decision with no native equivalent. Render preserved.

Structural one-offs kept: search/modal widths, swatch + picker dims, grid template.