### PR TITLE
refactor(ui): last raw-palette files (COS-98)

### DIFF
--- a/front/src/app/error.tsx
+++ b/front/src/app/error.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Button } from "@components/ui/button";
 import { useEffect } from "react";
 
 interface ErrorPageProps {
@@ -13,34 +14,32 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
   }, [error]);
 
   return (
-    <div className="min-h-screen w-full bg-gradient-to-br from-slate-900 via-slate-800 to-slate-700 px-4 py-16">
-      <div className="mx-auto flex max-w-2xl flex-col items-center rounded-xl border border-slate-400/20 bg-slate-900/50 p-8 text-slate-100 shadow-2xl backdrop-blur-sm">
-        <p className="mb-2 text-xs uppercase tracking-[0.22em] text-amber-300">Application Error</p>
+    <div className="min-h-screen w-full bg-bg px-4 py-16">
+      <div className="mx-auto flex max-w-2xl flex-col items-center rounded-xl border border-line bg-surface-elev p-8 text-ink shadow-card backdrop-blur-sm">
+        <p className="mb-2 text-xs uppercase tracking-[0.22em] text-neg">Application Error</p>
         <h1 className="mb-4 text-center text-3xl font-bold">Something went wrong</h1>
-        <p className="mb-8 text-center text-sm text-slate-300">
+        <p className="mb-8 text-center text-sm text-ink-3">
           The page failed to load. You can retry now or go back to the dashboard.
         </p>
 
         <div className="flex flex-wrap items-center justify-center gap-3">
-          <button
+          <Button
             type="button"
+            variant="primary"
             onClick={reset}
-            className="rounded-sm bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400"
           >
             Retry
-          </button>
-          <a
-            href="/dashboard"
-            className="rounded-sm border border-slate-300/50 px-4 py-2 text-sm font-semibold text-slate-100 hover:bg-slate-100 hover:text-slate-900"
+          </Button>
+          <Button
+            variant="muted"
+            asChild
           >
-            Back to dashboard
-          </a>
+            <a href="/dashboard">Back to dashboard</a>
+          </Button>
         </div>
 
         {process.env.NODE_ENV !== "production" && (
-          <pre className="mt-6 w-full overflow-auto rounded-sm bg-slate-950 p-3 text-xs text-rose-300">
-            {error.message}
-          </pre>
+          <pre className="mt-6 w-full overflow-auto rounded-sm bg-bg p-3 text-xs text-neg">{error.message}</pre>
         )}
       </div>
     </div>

--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -78,17 +78,17 @@ const DatePickerWrapper = () => {
         type="button"
         onClick={toggleCalendar}
         className={cn(
-          "inline-flex select-none items-center gap-2.5 whitespace-nowrap rounded-lg border px-3.5 py-2 text-sm text-gray-200 shadow-lg transition-colors hover:cursor-pointer",
+          "inline-flex select-none items-center gap-2.5 whitespace-nowrap rounded-lg border px-3.5 py-2 text-sm text-ink-2 shadow-lg transition-colors hover:cursor-pointer",
           isCalendarVisible
-            ? "border-accent-d bg-[#151515]"
-            : "border-gray-700/50 bg-[#0c0c0c] hover:border-gray-600 hover:bg-[#151515]",
+            ? "border-accent-d bg-surface-elev"
+            : "border-line bg-bg hover:border-ink-4 hover:bg-surface-elev",
         )}
       >
-        <CalendarIcon className="size-4 shrink-0 text-gray-400" />
+        <CalendarIcon className="size-4 shrink-0 text-ink-4" />
         {selectedDays.length > 0 ? (
           <span className="num text-sm tracking-snug">
             {format(selectedDays[0], "dd MMM yyyy", { locale: fr })}
-            <span className="mx-1 text-gray-500">—</span>
+            <span className="mx-1 text-ink-5">—</span>
             {format(selectedDays[selectedDays.length - 1], "dd MMM yyyy", {
               locale: fr,
             })}
@@ -97,7 +97,7 @@ const DatePickerWrapper = () => {
           <span className="text-sm">Sélectionner une période</span>
         )}
         <ChevronDown
-          className={cn("size-3.5 shrink-0 text-gray-500 transition-transform", isCalendarVisible && "rotate-180")}
+          className={cn("size-3.5 shrink-0 text-ink-5 transition-transform", isCalendarVisible && "rotate-180")}
         />
       </button>
       {isCalendarVisible && (


### PR DESCRIPTION
Tokenize the final two files still on the pre-DS Tailwind palette. src/ now contains zero raw palette colours; the only hex left are the invoice paper, the contrast-math helpers, the category colour system and the one documented card gradient.

error.tsx was hand-rolling a card and two buttons the DS already owns:
- page from-slate-900..to-slate-700 -> bg-bg (the slate gradient bore no relation to the palette; the error page now looks like the app)
- card -> border-line/bg-surface-elev/text-ink + shadow-card
- Retry -> Button variant=primary, Back -> Button variant=muted asChild, dropping the hand-rolled button CSS
- text-amber-300 -> text-neg: there is no amber/warning token, and on an error page --neg already carries that meaning

DatePickerWrapper: greys -> ink-2/4/5, borders -> line + hover:border-ink-4 (the comboboxTriggerClass idiom), and its two raw hex fills (#0c0c0c/#151515) -> bg-bg / bg-surface-elev.