### PR TITLE
refactor(ui): spendings colour tokens (COS-96)

### DIFF
--- a/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
@@ -1,3 +1,4 @@
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import spendingsText from "@components/spendings/config/text";
 import useClickSort from "@components/spendings/helpers/useClickSort";
@@ -75,24 +76,24 @@ const SpendingDayItem = ({
   const getCategories = (items: SpendingItemType[]) =>
     Array.from(new Set(items.map((s) => s.category).filter((c): c is string | null => c !== undefined)));
   const getCategoryColor = (category: string | null) =>
-    categorySpendings.find((s) => s.category === category)?.categoryColor ?? "#94a3b8";
+    categorySpendings.find((s) => s.category === category)?.categoryColor ?? CATEGORY_FALLBACK;
 
   return (
     <div
       className={cn(
         "relative bg-gradient-to-br from-[#121212] via-[#0a0a0a] to-black rounded-lg border overflow-hidden transition-all shadow-xl flex flex-col h-full",
-        isToday ? "border-cyan-300" : "border-gray-800/50 hover:border-gray-700/50",
+        isToday ? "border-elec" : "border-line-soft hover:border-line",
       )}
     >
       {/* Header */}
-      <div className="bg-linear-to-r from-gray-800/60 to-gray-800/40 px-4 py-2.5 border-b border-gray-700/50 shrink-0">
+      <div className="bg-linear-to-r from-surface-hi/60 to-surface-hi/40 px-4 py-2.5 border-b border-line shrink-0">
         <div className="flex items-center justify-between mb-2">
-          <div className={cn("text-sm", isToday ? "text-cyan-300 font-semibold" : "text-gray-200")}>
+          <div className={cn("text-sm", isToday ? "text-elec font-semibold" : "text-ink-2")}>
             {date ? format(date, "dd MMM yyyy", { locale: fr }) : "—"}
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-gray-400 text-xs uppercase tracking-wide">{spendingsText.dayItem.total}</span>
-            <span className="text-gray-100 text-sm tabular-nums">{Number(displayTotal).toFixed(2)} €</span>
+            <span className="text-ink-4 text-xs uppercase tracking-wide">{spendingsText.dayItem.total}</span>
+            <span className="text-ink text-sm tabular-nums">{Number(displayTotal).toFixed(2)} €</span>
           </div>
         </div>
 
@@ -133,7 +134,7 @@ const SpendingDayItem = ({
               <button
                 type="button"
                 onClick={() => setSelectedCategory(null)}
-                className="px-2 py-0.5 rounded text-2xs uppercase font-medium bg-gray-700/60 text-gray-200 hover:bg-gray-600"
+                className="px-2 py-0.5 rounded text-2xs uppercase font-medium bg-surface-hi text-ink-2 hover:bg-surface-hover"
               >
                 {spendingsText.dayItem.filterResetLabel}
               </button>
@@ -154,7 +155,7 @@ const SpendingDayItem = ({
             type="button"
             onClick={addSpending}
             disabled={!addSpendingEnabled}
-            className="mt-auto w-full inline-flex items-center justify-center gap-1.5 py-2 rounded-md border border-dashed border-gray-700/60 text-gray-500 text-xs uppercase tracking-wide font-medium transition-all hover:border-cyan-500/60 hover:text-cyan-400 hover:bg-cyan-500/5 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-gray-700/60 disabled:hover:text-gray-500 disabled:hover:bg-transparent"
+            className="mt-auto w-full inline-flex items-center justify-center gap-1.5 py-2 rounded-md border border-dashed border-line text-ink-5 text-xs uppercase tracking-wide font-medium transition-all hover:border-elec/60 hover:text-elec hover:bg-elec/5 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-line disabled:hover:text-ink-5 disabled:hover:bg-transparent"
           >
             <Plus className="w-3.5 h-3.5" />
             Ajouter une dépense
@@ -162,9 +163,9 @@ const SpendingDayItem = ({
         )}
 
         {!recurringType && isToday && (
-          <div className="mt-2 pt-2 border-t border-gray-800/50 flex items-center justify-between text-xs">
-            <span className="text-gray-500">{spendingsText.dayItem.remainingBudget}</span>
-            <span className="text-cyan-400 font-semibold">{Math.trunc(todayCredits)} €</span>
+          <div className="mt-2 pt-2 border-t border-line-soft flex items-center justify-between text-xs">
+            <span className="text-ink-5">{spendingsText.dayItem.remainingBudget}</span>
+            <span className="text-elec font-semibold">{Math.trunc(todayCredits)} €</span>
           </div>
         )}
       </div>

--- a/front/src/components/spendings/spendingDayItem/spendingItem/SpendingItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/spendingItem/SpendingItem.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import InvoiceModal from "@components/spendings/invoiceModal/InvoiceModal";
 import useReccurings from "@components/spendings/services/useReccurings";
 import useSpendings from "@components/spendings/services/useSpendings";
@@ -42,19 +43,19 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
 
   if (isDeleteConfirmVisible) {
     return (
-      <div className="flex items-center gap-2 py-2 px-3 bg-red-900/20 border border-red-600/40 rounded">
-        <span className="text-gray-200 text-sm flex-1">Supprimer cette dépense ?</span>
+      <div className="flex items-center gap-2 py-2 px-3 bg-danger-surface border border-danger-border-soft rounded">
+        <span className="text-ink-2 text-sm flex-1">Supprimer cette dépense ?</span>
         <button
           type="button"
           onClick={onCancelDelete}
-          className="px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-200 rounded transition-colors text-sm"
+          className="px-3 py-1.5 bg-surface-hi hover:bg-surface-hover text-ink-2 rounded transition-colors text-sm"
         >
           Annuler
         </button>
         <button
           type="button"
           onClick={onConfirmDelete}
-          className="px-3 py-1.5 bg-red-600 hover:bg-red-700 text-white rounded transition-colors text-sm"
+          className="px-3 py-1.5 bg-danger-solid hover:brightness-110 text-on-danger rounded transition-colors text-sm"
         >
           Confirmer
         </button>
@@ -63,7 +64,8 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
   }
 
   const category = "category" in spending ? spending.category : null;
-  const categoryColor = "categoryColor" in spending && spending.categoryColor ? spending.categoryColor : "#94a3b8";
+  const categoryColor =
+    "categoryColor" in spending && spending.categoryColor ? spending.categoryColor : CATEGORY_FALLBACK;
 
   return (
     <>
@@ -73,7 +75,7 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
           spending={spending}
         />
       )}
-      <div className="group flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 py-1.5 hover:bg-gray-800/40 rounded px-2 transition-colors">
+      <div className="group flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2 py-1.5 hover:bg-surface-hover rounded px-2 transition-colors">
         <div className="flex items-center gap-2 sm:contents">
           <div
             className="w-1 h-5 rounded-full flex-shrink-0"
@@ -81,13 +83,13 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
           />
 
           <span
-            className="text-gray-300 text-sm flex-1 min-w-0 truncate"
+            className="text-ink-3 text-sm flex-1 min-w-0 truncate"
             title={spendingLabel}
           >
             {spendingLabel}
           </span>
 
-          <span className="text-gray-100 text-sm shrink-0 tabular-nums sm:hidden">
+          <span className="text-ink text-sm shrink-0 tabular-nums sm:hidden">
             {Number(spending.amount).toFixed(2)} €
           </span>
         </div>
@@ -111,19 +113,19 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
               onClick={() => setIsInvoiceModalVisible(true)}
               className={cn(
                 "w-6 h-6 rounded flex items-center justify-center transition-colors cursor-pointer",
-                hasInvoice ? "bg-emerald-700/80 hover:bg-emerald-600" : "bg-gray-700/80 hover:bg-cyan-600",
+                hasInvoice ? "bg-accent-d/80 hover:bg-accent-d" : "bg-surface-hi hover:bg-elec",
               )}
               title="Facture"
             >
-              <ImageIcon className="w-3 h-3 text-gray-200" />
+              <ImageIcon className="w-3 h-3 text-ink-2" />
             </button>
             <button
               type="button"
               onClick={() => editCallback(spending)}
-              className="w-6 h-6 bg-gray-700/80 hover:bg-gray-600 rounded flex items-center justify-center transition-colors cursor-pointer"
+              className="w-6 h-6 bg-surface-hi hover:bg-surface-hover rounded flex items-center justify-center transition-colors cursor-pointer"
               title="Modifier"
             >
-              <Edit2 className="w-3 h-3 text-gray-300" />
+              <Edit2 className="w-3 h-3 text-ink-3" />
             </button>
             <button
               type="button"
@@ -131,14 +133,14 @@ const SpendingItem = ({ spending, editCallback, toggleAddSpending, isRecurring }
                 toggleAddSpending();
                 setIsDeleteConfirmVisible(true);
               }}
-              className="w-6 h-6 bg-gray-700/80 hover:bg-red-600 rounded flex items-center justify-center transition-colors cursor-pointer"
+              className="w-6 h-6 bg-surface-hi hover:bg-danger-solid rounded flex items-center justify-center transition-colors cursor-pointer"
               title="Supprimer"
             >
-              <Trash2 className="w-3 h-3 text-gray-300 group-hover:text-white" />
+              <Trash2 className="w-3 h-3 text-ink-3 group-hover:text-ink" />
             </button>
           </div>
 
-          <span className="hidden sm:inline text-gray-100 text-sm shrink-0 min-w-[70px] text-right tabular-nums">
+          <span className="hidden sm:inline text-ink text-sm shrink-0 min-w-[70px] text-right tabular-nums">
             {Number(spending.amount).toFixed(2)} €
           </span>
         </div>

--- a/front/src/components/spendings/spendingSort/SpendingSort.tsx
+++ b/front/src/components/spendings/spendingSort/SpendingSort.tsx
@@ -13,7 +13,7 @@ const SortPill = ({ label, onClick }: { label: string; onClick: () => void }) =>
   <button
     type="button"
     onClick={onClick}
-    className="px-2 py-1 bg-gray-700/60 hover:bg-gray-600/80 rounded text-gray-300 text-xs transition-colors inline-flex items-center gap-1 cursor-pointer"
+    className="px-2 py-1 bg-surface-hi hover:bg-surface-hover rounded text-ink-3 text-xs transition-colors inline-flex items-center gap-1 cursor-pointer"
   >
     {label}
     <ArrowDownUp className="w-3 h-3" />

--- a/front/src/components/spendings/spendingsListContainer/SpendingListContainer.tsx
+++ b/front/src/components/spendings/spendingsListContainer/SpendingListContainer.tsx
@@ -19,7 +19,7 @@ const SpendingsListContainer = ({
   }
 
   if (!spendingsByDaySorted?.length) {
-    return <div className="flex justify-center items-center min-h-[80px] text-gray-500 text-xs">Aucune dépense</div>;
+    return <div className="flex justify-center items-center min-h-[80px] text-ink-5 text-xs">Aucune dépense</div>;
   }
 
   return (


### PR DESCRIPTION
Route the last 50 raw pre-DS palette colours (gray/cyan/emerald/red) in the Dépenses page onto the token vocabulary — the colour axis COS-65 missed while adopting the typo/spacing/radius scales.

The mapping is semantic, and the tokens already existed:
- cyan-* was the isToday highlight -> --elec, which is annotated /* "aujourd'hui" */ for exactly this.
- The inline delete-confirm bar -> --danger-surface/--danger-border-soft, which COS-82 created as "inline confirm bar bg/border", and --danger-solid/--on-danger for its confirm button.
- emerald invoice pill -> accent-d; gray-100..500 -> ink..ink-5 ordinally, preserving the hierarchy; gray borders/fills -> line/line-soft and surface-hi/surface-hover.

Also drop the hardcoded #94a3b8 in both files for CATEGORY_FALLBACK, which COS-89 already introduced.

Left as-is: the bespoke near-black card gradient (from-[#121212] to-black) — flattening it to a surface token would be a redesign, not a tokenisation.