### PR TITLE
refactor(ui): canonicalize scales (COS-95)

### DIFF
--- a/front/src/app/(public)/about/page.tsx
+++ b/front/src/app/(public)/about/page.tsx
@@ -18,7 +18,7 @@ export default function About() {
         subtitle="Personal Finance Assistant"
       />
 
-      <ul className="flex flex-col gap-2.5 text-[13px] text-ink-2">
+      <ul className="flex flex-col gap-2.5 text-sm text-ink-2">
         {LEGAL.map((line) => (
           <li
             key={line}
@@ -29,7 +29,7 @@ export default function About() {
         ))}
       </ul>
 
-      <div className="mt-5 border-t border-white/[0.07] pt-[18px] text-center font-mono text-[12px] text-ink-4">
+      <div className="mt-5 border-t border-white/[0.07] pt-4.5 text-center font-mono text-xs text-ink-4">
         pfa · 1991computer.com
       </div>
     </AuthCard>

--- a/front/src/app/(public)/forgotPassword/page.tsx
+++ b/front/src/app/(public)/forgotPassword/page.tsx
@@ -29,10 +29,10 @@ export default function ForgotPassword() {
         displayEmailField
       />
 
-      <div className="mt-5 flex justify-center border-t border-white/[0.07] pt-[18px]">
+      <div className="mt-5 flex justify-center border-t border-white/[0.07] pt-4.5">
         <Link
           href="/login"
-          className="inline-flex items-center gap-1.5 text-[12.5px] text-ink-3 transition-colors hover:text-ink"
+          className="inline-flex items-center gap-1.5 text-xs text-ink-3 transition-colors hover:text-ink"
         >
           <ArrowLeft
             className="size-3.5"

--- a/front/src/app/(public)/layout.tsx
+++ b/front/src/app/(public)/layout.tsx
@@ -24,9 +24,7 @@ export default async function PublicLayout({ children }: { children: React.React
         />
         <AuthHeader />
         <main className="relative z-[1] grid flex-1 place-items-center px-6 py-8">{children}</main>
-        <div className="relative z-[1] py-[18px] text-center font-mono text-[11px] text-ink-4">
-          pfa · 1991computer.com
-        </div>
+        <div className="relative z-[1] py-4.5 text-center font-mono text-2xs text-ink-4">pfa · 1991computer.com</div>
       </div>
     </AuthProvider>
   );

--- a/front/src/app/(public)/signup/page.tsx
+++ b/front/src/app/(public)/signup/page.tsx
@@ -35,7 +35,7 @@ export default function SignUp() {
         displayConfirmPasswordField
       />
 
-      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-[18px] text-[12.5px] text-ink-3">
+      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-4.5 text-xs text-ink-3">
         Déjà un compte ?{" "}
         <Link
           href="/login"

--- a/front/src/components/auth/AuthBrand.tsx
+++ b/front/src/components/auth/AuthBrand.tsx
@@ -6,13 +6,13 @@ import Logo from "@components/shared/brand/Logo";
  */
 export default function AuthBrand({ title, subtitle }: { title: string; subtitle?: string }) {
   return (
-    <div className="mb-[30px] flex flex-col items-center gap-4 text-center">
+    <div className="mb-7.5 flex flex-col items-center gap-4 text-center">
       <Logo
         size={58}
         glow
       />
-      <h1 className="text-[20px] font-semibold tracking-[-0.015em] text-ink">{title}</h1>
-      {subtitle && <p className="text-[13px] text-ink-3">{subtitle}</p>}
+      <h1 className="text-xl font-semibold tracking-snug text-ink">{title}</h1>
+      {subtitle && <p className="text-sm text-ink-3">{subtitle}</p>}
     </div>
   );
 }

--- a/front/src/components/auth/AuthCard.tsx
+++ b/front/src/components/auth/AuthCard.tsx
@@ -18,7 +18,7 @@ export default function AuthCard({ children, className }: { children: React.Reac
         {/* glass */}
         <div
           className={cn(
-            "relative w-[400px] max-w-[calc(100vw-48px)] overflow-hidden rounded-[25px] px-[34px] pt-[38px] pb-7 backdrop-blur-[24px] [background:linear-gradient(180deg,oklch(0.215_0.010_245/0.92)_0%,oklch(0.185_0.008_250/0.94)_100%)]",
+            "relative w-[400px] max-w-[calc(100vw-48px)] overflow-hidden rounded-[25px] px-8.5 pt-9.5 pb-7 backdrop-blur-[24px] [background:linear-gradient(180deg,oklch(0.215_0.010_245/0.92)_0%,oklch(0.185_0.008_250/0.94)_100%)]",
             className,
           )}
         >

--- a/front/src/components/auth/AuthHeader.tsx
+++ b/front/src/components/auth/AuthHeader.tsx
@@ -24,8 +24,8 @@ export default function AuthHeader() {
   const pathname = usePathname();
 
   return (
-    <header className="relative z-[2] flex flex-wrap items-center gap-x-4 gap-y-3 px-5 py-4 sm:gap-x-[26px] sm:px-8 sm:py-[18px]">
-      <div className="flex items-center gap-2.5 text-[15px] font-semibold tracking-[-0.02em] text-ink">
+    <header className="relative z-[2] flex flex-wrap items-center gap-x-4 gap-y-3 px-5 py-4 sm:gap-x-6.5 sm:px-8 sm:py-4.5">
+      <div className="flex items-center gap-2.5 text-base font-semibold tracking-tight text-ink">
         <Logo size={26} />
         <span>pfa</span>
       </div>
@@ -39,7 +39,7 @@ export default function AuthHeader() {
               href={path}
               aria-current={active ? "page" : undefined}
               className={cn(
-                "relative inline-flex items-center gap-2 rounded-[6px] px-[13px] py-2 text-[13.5px] font-medium transition-colors",
+                "relative inline-flex items-center gap-2 rounded-sm px-3.5 py-2 text-sm font-medium transition-colors",
                 active ? "text-ink" : "text-ink-3 hover:bg-white/[0.03] hover:text-ink-2",
               )}
             >

--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -78,7 +78,7 @@ const DatePickerWrapper = () => {
         type="button"
         onClick={toggleCalendar}
         className={cn(
-          "inline-flex select-none items-center gap-2.5 whitespace-nowrap rounded-[10px] border px-3.5 py-2 text-sm text-gray-200 shadow-lg transition-colors hover:cursor-pointer",
+          "inline-flex select-none items-center gap-2.5 whitespace-nowrap rounded-lg border px-3.5 py-2 text-sm text-gray-200 shadow-lg transition-colors hover:cursor-pointer",
           isCalendarVisible
             ? "border-accent-d bg-[#151515]"
             : "border-gray-700/50 bg-[#0c0c0c] hover:border-gray-600 hover:bg-[#151515]",
@@ -86,15 +86,15 @@ const DatePickerWrapper = () => {
       >
         <CalendarIcon className="size-4 shrink-0 text-gray-400" />
         {selectedDays.length > 0 ? (
-          <span className="num text-[13.5px] tracking-[-0.01em]">
+          <span className="num text-sm tracking-snug">
             {format(selectedDays[0], "dd MMM yyyy", { locale: fr })}
-            <span className="mx-[3px] text-gray-500">—</span>
+            <span className="mx-1 text-gray-500">—</span>
             {format(selectedDays[selectedDays.length - 1], "dd MMM yyyy", {
               locale: fr,
             })}
           </span>
         ) : (
-          <span className="text-[13.5px]">Sélectionner une période</span>
+          <span className="text-sm">Sélectionner une période</span>
         )}
         <ChevronDown
           className={cn("size-3.5 shrink-0 text-gray-500 transition-transform", isCalendarVisible && "rotate-180")}

--- a/front/src/components/exceptionals/ExceptionalFilters.tsx
+++ b/front/src/components/exceptionals/ExceptionalFilters.tsx
@@ -90,7 +90,7 @@ const ExceptionalFilters = ({
               className="gap-1.5 rounded-full px-2.5 capitalize"
             >
               <span
-                className="size-[7px] shrink-0 rounded-[2px]"
+                className="size-[7px] shrink-0 rounded-xs"
                 style={{ backgroundColor: cat.color }}
               />
               {cat.name}

--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -148,21 +148,20 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
       onOpenChange={(isOpen) => !isOpen && closeModal()}
     >
       <DialogContent className="gap-0 overflow-hidden border-line bg-surface-elev p-0 sm:max-w-[440px]">
-        <DialogHeader className="flex-row items-center justify-between space-y-0 border-b border-line-soft px-[22px] py-[18px] text-left">
-          <DialogTitle className="pr-8 text-[15px] font-semibold tracking-[-0.01em] text-ink">
+        <DialogHeader className="flex-row items-center justify-between space-y-0 border-b border-line-soft px-5.5 py-4.5 text-left">
+          <DialogTitle className="pr-8 text-base font-semibold tracking-snug text-ink">
             {isEditing ? "Modifier l'achat exceptionnel" : "Nouvel achat exceptionnel"}
           </DialogTitle>
         </DialogHeader>
 
         <form
           onSubmit={handleSubmit(onSubmit)}
-          className="flex flex-col gap-[18px] px-[22px] py-[22px]"
+          className="flex flex-col gap-4.5 px-5.5 py-5.5"
         >
           <div className="grid grid-cols-2 gap-3.5">
             <FieldShell
               label="Date"
               htmlFor="exceptional-date"
-              labelClassName="text-[13px]"
             >
               <TextInput
                 id="exceptional-date"
@@ -174,7 +173,6 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
             <FieldShell
               label="Montant (€)"
               htmlFor="exceptional-amount"
-              labelClassName="text-[13px]"
             >
               <TextInput
                 id="exceptional-amount"
@@ -190,7 +188,6 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
           <FieldShell
             label="Label"
             htmlFor="exceptional-label"
-            labelClassName="text-[13px]"
             error={errors.label?.message}
           >
             <TextInput
@@ -207,7 +204,6 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
               </>
             }
             htmlFor="exceptional-description"
-            labelClassName="text-[13px]"
           >
             <TextInput
               id="exceptional-description"
@@ -216,10 +212,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
             />
           </FieldShell>
 
-          <FieldShell
-            label="Catégorie"
-            labelClassName="text-[13px]"
-          >
+          <FieldShell label="Catégorie">
             <Popover
               open={comboboxOpen}
               onOpenChange={setComboboxOpen}
@@ -235,7 +228,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
                   {selectedCategory ? (
                     <>
                       <span
-                        className="size-2.5 shrink-0 rounded-[3px]"
+                        className="size-2.5 shrink-0 rounded-xs"
                         style={{ backgroundColor: selectedCategory.color }}
                       />
                       <span className="capitalize">{selectedCategory.name}</span>
@@ -293,7 +286,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
                           }}
                         >
                           <span
-                            className="mr-1 size-2.5 rounded-[3px]"
+                            className="mr-1 size-2.5 rounded-xs"
                             style={{ backgroundColor: cat.color }}
                           />
                           <span className="flex-1 capitalize">{cat.name}</span>

--- a/front/src/components/exceptionals/ExceptionalsList.tsx
+++ b/front/src/components/exceptionals/ExceptionalsList.tsx
@@ -41,15 +41,15 @@ const ExceptionalsList = ({ items, onEdit, monthlyAverage }: ExceptionalsListPro
   }, [items]);
 
   if (groups.length === 0) {
-    return <div className="py-12 text-center text-[12.5px] text-ink-4">Aucun achat exceptionnel.</div>;
+    return <div className="py-12 text-center text-xs text-ink-4">Aucun achat exceptionnel.</div>;
   }
 
   return (
-    <div className="flex flex-col gap-[18px]">
+    <div className="flex flex-col gap-4.5">
       {groups.map((group) => (
         <section key={group.key}>
           <div className="flex items-baseline justify-between px-1 pb-2.5">
-            <h2 className="text-[15px] font-semibold capitalize tracking-[-0.01em] text-ink">
+            <h2 className="text-base font-semibold capitalize tracking-snug text-ink">
               {group.label}
               <span className="ml-2 text-xs font-normal text-ink-4">
                 · {group.items.length} achat
@@ -60,7 +60,7 @@ const ExceptionalsList = ({ items, onEdit, monthlyAverage }: ExceptionalsListPro
               Total <b className="font-medium text-ink">{euro(group.total)} €</b>
             </span>
           </div>
-          <div className="overflow-hidden rounded-[14px] border border-line-soft bg-surface-elev">
+          <div className="overflow-hidden rounded-xl border border-line-soft bg-surface-elev">
             {group.items.map((item) => (
               <ExceptionalItem
                 key={item.ID}

--- a/front/src/components/login/LoginFormClient.tsx
+++ b/front/src/components/login/LoginFormClient.tsx
@@ -50,13 +50,13 @@ export default function LoginFormClient() {
         <Link
           href="/forgotPassword"
           prefetch={false}
-          className="text-[12.5px] text-ink-3 transition-colors hover:text-ink"
+          className="text-xs text-ink-3 transition-colors hover:text-ink"
         >
           Mot de passe oublié ?
         </Link>
       </div>
 
-      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-[18px] text-[12.5px] text-ink-3">
+      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-4.5 text-xs text-ink-3">
         Pas encore de compte ?{" "}
         <Link
           href="/signup"

--- a/front/src/components/shared/FieldShell.tsx
+++ b/front/src/components/shared/FieldShell.tsx
@@ -8,19 +8,17 @@ interface FieldShellProps {
   htmlFor?: string;
   /** Error message rendered below the control (falsy = hidden). */
   error?: string;
-  /** Overrides the default `text-sm` label size (e.g. `text-[13px]`). */
-  labelClassName?: string;
   className?: string;
   children: ReactNode;
 }
 
 /** Vertical form-field wrapper: label + control slot + optional error message. */
-function FieldShell({ label, htmlFor, error, labelClassName, className, children }: FieldShellProps) {
+function FieldShell({ label, htmlFor, error, className, children }: FieldShellProps) {
   return (
     <div className={cn("flex flex-col gap-2", className)}>
       <Label
         htmlFor={htmlFor}
-        className={cn("text-sm text-ink-2", labelClassName)}
+        className="text-sm text-ink-2"
       >
         {label}
       </Label>

--- a/front/src/components/shared/MeterBar.tsx
+++ b/front/src/components/shared/MeterBar.tsx
@@ -20,11 +20,11 @@ interface MeterBarProps {
 function MeterBar({ value, fill = "var(--bar-fill)", height, opacity = 1, className }: MeterBarProps) {
   return (
     <div
-      className={cn("overflow-hidden rounded-[4px] bg-surface-hi", className)}
+      className={cn("overflow-hidden rounded-sm bg-surface-hi", className)}
       style={{ height }}
     >
       <span
-        className="block h-full rounded-[4px]"
+        className="block h-full rounded-sm"
         style={{ width: `${value}%`, background: fill, opacity }}
       />
     </div>

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -39,7 +39,7 @@ const ROUTE_ICONS: Record<string, LucideIcon> = {
 
 const ACTIVE_BG = "bg-[oklch(0.26_0.010_248)]";
 const PERIOD_BTN =
-  "cursor-pointer rounded-[6px] border border-[oklch(0.30_0.010_248)] bg-[oklch(0.125_0.006_250/0.55)] px-3 py-2 text-[13px] text-ink-2 transition-colors hover:text-ink whitespace-nowrap";
+  "cursor-pointer rounded-sm border border-[oklch(0.30_0.010_248)] bg-[oklch(0.125_0.006_250/0.55)] px-3 py-2 text-sm text-ink-2 transition-colors hover:text-ink whitespace-nowrap";
 
 const normalizePath = (path: string): string => {
   const normalized = path.replace(/\/+$/, "");
@@ -101,7 +101,7 @@ const NavBar = () => {
   if (!user) return null;
 
   const brand = (
-    <div className="flex items-center gap-2.5 text-[15px] font-semibold tracking-[-0.02em] text-ink">
+    <div className="flex items-center gap-2.5 text-base font-semibold tracking-tight text-ink">
       <Logo size={24} />
       <span>pfa</span>
     </div>
@@ -128,7 +128,7 @@ const NavBar = () => {
               key={route.path}
               href={hrefFor(route)}
               className={cn(
-                "rounded-[6px] px-3 py-1.5 text-[13px] font-medium transition-colors",
+                "rounded-sm px-3 py-1.5 text-sm font-medium transition-colors",
                 isActiveRoute(route.path) ? cn(ACTIVE_BG, "text-ink") : "text-ink-3 hover:text-ink-2",
               )}
             >
@@ -213,7 +213,7 @@ const NavBar = () => {
                 href={hrefFor(route)}
                 onClick={() => setDrawerOpen(false)}
                 className={cn(
-                  "flex items-center gap-2.5 rounded-[8px] px-3 py-2.5 text-[14px] font-medium transition-colors",
+                  "flex items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium transition-colors",
                   isActiveRoute(route.path)
                     ? cn(ACTIVE_BG, "text-ink")
                     : "text-ink-3 hover:bg-white/[0.05] hover:text-ink",

--- a/front/src/components/shared/navBar/userMenu/UserMenu.tsx
+++ b/front/src/components/shared/navBar/userMenu/UserMenu.tsx
@@ -43,11 +43,11 @@ const UserMenu = () => {
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2.5 rounded-[8px] outline-hidden">
-        <span className="grid size-[30px] flex-shrink-0 place-items-center rounded-full border border-line bg-surface-hi text-[11px] font-medium text-ink-2">
+      <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2.5 rounded-md outline-hidden">
+        <span className="grid size-[30px] flex-shrink-0 place-items-center rounded-full border border-line bg-surface-hi text-2xs font-medium text-ink-2">
           {initialsFromEmail(user?.email)}
         </span>
-        <span className="hidden max-w-[200px] truncate text-[13px] text-ink-2 xl:inline">{user?.email}</span>
+        <span className="hidden max-w-[200px] truncate text-sm text-ink-2 xl:inline">{user?.email}</span>
         <ChevronDown className="size-4 flex-shrink-0 text-ink-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -57,7 +57,7 @@ const UserMenu = () => {
       >
         <DropdownMenuItem
           onClick={() => router.push(ROUTES.changePassword.path)}
-          className="cursor-pointer gap-3 px-3 py-2.5 text-[13px] text-ink-2"
+          className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2"
         >
           <KeyRound className="size-4 text-primary" />
           Modifier le mot de passe
@@ -65,7 +65,7 @@ const UserMenu = () => {
         <DropdownMenuSeparator className="my-1" />
         <DropdownMenuItem
           onClick={handleLogout}
-          className="cursor-pointer gap-3 px-3 py-2.5 text-[13px] text-ink-2"
+          className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2"
         >
           <LogOut className="size-4 text-ink-3" />
           Se déconnecter

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -29,7 +29,7 @@ const buildSchema = (needEmail: boolean, needPassword: boolean, needConfirm: boo
 
 const LABEL = overlineClass;
 const INPUT_BASE =
-  "w-full rounded-[6px] border px-[13px] py-[11px] text-[14px] text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] border-[oklch(0.30_0.010_250)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";
+  "w-full rounded-sm border px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] border-[oklch(0.30_0.010_250)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";
 
 /**
  * Single shared message slot for the auth forms. Always rendered — it reserves one
@@ -40,7 +40,7 @@ const INPUT_BASE =
 const FormMessage = ({ message }: { message?: string | null }) => (
   <p
     role="alert"
-    className="min-h-5 text-[13px] leading-5 text-neg"
+    className="min-h-5 text-sm leading-5 text-neg"
   >
     {message ?? ""}
   </p>
@@ -138,7 +138,7 @@ const SharedLoginForm = ({
               type={showPassword ? "text" : "password"}
               placeholder="••••••••"
               autoComplete={displayConfirmPasswordField ? "new-password" : "current-password"}
-              className={cn(INPUT_BASE, "pr-[42px]")}
+              className={cn(INPUT_BASE, "pr-10.5")}
               aria-invalid={!!errors.password}
               {...register("password", { onChange: clearFieldError("password") })}
             />
@@ -169,7 +169,7 @@ const SharedLoginForm = ({
               type={showConfirm ? "text" : "password"}
               placeholder="••••••••"
               autoComplete="new-password"
-              className={cn(INPUT_BASE, "pr-[42px]")}
+              className={cn(INPUT_BASE, "pr-10.5")}
               aria-invalid={!!errors.confirmPassword}
               {...register("confirmPassword", {
                 onChange: clearFieldError("confirmPassword"),
@@ -226,7 +226,7 @@ const SharedLoginForm = ({
         type="submit"
         variant="primary"
         disabled={isSubmitting}
-        className="h-auto w-full rounded-[10px] py-3 text-[14px] tracking-[0.01em]"
+        className="h-auto w-full rounded-lg py-3 text-sm tracking-normal"
       >
         {buttonTitle}
         {submitIcon && (

--- a/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
@@ -117,7 +117,7 @@ const SpendingDayItem = ({
                   key={key}
                   onClick={() => setSelectedCategory(key)}
                   className={cn(
-                    "px-2 py-0.5 rounded text-[10px] uppercase font-medium transition-all border cursor-pointer",
+                    "px-2 py-0.5 rounded text-2xs uppercase font-medium transition-all border cursor-pointer",
                     isClicked ? "border-transparent" : "border-transparent opacity-70 hover:opacity-100",
                   )}
                   style={{
@@ -133,7 +133,7 @@ const SpendingDayItem = ({
               <button
                 type="button"
                 onClick={() => setSelectedCategory(null)}
-                className="px-2 py-0.5 rounded text-[10px] uppercase font-medium bg-gray-700/60 text-gray-200 hover:bg-gray-600"
+                className="px-2 py-0.5 rounded text-2xs uppercase font-medium bg-gray-700/60 text-gray-200 hover:bg-gray-600"
               >
                 {spendingsText.dayItem.filterResetLabel}
               </button>

--- a/front/src/components/statistics/StatMiniChart.tsx
+++ b/front/src/components/statistics/StatMiniChart.tsx
@@ -67,7 +67,7 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
       style={{ height }}
     >
       <div
-        className="num flex flex-col justify-between text-[11px] leading-none text-ink-4"
+        className="num flex flex-col justify-between text-2xs leading-none text-ink-4"
         style={{ paddingTop: PAD.top - 6, paddingBottom: PAD.bottom - 6 }}
       >
         <span>{kFormat(max)}</span>
@@ -193,7 +193,7 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
 
         {avgY != null && (
           <span
-            className="num pointer-events-none absolute right-6 text-[9px] text-ink-4"
+            className="num pointer-events-none absolute right-6 text-3xs text-ink-4"
             style={{ top: `calc(${avgTop}% - 14px)` }}
           >
             moy.

--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -65,14 +65,14 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
   return (
     <GlowCard
       as="section"
-      className="px-6 py-[22px]"
+      className="px-6 py-5.5"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-4">
         <div>
           <CardTitle>Dépenses mensuelles par catégorie</CardTitle>
-          <p className="mt-0.5 text-[12px] text-ink-4">{subtitle}</p>
+          <p className="mt-0.5 text-xs text-ink-4">{subtitle}</p>
         </div>
-        <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">
+        <div className="flex flex-wrap items-center gap-4.5 text-xs text-ink-3">
           {series.map((s) => (
             <LegendItem
               key={s.name}
@@ -92,7 +92,7 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
 
       <div
         ref={ref}
-        className="mt-[18px] w-full"
+        className="mt-4.5 w-full"
       >
         {width > 0 && (
           <svg

--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -32,18 +32,18 @@ const WEEKEND_FILL = "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.1
 const StatisticsDayOfWeek = () => (
   <GlowCard
     as="section"
-    className="px-6 py-[22px]"
+    className="px-6 py-5.5"
   >
     <CardSectionHeader
       title="Dépenses par jour de la semaine"
       meta="moyenne sur 12 mois"
     />
 
-    <div className="mt-[18px] flex flex-col gap-2">
+    <div className="mt-4.5 flex flex-col gap-2">
       {ROWS.map((row) => (
         <div
           key={row.day}
-          className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-[13px]"
+          className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-sm"
         >
           <span className={row.weekend ? "text-ink" : "text-ink-2"}>{row.day}</span>
           <MeterBar
@@ -54,7 +54,7 @@ const StatisticsDayOfWeek = () => (
           />
           <span className="num text-right font-medium text-ink">
             {row.amount}
-            <small className="block text-[10.5px] font-normal text-ink-4">{row.transactions}</small>
+            <small className="block text-2xs font-normal text-ink-4">{row.transactions}</small>
           </span>
         </div>
       ))}

--- a/front/src/components/statistics/StatisticsFilters.tsx
+++ b/front/src/components/statistics/StatisticsFilters.tsx
@@ -26,7 +26,7 @@ interface StatisticsFiltersProps {
   maxCategories: number;
 }
 
-const popContent = "rounded-[10px] border border-line bg-surface-elev p-1.5 shadow-popover";
+const popContent = "rounded-lg border border-line bg-surface-elev p-1.5 shadow-popover";
 
 const YearMenu = ({
   years,
@@ -66,7 +66,7 @@ const YearMenu = ({
                   setOpen(false);
                 }}
                 className={cn(
-                  "num flex items-center justify-between rounded-md px-2.5 py-2 text-left text-[13px] transition-colors hover:bg-surface-hi",
+                  "num flex items-center justify-between rounded-md px-2.5 py-2 text-left text-sm transition-colors hover:bg-surface-hi",
                   year === selected ? "text-accent-strong" : "text-ink-2",
                 )}
               >
@@ -117,7 +117,7 @@ const StatisticsFilters = ({
       >
         <button
           type="button"
-          className="inline-flex items-center gap-2 rounded-[6px] border border-line bg-surface-elev px-2.5 py-[7px] text-[13px] text-ink-2 transition-colors hover:border-ink-4"
+          className="inline-flex items-center gap-2 rounded-sm border border-line bg-surface-elev px-2.5 py-2 text-sm text-ink-2 transition-colors hover:border-ink-4"
         >
           <Calendar className="size-3.5 text-ink-4" />
           <span className="num text-ink">{selectedYear}</span>
@@ -128,7 +128,7 @@ const StatisticsFilters = ({
       {/* Compare */}
       <div
         className={cn(
-          "inline-flex items-center gap-2 rounded-[6px] border border-line px-2.5 py-[6px] text-[12px]",
+          "inline-flex items-center gap-2 rounded-sm border border-line px-2.5 py-1.5 text-xs",
           compareEnabled ? "bg-surface-elev" : "bg-transparent",
         )}
       >
@@ -148,7 +148,7 @@ const StatisticsFilters = ({
           <button
             type="button"
             disabled={!compareEnabled}
-            className="inline-flex items-center gap-1 rounded-[6px] border border-line bg-surface-hi px-1.5 py-0.5 text-[12px] text-ink-2 transition-colors hover:border-ink-4 disabled:opacity-40"
+            className="inline-flex items-center gap-1 rounded-sm border border-line bg-surface-hi px-1.5 py-0.5 text-xs text-ink-2 transition-colors hover:border-ink-4 disabled:opacity-40"
           >
             <span className="num">{compareYear}</span>
             <ChevronDown className="size-2.5 text-ink-4" />
@@ -159,7 +159,7 @@ const StatisticsFilters = ({
       {/* Exceptionals */}
       <label
         htmlFor="stat-exceptionals"
-        className="inline-flex cursor-pointer items-center gap-2 rounded-[6px] border border-line px-2.5 py-[6px] text-[12px] text-ink-2"
+        className="inline-flex cursor-pointer items-center gap-2 rounded-sm border border-line px-2.5 py-1.5 text-xs text-ink-2"
       >
         <Switch
           id="stat-exceptionals"
@@ -180,7 +180,7 @@ const StatisticsFilters = ({
             type="button"
             disabled={atMax}
             className={cn(
-              "inline-flex items-center gap-1.5 rounded-[6px] border border-line bg-surface-elev py-[7px] pl-2.5 pr-3 text-[13px] text-ink-2 transition-colors hover:border-ink-4",
+              "inline-flex items-center gap-1.5 rounded-sm border border-line bg-surface-elev py-2 pl-2.5 pr-3 text-sm text-ink-2 transition-colors hover:border-ink-4",
               atMax && "pointer-events-none opacity-45",
             )}
           >
@@ -198,12 +198,12 @@ const StatisticsFilters = ({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Rechercher…"
-              className="h-9 border-line bg-background pl-8 text-[13px]"
+              className="h-9 border-line bg-background pl-8 text-sm"
             />
           </div>
           <div className="max-h-[264px] overflow-y-auto pr-0.5">
             {filtered.length === 0 ? (
-              <div className="px-2.5 py-3 text-center text-[12.5px] text-ink-4">Aucune catégorie</div>
+              <div className="px-2.5 py-3 text-center text-xs text-ink-4">Aucune catégorie</div>
             ) : (
               filtered.map((category) => {
                 const active = selectedCategoryIds.includes(category.ID);
@@ -212,7 +212,7 @@ const StatisticsFilters = ({
                     key={category.ID}
                     type="button"
                     onClick={() => onToggleCategory(category.ID)}
-                    className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] capitalize text-ink-2 transition-colors hover:bg-surface-hi hover:text-ink"
+                    className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm capitalize text-ink-2 transition-colors hover:bg-surface-hi hover:text-ink"
                   >
                     <span
                       className="size-2.5 shrink-0 rounded-full"
@@ -232,7 +232,7 @@ const StatisticsFilters = ({
       {selectedCategories.map((category) => (
         <span
           key={category.ID}
-          className="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-hi py-[5px] pl-2 pr-1.5 text-[12.5px] capitalize text-ink-2"
+          className="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-hi py-1.5 pl-2 pr-1.5 text-xs capitalize text-ink-2"
         >
           <span
             className="size-2 rounded-full"
@@ -243,7 +243,7 @@ const StatisticsFilters = ({
             type="button"
             onClick={() => onToggleCategory(category.ID)}
             aria-label={`Retirer ${category.name}`}
-            className="grid size-[17px] place-items-center rounded-[5px] text-ink-4 transition-colors hover:bg-surface-hover hover:text-ink"
+            className="grid size-[17px] place-items-center rounded-sm text-ink-4 transition-colors hover:bg-surface-hover hover:text-ink"
           >
             <X className="size-3" />
           </button>

--- a/front/src/components/statistics/StatisticsFixedExpenses.tsx
+++ b/front/src/components/statistics/StatisticsFixedExpenses.tsx
@@ -46,14 +46,12 @@ const Stat = ({
       <div
         className={
           small
-            ? "num mt-2 text-[19px] font-medium tracking-[-0.025em] text-ink-2"
-            : "num mt-2 text-[30px] font-medium tracking-[-0.025em] text-ink"
+            ? "num mt-2 text-lg font-medium tracking-tight text-ink-2"
+            : "num mt-2 text-3xl font-medium tracking-tight text-ink"
         }
       >
         {int}
-        <span className={small ? "text-[14px] font-normal text-ink-3" : "text-[20px] font-normal text-ink-3"}>
-          ,{dec} €
-        </span>
+        <span className={small ? "text-sm font-normal text-ink-3" : "text-xl font-normal text-ink-3"}>,{dec} €</span>
       </div>
     </div>
   );
@@ -77,14 +75,14 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
   return (
     <GlowCard
       as="section"
-      className="px-6 py-[22px]"
+      className="px-6 py-5.5"
     >
       <CardSectionHeader
         title="Dépenses fixes"
         meta={<>annualisé · {list.length} lignes récurrentes · sans catégorie</>}
       />
 
-      <div className="mt-[18px] flex flex-wrap items-baseline gap-x-10 gap-y-4 border-b border-line-soft pb-5">
+      <div className="mt-4.5 flex flex-wrap items-baseline gap-x-10 gap-y-4 border-b border-line-soft pb-5">
         <Stat
           label="Total sur l'année"
           value={annualTotal}
@@ -110,12 +108,12 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
           return (
             <div
               key={r.ID}
-              className="flex flex-col gap-[7px]"
+              className="flex flex-col gap-2"
             >
-              <div className="flex items-baseline gap-2.5 text-[13px]">
+              <div className="flex items-baseline gap-2.5 text-sm">
                 <span className="text-ink">{r.label}</span>
                 <span className="num ml-auto font-medium text-ink">
-                  {euro(annual)} €<small className="ml-1.5 text-[11px] font-normal text-ink-4">{share}%</small>
+                  {euro(annual)} €<small className="ml-1.5 text-2xs font-normal text-ink-4">{share}%</small>
                 </span>
               </div>
               <MeterBar
@@ -128,7 +126,7 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
         })}
       </div>
 
-      <p className="mt-5 border-t border-line-soft pt-[18px] text-[12px] text-ink-4">
+      <p className="mt-5 border-t border-line-soft pt-4.5 text-xs text-ink-4">
         Les dépenses fixes ne portent pas de catégorie — elles sont totalisées par nom. Le{" "}
         <b className="num font-medium text-ink-2">{list[0].label}</b> représente à lui seul{" "}
         <b className="num font-medium text-ink-2">{topShare} %</b> du total annuel des récurrents.

--- a/front/src/components/statistics/StatisticsForecast.tsx
+++ b/front/src/components/statistics/StatisticsForecast.tsx
@@ -59,9 +59,9 @@ const StatisticsForecast = ({
           value={spent}
           decimals={0}
           suffix=" €"
-          className="num text-[24px] font-medium tracking-[-0.02em] text-ink"
+          className="num text-2xl font-medium tracking-tight text-ink"
         />
-        <span className="text-[12px] text-ink-3">
+        <span className="text-xs text-ink-3">
           {daysElapsed} jours · {euro(perDay)} €/jour
         </span>
       </div>
@@ -79,7 +79,7 @@ const StatisticsForecast = ({
           height={36}
           radius={8}
         />
-        <div className="mt-2 flex items-center justify-between text-[11px] text-ink-4">
+        <div className="mt-2 flex items-center justify-between text-2xs text-ink-4">
           <span className="num">1er janv.</span>
           <span>— projection —</span>
           <span className="num">31 déc.</span>
@@ -93,9 +93,9 @@ const StatisticsForecast = ({
           decimals={0}
           suffix=" €"
           color="var(--accent-strong)"
-          className="num text-[24px] font-medium tracking-[-0.02em]"
+          className="num text-2xl font-medium tracking-tight"
         />
-        <span className="text-[12px] text-ink-3">
+        <span className="text-xs text-ink-3">
           <span className={delta > 0 ? "text-neg" : "text-accent-strong"}>
             {delta > 0 ? `+${euro0(delta)}` : euro0(delta)} €
           </span>{" "}

--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -135,7 +135,7 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
   return (
     <GlowCard
       as="div"
-      className="flex flex-col overflow-x-auto px-6 py-[22px]"
+      className="flex flex-col overflow-x-auto px-6 py-5.5"
     >
       <CardSectionHeader
         title="Carte de chaleur — quotidienne"
@@ -146,10 +146,10 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
         }
       />
 
-      <div className="mt-[18px] min-w-[620px]">
+      <div className="mt-4.5 min-w-[620px]">
         {/* month axis */}
         <div
-          className="num mb-1 grid text-[9px] text-ink-4"
+          className="num mb-1 grid text-3xs text-ink-4"
           style={{ gridTemplateColumns: "16px repeat(53, minmax(0, 1fr))" }}
         >
           {MONTH_COLS.map((m) => (
@@ -173,14 +173,12 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
               key={dow}
               className="contents"
             >
-              <span className="num self-center pr-1 text-right text-[9px] leading-[11px] text-ink-4">
-                {DOW_LABELS[dow]}
-              </span>
+              <span className="num self-center pr-1 text-right text-3xs leading-3 text-ink-4">{DOW_LABELS[dow]}</span>
               {weekArr.map((lvl, week) => (
                 <span
                   // biome-ignore lint/suspicious/noArrayIndexKey: fixed 53-week grid, positional cell never reorders
                   key={week}
-                  className="aspect-square min-h-[9px] rounded-[2px]"
+                  className="aspect-square min-h-[9px] rounded-xs"
                   style={
                     lvl === "future"
                       ? { background: "transparent", border: "1px dashed var(--line)" }
@@ -193,13 +191,13 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
         </div>
 
         {/* scale legend */}
-        <div className="num mt-4 flex items-center gap-2 text-[11px] text-ink-4">
+        <div className="num mt-4 flex items-center gap-2 text-2xs text-ink-4">
           <span>0 €</span>
           <span className="flex gap-0.5">
             {(["lvl-0", "lvl-1", "lvl-2", "lvl-3", "lvl-4"] as FilledLevel[]).map((lvl) => (
               <span
                 key={lvl}
-                className="size-2.5 rounded-[2px]"
+                className="size-2.5 rounded-xs"
                 style={{ background: CELL_BG[lvl] }}
               />
             ))}
@@ -220,26 +218,26 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
       </div>
 
       {/* derived insights, pinned to the bottom */}
-      <div className="mt-auto flex flex-col gap-[22px] border-t border-line-soft pt-[22px]">
+      <div className="mt-auto flex flex-col gap-5.5 border-t border-line-soft pt-5.5">
         <div>
-          <div className="num mb-2.5 text-[11px] uppercase tracking-[0.07em] text-ink-4">Répartition des journées</div>
-          <div className="flex h-4 gap-0.5 overflow-hidden rounded-[5px]">
+          <div className="num mb-2.5 text-2xs uppercase tracking-caps text-ink-4">Répartition des journées</div>
+          <div className="flex h-4 gap-0.5 overflow-hidden rounded-sm">
             {FILLED_ORDER.filter((lvl) => counts[lvl] > 0).map((lvl) => (
               <span
                 key={lvl}
-                className="block h-full rounded-[2px]"
+                className="block h-full rounded-xs"
                 style={{ background: DIST_BG[lvl], flexGrow: counts[lvl], flexBasis: 0 }}
               />
             ))}
           </div>
-          <div className="num mt-[11px] flex flex-wrap gap-x-[18px] gap-y-[7px] text-[11px] text-ink-3">
+          <div className="num mt-3 flex flex-wrap gap-x-4.5 gap-y-2 text-2xs text-ink-3">
             {distGroups.map((g) => (
               <span
                 key={g.label}
                 className="inline-flex items-center gap-1.5"
               >
                 <i
-                  className="size-2 shrink-0 rounded-[2px]"
+                  className="size-2 shrink-0 rounded-xs"
                   style={{ background: g.color }}
                 />
                 {g.label} <b className="font-medium text-ink">{g.n}</b>
@@ -248,28 +246,22 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
           </div>
         </div>
 
-        <div className="grid grid-cols-3 gap-[18px]">
+        <div className="grid grid-cols-3 gap-4.5">
           <div>
-            <div className="num text-[10.5px] uppercase leading-[1.35] tracking-[0.04em] text-ink-4">
-              Journée la plus chargée
-            </div>
+            <div className="num text-2xs uppercase leading-snug tracking-wider text-ink-4">Journée la plus chargée</div>
             {/* MOCK — no per-day amounts */}
-            <div className="num mt-[7px] text-[20px] tracking-[-0.01em] text-ink">210 €</div>
-            <div className="mt-[3px] text-[11px] text-ink-4">hors exceptionnel</div>
+            <div className="num mt-2 text-xl tracking-snug text-ink">210 €</div>
+            <div className="mt-1 text-2xs text-ink-4">hors exceptionnel</div>
           </div>
           <div>
-            <div className="num text-[10.5px] uppercase leading-[1.35] tracking-[0.04em] text-ink-4">
-              Plus longue série sobre
-            </div>
-            <div className="num mt-[7px] text-[20px] tracking-[-0.01em] text-ink">{streak} jours</div>
-            <div className="mt-[3px] text-[11px] text-ink-4">journées calmes d&apos;affilée</div>
+            <div className="num text-2xs uppercase leading-snug tracking-wider text-ink-4">Plus longue série sobre</div>
+            <div className="num mt-2 text-xl tracking-snug text-ink">{streak} jours</div>
+            <div className="mt-1 text-2xs text-ink-4">journées calmes d&apos;affilée</div>
           </div>
           <div>
-            <div className="num text-[10.5px] uppercase leading-[1.35] tracking-[0.04em] text-ink-4">
-              Pics exceptionnels
-            </div>
-            <div className="num mt-[7px] text-[20px] tracking-[-0.01em] text-ink">{counts["lvl-neg"]}</div>
-            <div className="mt-[3px] text-[11px] text-ink-4">ordinateur · vélo</div>
+            <div className="num text-2xs uppercase leading-snug tracking-wider text-ink-4">Pics exceptionnels</div>
+            <div className="num mt-2 text-xl tracking-snug text-ink">{counts["lvl-neg"]}</div>
+            <div className="mt-1 text-2xs text-ink-4">ordinateur · vélo</div>
           </div>
         </div>
       </div>

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -43,9 +43,9 @@ const Card = ({ label, children }: { label: string; children: React.ReactNode })
 );
 
 const Value = ({ amount }: { amount: number }) => (
-  <div className="num mb-1 mt-2.5 text-[30px] font-medium leading-none tracking-[-0.025em] text-ink">
+  <div className="num mb-1 mt-2.5 text-3xl font-medium leading-none tracking-tight text-ink">
     {euro0(amount)}
-    <span className="text-[20px] font-normal text-ink-3"> €</span>
+    <span className="text-xl font-normal text-ink-3"> €</span>
   </div>
 );
 
@@ -76,7 +76,7 @@ const CmpRow = ({
     <div className="flex items-baseline gap-2">
       <span
         className={cn(
-          "num shrink-0 rounded-[3px] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.04em]",
+          "num shrink-0 rounded-xs px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider",
           kind === "exc" ? "bg-exc-bg text-exc" : "bg-accent-bg text-accent-strong",
         )}
       >
@@ -85,14 +85,14 @@ const CmpRow = ({
       <span
         className={cn(
           "truncate",
-          titleVariant === "month" ? "text-[11px] uppercase tracking-[0.08em] text-ink-3" : "text-[13px] text-ink-2",
+          titleVariant === "month" ? "text-2xs uppercase tracking-caps text-ink-3" : "text-sm text-ink-2",
         )}
       >
         {title}
       </span>
-      <span className="num ml-auto text-[17px] font-medium text-ink">{euro0(amount)} €</span>
+      <span className="num ml-auto text-lg font-medium text-ink">{euro0(amount)} €</span>
     </div>
-    <div className="flex h-2 overflow-hidden rounded-[3px] bg-surface-hi">
+    <div className="flex h-2 overflow-hidden rounded-xs bg-surface-hi">
       <span
         style={{
           width: `${Math.max(0, regWidth) * 100}%`,
@@ -154,7 +154,7 @@ const StatisticsKpis = ({
     <section className="grid grid-cols-1 gap-4 min-[520px]:grid-cols-2 min-[768px]:grid-cols-4">
       <Card label={`Total dépensé ${year}`}>
         <Value amount={total} />
-        <span className="text-[12px] text-ink-3">
+        <span className="text-xs text-ink-3">
           <Delta down={deltaPct <= 0}>{Math.abs(Math.round(deltaPct))}%</Delta> vs {compareYear} · sur {months} mois
         </span>
         <div className="mt-4">
@@ -168,7 +168,7 @@ const StatisticsKpis = ({
 
       <Card label="Moyenne / mois">
         <Value amount={avg} />
-        <span className="text-[12px] text-ink-3">
+        <span className="text-xs text-ink-3">
           <Delta down={avgDelta <= 0}>{euro0(Math.abs(avgDelta))} €</Delta> vs moyenne {compareYear} (
           <span className="num font-medium text-ink">{euro0(compareAvg)} €</span>)
         </span>

--- a/front/src/components/statistics/StatisticsMonthlyChart.tsx
+++ b/front/src/components/statistics/StatisticsMonthlyChart.tsx
@@ -118,14 +118,14 @@ const StatisticsMonthlyChart = ({
   return (
     <GlowCard
       as="section"
-      className="px-6 py-[22px]"
+      className="px-6 py-5.5"
     >
       <div className="flex flex-wrap items-baseline justify-between gap-4">
         <div>
           <CardTitle>Dépenses mensuelles</CardTitle>
-          <p className="mt-0.5 text-[12px] text-ink-4">{subtitle}</p>
+          <p className="mt-0.5 text-xs text-ink-4">{subtitle}</p>
         </div>
-        <div className="flex flex-wrap items-center gap-[18px] text-[12px] text-ink-3">
+        <div className="flex flex-wrap items-center gap-4.5 text-xs text-ink-3">
           <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-accent-strong" />}>{year}</LegendItem>
           {showExceptionals && (
             <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-exc" />}>
@@ -150,7 +150,7 @@ const StatisticsMonthlyChart = ({
 
       <div
         ref={ref}
-        className="mt-[18px] w-full"
+        className="mt-4.5 w-full"
       >
         {width > 0 && (
           <svg

--- a/front/src/components/statistics/StatisticsTopCategories.tsx
+++ b/front/src/components/statistics/StatisticsTopCategories.tsx
@@ -50,14 +50,14 @@ const Trend = ({ deltaPct }: { deltaPct: number | null }) => {
 /** "Top catégories" — the year's largest categories with their real
  *  year-over-year trend (all figures from /statistics). */
 const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesProps) => (
-  <GlowCard className="flex flex-col px-6 py-[22px]">
+  <GlowCard className="flex flex-col px-6 py-5.5">
     <CardSectionHeader
       title="Top catégories"
       meta={`tendance vs ${compareYear}`}
     />
 
-    <div className="mt-[18px] flex flex-col">
-      <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-[10.5px] font-medium uppercase tracking-[0.08em] text-ink-4">
+    <div className="mt-4.5 flex flex-col">
+      <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-2xs font-medium uppercase tracking-caps text-ink-4">
         <span />
         <span>Catégorie</span>
         <span className="text-right">Total</span>
@@ -67,15 +67,15 @@ const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesP
       {rows.map((row) => (
         <div
           key={row.name}
-          className="grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line-soft py-2.5 text-[13px] last:border-b-0"
+          className="grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line-soft py-2.5 text-sm last:border-b-0"
         >
           <span
-            className="size-2 rounded-[2px]"
+            className="size-2 rounded-xs"
             style={{ background: row.color }}
           />
           <span className="truncate capitalize text-ink">{row.name}</span>
           <span className="num text-right font-medium text-ink">{euro0(row.value)} €</span>
-          <span className="num flex justify-end text-right text-[12px]">
+          <span className="num flex justify-end text-right text-xs">
             <Trend deltaPct={row.deltaPct} />
           </span>
         </div>

--- a/front/src/components/ui/checkbox.tsx
+++ b/front/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-sm border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/front/src/components/ui/tabs.tsx
+++ b/front/src/components/ui/tabs.tsx
@@ -18,7 +18,7 @@ function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimi
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-1",
         className,
       )}
       {...props}

--- a/front/src/components/ui/tooltip.tsx
+++ b/front/src/components/ui/tooltip.tsx
@@ -51,7 +51,7 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-xs" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -106,15 +106,15 @@ const CategoryBarTooltip = ({ point, datum }: CategoryBarTooltipProps) => {
     >
       <div className="mb-2 flex items-center gap-2">
         <span
-          className="size-2 shrink-0 rounded-[2px]"
+          className="size-2 shrink-0 rounded-xs"
           style={{ background: datum.color }}
         />
-        <span className="truncate text-[13px] font-medium capitalize text-ink">{datum.name}</span>
-        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-background px-[7px] text-[10.5px] leading-[1.55] text-ink-3">
+        <span className="truncate text-sm font-medium capitalize text-ink">{datum.name}</span>
+        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-background px-2 text-2xs leading-normal text-ink-3">
           {datum.count}
         </span>
       </div>
-      <div className="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-1 text-[12px]">
+      <div className="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-1 text-xs">
         <span className="text-ink-4">Part</span>
         <span className="num text-right text-ink-2">{datum.pct.toFixed(1).replace(".", ",")} %</span>
         <span className="text-ink-4">Montant</span>

--- a/front/src/lib/dataviz/CategoryTrend.tsx
+++ b/front/src/lib/dataviz/CategoryTrend.tsx
@@ -25,7 +25,7 @@ interface CategoryTrendProps extends CategoryTrendData {
 const CategoryTrend = ({ direction, label, className }: CategoryTrendProps) => (
   <span
     className={cn(
-      "num flex items-center justify-end gap-1 text-[11.5px]",
+      "num flex items-center justify-end gap-1 text-2xs",
       direction === "up" && "text-neg",
       direction === "down" && "text-accent-strong",
       direction === "flat" && "text-ink-4",

--- a/front/src/lib/dataviz/ProgressTrack.tsx
+++ b/front/src/lib/dataviz/ProgressTrack.tsx
@@ -142,7 +142,7 @@ const ProgressTrack = ({
           }}
         >
           {markerLabel && (
-            <span className="num absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-line bg-surface-elev px-1.5 py-px text-[11px] text-ink">
+            <span className="num absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap rounded border border-line bg-surface-elev px-1.5 py-px text-2xs text-ink">
               {markerLabel}
             </span>
           )}


### PR DESCRIPTION
Replace ~206 arbitrary scale values with tokens across 34 files, in one deterministic pass. The values were never page-specific (text-[13px] in 14 files, rounded-[6px] in 6, incl. shared NavBar/UserMenu/FieldShell/ dataviz that belong to no page ticket), and the mapping is context-free, so sweeping globally beats re-deciding it per page.

~87 map exactly (0px delta): text 12/14/20/24/30px, radius 2/6/8/10/14px, tracking -0.025em/0.08em, spacing 18px->4.5 / 22px->5.5. The rest snap by <=2px onto the scale.

Drop FieldShell's labelClassName prop: its only consumers were 5 ExceptionalModal overrides pinning the label to 13px, which the snap collapsed into the component's own text-sm default.

Preserved one-offs: AuthCard's paired rounded-[25px]/[26px], the tracking-[0.22em] label, leading-[0], and every structural dimension.

Absorbs the token work of COS-66, COS-68, COS-69 and COS-70.