### PR TITLE
refactor(ui): auth form kit (COS-69)

### DIFF
--- a/front/src/app/(public)/signup/page.tsx
+++ b/front/src/app/(public)/signup/page.tsx
@@ -4,8 +4,8 @@ import useCredentials from "@auth/helpers/useCredentials";
 import useSignupService from "@auth/useSignupService";
 import AuthBrand from "@components/auth/AuthBrand";
 import AuthCard from "@components/auth/AuthCard";
+import { AuthSwitchLink } from "@components/auth/AuthSwitchLink";
 import SharedLoginForm from "@components/shared/sharedLoginForm/sharedLoginForm";
-import Link from "next/link";
 
 import type { LoginValues } from "@components/shared/sharedLoginForm/interfaces";
 
@@ -35,15 +35,11 @@ export default function SignUp() {
         displayConfirmPasswordField
       />
 
-      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-4.5 text-xs text-ink-3">
-        Déjà un compte ?{" "}
-        <Link
-          href="/login"
-          className="font-medium text-[oklch(0.82_0.12_165)] hover:underline"
-        >
-          Se connecter
-        </Link>
-      </div>
+      <AuthSwitchLink
+        prompt="Déjà un compte ?"
+        href="/login"
+        label="Se connecter"
+      />
     </AuthCard>
   );
 }

--- a/front/src/components/auth/AuthSwitchLink.tsx
+++ b/front/src/components/auth/AuthSwitchLink.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+interface AuthSwitchLinkProps {
+  /** Question preceding the link, e.g. "Pas encore de compte ?". */
+  prompt: string;
+  href: string;
+  label: string;
+}
+
+/**
+ * Footer rule of the auth card, sending the user to the opposite screen
+ * (login ⇄ signup).
+ *
+ * The oklch link colour is a deliberate one-off rather than a missed token —
+ * see `authInputClass` for why the auth screen keeps its own teal-shifted
+ * accent family instead of the app's `--accent-strong`.
+ */
+const AuthSwitchLink = ({ prompt, href, label }: AuthSwitchLinkProps) => (
+  <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-4.5 text-xs text-ink-3">
+    {prompt}{" "}
+    <Link
+      href={href}
+      className="font-medium text-[oklch(0.82_0.12_165)] hover:underline"
+    >
+      {label}
+    </Link>
+  </div>
+);
+
+export { AuthSwitchLink };

--- a/front/src/components/login/LoginFormClient.tsx
+++ b/front/src/components/login/LoginFormClient.tsx
@@ -4,6 +4,7 @@ import useCredentials from "@auth/helpers/useCredentials";
 import useLoginService from "@auth/useLoginService";
 import AuthBrand from "@components/auth/AuthBrand";
 import AuthCard from "@components/auth/AuthCard";
+import { AuthSwitchLink } from "@components/auth/AuthSwitchLink";
 import SharedLoginForm from "@src/components/shared/sharedLoginForm/sharedLoginForm";
 import Link from "next/link";
 import { useState } from "react";
@@ -56,15 +57,11 @@ export default function LoginFormClient() {
         </Link>
       </div>
 
-      <div className="mt-5 flex justify-center gap-1.5 border-t border-white/[0.07] pt-4.5 text-xs text-ink-3">
-        Pas encore de compte ?{" "}
-        <Link
-          href="/signup"
-          className="font-medium text-[oklch(0.82_0.12_165)] hover:underline"
-        >
-          Créer un compte
-        </Link>
-      </div>
+      <AuthSwitchLink
+        prompt="Pas encore de compte ?"
+        href="/signup"
+        label="Créer un compte"
+      />
     </AuthCard>
   );
 }

--- a/front/src/components/shared/sharedLoginForm/PasswordField.tsx
+++ b/front/src/components/shared/sharedLoginForm/PasswordField.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { overlineClass } from "@components/shared/Overline";
+import { authInputClass } from "@components/shared/sharedLoginForm/authInputClass";
+import { cn } from "@lib/utils";
+import { Eye, EyeOff } from "lucide-react";
+import { useState } from "react";
+
+import type { UseFormRegisterReturn } from "react-hook-form";
+
+interface PasswordFieldProps {
+  id: string;
+  label: string;
+  autoComplete: string;
+  invalid: boolean;
+  registration: UseFormRegisterReturn;
+}
+
+/** Auth password input with its own show/hide toggle. */
+const PasswordField = ({ id, label, autoComplete, invalid, registration }: PasswordFieldProps) => {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label
+        htmlFor={id}
+        className={overlineClass}
+      >
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={show ? "text" : "password"}
+          placeholder="••••••••"
+          autoComplete={autoComplete}
+          className={cn(authInputClass, "pr-10.5")}
+          aria-invalid={invalid}
+          {...registration}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((p) => !p)}
+          className="absolute right-[7px] top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-md text-ink-4 transition-colors hover:bg-white/[0.06] hover:text-ink-2"
+          tabIndex={-1}
+          aria-label={show ? "Masquer le mot de passe" : "Afficher le mot de passe"}
+        >
+          {show ? <EyeOff className="size-[15px]" /> : <Eye className="size-[15px]" />}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export { PasswordField };

--- a/front/src/components/shared/sharedLoginForm/authInputClass.ts
+++ b/front/src/components/shared/sharedLoginForm/authInputClass.ts
@@ -1,0 +1,12 @@
+/**
+ * Input skin for the auth forms, shared by the plain fields and `PasswordField`.
+ *
+ * The oklch literals are deliberate one-offs, not un-tokenized leftovers: the auth
+ * screen runs a teal-shifted accent family (165 link, 175 focus, 185/150 halo,
+ * 148→200 tab underline) that matches `AuthCard`'s gradient border and halo.
+ * Routing focus through the app's `--accent-d` (hue 148) would clash with the
+ * card's teal. The translucent fill is likewise load-bearing — it lets the glass
+ * card show through, which an opaque `bg-bg` would kill.
+ */
+export const authInputClass =
+  "w-full rounded-sm border border-line px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { overlineClass } from "@components/shared/Overline";
+import { authInputClass } from "@components/shared/sharedLoginForm/authInputClass";
+import { PasswordField } from "@components/shared/sharedLoginForm/PasswordField";
 import { Button } from "@components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@components/ui/select";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { cn } from "@lib/utils";
 import currencyCodes from "@src/currency-codes.json";
 import getSymbolFromCurrency from "currency-symbol-map";
-import { ArrowRight, Eye, EyeOff } from "lucide-react";
-import { useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -28,8 +28,6 @@ const buildSchema = (needEmail: boolean, needPassword: boolean, needConfirm: boo
     });
 
 const LABEL = overlineClass;
-const INPUT_BASE =
-  "w-full rounded-sm border px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] border-[oklch(0.30_0.010_250)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";
 
 /**
  * Single shared message slot for the auth forms. Always rendered — it reserves one
@@ -57,9 +55,6 @@ const SharedLoginForm = ({
   serverError,
   onDismissError,
 }: SharedLoginFormProps) => {
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirm, setShowConfirm] = useState(false);
-
   const schema = buildSchema(
     !!displayEmailField,
     !!displayPasswordField,
@@ -117,7 +112,7 @@ const SharedLoginForm = ({
             type="email"
             placeholder="vous@example.com"
             autoComplete="email"
-            className={INPUT_BASE}
+            className={authInputClass}
             aria-invalid={!!errors.email}
             {...register("email", { onChange: clearFieldError("email") })}
           />
@@ -125,67 +120,23 @@ const SharedLoginForm = ({
       )}
 
       {displayPasswordField && (
-        <div className="flex flex-col gap-1.5">
-          <label
-            htmlFor="password"
-            className={LABEL}
-          >
-            Mot de passe
-          </label>
-          <div className="relative">
-            <input
-              id="password"
-              type={showPassword ? "text" : "password"}
-              placeholder="••••••••"
-              autoComplete={displayConfirmPasswordField ? "new-password" : "current-password"}
-              className={cn(INPUT_BASE, "pr-10.5")}
-              aria-invalid={!!errors.password}
-              {...register("password", { onChange: clearFieldError("password") })}
-            />
-            <button
-              type="button"
-              onClick={() => setShowPassword((p) => !p)}
-              className="absolute right-[7px] top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-md text-ink-4 transition-colors hover:bg-white/[0.06] hover:text-ink-2"
-              tabIndex={-1}
-              aria-label={showPassword ? "Masquer le mot de passe" : "Afficher le mot de passe"}
-            >
-              {showPassword ? <EyeOff className="size-[15px]" /> : <Eye className="size-[15px]" />}
-            </button>
-          </div>
-        </div>
+        <PasswordField
+          id="password"
+          label="Mot de passe"
+          autoComplete={displayConfirmPasswordField ? "new-password" : "current-password"}
+          invalid={!!errors.password}
+          registration={register("password", { onChange: clearFieldError("password") })}
+        />
       )}
 
       {displayConfirmPasswordField && (
-        <div className="flex flex-col gap-1.5">
-          <label
-            htmlFor="confirmPassword"
-            className={LABEL}
-          >
-            Confirmer le mot de passe
-          </label>
-          <div className="relative">
-            <input
-              id="confirmPassword"
-              type={showConfirm ? "text" : "password"}
-              placeholder="••••••••"
-              autoComplete="new-password"
-              className={cn(INPUT_BASE, "pr-10.5")}
-              aria-invalid={!!errors.confirmPassword}
-              {...register("confirmPassword", {
-                onChange: clearFieldError("confirmPassword"),
-              })}
-            />
-            <button
-              type="button"
-              onClick={() => setShowConfirm((p) => !p)}
-              className="absolute right-[7px] top-1/2 grid size-7 -translate-y-1/2 place-items-center rounded-md text-ink-4 transition-colors hover:bg-white/[0.06] hover:text-ink-2"
-              tabIndex={-1}
-              aria-label={showConfirm ? "Masquer le mot de passe" : "Afficher le mot de passe"}
-            >
-              {showConfirm ? <EyeOff className="size-[15px]" /> : <Eye className="size-[15px]" />}
-            </button>
-          </div>
-        </div>
+        <PasswordField
+          id="confirmPassword"
+          label="Confirmer le mot de passe"
+          autoComplete="new-password"
+          invalid={!!errors.confirmPassword}
+          registration={register("confirmPassword", { onChange: clearFieldError("confirmPassword") })}
+        />
       )}
 
       {displayCurrencyField && (


### PR DESCRIPTION
Extract PasswordField (the COS-91 deferral): the password and confirm blocks were near-identical label+input+eye-toggle markup, differing only in id/label/autoComplete. The toggle state now lives in the component, dropping two useState from the form.

Extract AuthSwitchLink: the login<->signup footer was duplicated byte-for-byte across LoginFormClient and signup/page.

Extract authInputClass so the plain fields and PasswordField share one input skin, and snap its border oklch(0.30 0.010 250) -> border-line.

Keep auth's teal accent family (165 link, 175 focus) as documented one-offs rather than folding it into --accent-strong: it is tuned to AuthCard's gradient border, and the app's hue-148 green would clash. The literals now live in exactly one place each.