### PR TITLE
refactor(ui): unify cards on GlowCard (COS-100)

### DIFF
--- a/front/src/components/categories/CategoryItem.tsx
+++ b/front/src/components/categories/CategoryItem.tsx
@@ -3,6 +3,7 @@
 import { CategoryColorDot } from "@components/categories/CategoryColorDot";
 import CategoryFormModal from "@components/categories/CategoryFormModal";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
+import GlowCard from "@components/shared/GlowCard";
 import { IconButton } from "@components/shared/IconButton";
 import { Pencil, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -29,7 +30,10 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
 
   return (
     <>
-      <div className="pfa-card pfa-card-hover flex flex-col gap-2.5 rounded-lg px-4 pb-3 pt-3.5">
+      <GlowCard
+        hover
+        className="flex flex-col gap-2.5 px-4 pb-3 pt-3.5"
+      >
         <div className="flex items-center gap-2.5">
           <CategoryColorDot
             color={category.color}
@@ -69,7 +73,7 @@ const CategoryItem = ({ category, used, share, takenNames, onSave, onDelete }: C
             </>
           )}
         </span>
-      </div>
+      </GlowCard>
 
       <CategoryFormModal
         open={isEditOpen}

--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -3,6 +3,7 @@
 import EditGlyph from "@components/dashboard/EditGlyph";
 import DailySparkline from "@components/dashboard/sections/DailySparkline";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
 import { MoneyAmount } from "@components/shared/MoneyAmount";
 import useDashboard from "@components/spendings/services/useDashboard";
@@ -79,7 +80,10 @@ const BudgetHero = () => {
   }, [editing, setFocus]);
 
   return (
-    <section className="pfa-card flex flex-col px-7 py-6">
+    <GlowCard
+      as="section"
+      className="flex flex-col px-7 py-6"
+    >
       <div className="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex flex-col">
           <span className="text-xs font-medium uppercase tracking-widest text-ink-3">
@@ -181,7 +185,7 @@ const BudgetHero = () => {
       </div>
 
       <DailySparkline />
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -5,6 +5,7 @@ import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import { EmptyState } from "@components/shared/EmptyState";
+import GlowCard from "@components/shared/GlowCard";
 import { MONTHLY } from "@components/spendings/config/constants";
 import useCharts from "@components/spendings/services/useCharts";
 import useSpendings from "@components/spendings/services/useSpendings";
@@ -71,7 +72,10 @@ const CategoryBreakdown = () => {
   });
 
   return (
-    <section className="pfa-card flex max-h-137.5 min-h-80 flex-col gap-4 px-6 py-5">
+    <GlowCard
+      as="section"
+      className="flex max-h-137.5 min-h-80 flex-col gap-4 px-6 py-5"
+    >
       <CardSectionHeader
         title="Répartition par catégorie"
         meta={`${monthLabel} · part des variables`}
@@ -131,7 +135,7 @@ const CategoryBreakdown = () => {
           total={selected.value}
         />
       )}
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -2,6 +2,7 @@
 
 import { CardTitle } from "@components/shared/CardSectionHeader";
 import { EmptyState } from "@components/shared/EmptyState";
+import GlowCard from "@components/shared/GlowCard";
 import { IconButton } from "@components/shared/IconButton";
 import { MoneyAmount } from "@components/shared/MoneyAmount";
 import { Overline } from "@components/shared/Overline";
@@ -61,7 +62,10 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
   const upcomingSum = upcoming.reduce((a, r) => a + Number(r.amount), 0);
 
   return (
-    <section className="pfa-card flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5">
+    <GlowCard
+      as="section"
+      className="flex max-h-[550px] min-h-[320px] flex-col gap-4 px-6 py-5"
+    >
       <div className="flex items-start justify-between">
         <div>
           <CardTitle>Dépenses fixes</CardTitle>
@@ -217,7 +221,7 @@ const FixedExpenses = ({ month }: FixedExpensesProps) => {
           spending={invoiceFor}
         />
       )}
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/dashboard/sections/ForecastStrip.tsx
+++ b/front/src/components/dashboard/sections/ForecastStrip.tsx
@@ -4,6 +4,7 @@
 // (spent / days-elapsed × days-in-month). Spent + budget are real.
 
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
 import { Overline } from "@components/shared/Overline";
 import useDashboard from "@components/spendings/services/useDashboard";
@@ -40,7 +41,10 @@ const ForecastStrip = () => {
   const delta = projection - budget;
 
   return (
-    <section className="pfa-card grid grid-cols-1 items-center gap-6 px-6 py-5 sm:grid-cols-[200px_1fr_200px] sm:gap-8">
+    <GlowCard
+      as="section"
+      className="grid grid-cols-1 items-center gap-6 px-6 py-5 sm:grid-cols-[200px_1fr_200px] sm:gap-8"
+    >
       <div className="flex flex-col gap-1">
         <Overline>Dépensé · {format(asOf, "d MMM", { locale: fr })}</Overline>
         <AnimatedNumber
@@ -114,7 +118,7 @@ const ForecastStrip = () => {
           {delta > 0 ? "au-dessus" : "sous budget"}
         </span>
       </div>
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -4,6 +4,7 @@ import EditGlyph from "@components/dashboard/EditGlyph";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import { EmptyState } from "@components/shared/EmptyState";
+import GlowCard from "@components/shared/GlowCard";
 import useWeeklyStatsHelper from "@components/spendings/helpers/useWeeklyStatsHelper";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useWeeklyStats from "@components/spendings/services/useWeeklyStats";
@@ -77,7 +78,10 @@ const WeeklyCeiling = () => {
   }, [editing, setFocus]);
 
   return (
-    <section className="pfa-card flex flex-col gap-4 px-6 py-5">
+    <GlowCard
+      as="section"
+      className="flex flex-col gap-4 px-6 py-5"
+    >
       <CardSectionHeader
         title="Plafond hebdomadaire"
         className="items-center"
@@ -189,7 +193,7 @@ const WeeklyCeiling = () => {
           dépassement
         </div>
       )}
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/exceptionals/ExceptionalStatsCards.tsx
+++ b/front/src/components/exceptionals/ExceptionalStatsCards.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { computeExceptionalStats } from "@components/exceptionals/helpers/exceptionalStats";
+import GlowCard from "@components/shared/GlowCard";
 import { StatTile } from "@components/shared/StatTile";
 import { euro } from "@lib/format";
 import format from "date-fns/format";
@@ -17,12 +18,13 @@ interface ExceptionalStatsCardsProps {
 }
 
 const Kpi = ({ label, value, sub }: { label: string; value: ReactNode; sub: ReactNode }) => (
-  <StatTile
-    className="rounded-xl border border-line-soft bg-surface-elev px-5 py-4.5"
-    label={label}
-    value={value}
-    sub={sub}
-  />
+  <GlowCard className="px-5 py-4.5">
+    <StatTile
+      label={label}
+      value={value}
+      sub={sub}
+    />
+  </GlowCard>
 );
 
 const cur = (unit: string) => <span className="text-lg font-normal text-ink-3">{unit}</span>;

--- a/front/src/components/exceptionals/ExceptionalsList.tsx
+++ b/front/src/components/exceptionals/ExceptionalsList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ExceptionalItem from "@components/exceptionals/ExceptionalItem";
+import GlowCard from "@components/shared/GlowCard";
 import { euro } from "@lib/format";
 import format from "date-fns/format";
 import { fr } from "date-fns/locale";
@@ -60,7 +61,7 @@ const ExceptionalsList = ({ items, onEdit, monthlyAverage }: ExceptionalsListPro
               Total <b className="font-medium text-ink">{euro(group.total)} €</b>
             </span>
           </div>
-          <div className="overflow-hidden rounded-xl border border-line-soft bg-surface-elev">
+          <GlowCard className="overflow-hidden">
             {group.items.map((item) => (
               <ExceptionalItem
                 key={item.ID}
@@ -69,7 +70,7 @@ const ExceptionalsList = ({ items, onEdit, monthlyAverage }: ExceptionalsListPro
                 monthlyAverage={monthlyAverage}
               />
             ))}
-          </div>
+          </GlowCard>
         </section>
       ))}
     </div>

--- a/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
+++ b/front/src/components/spendings/spendingDayItem/SpendingDayItem.tsx
@@ -1,4 +1,5 @@
 import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+import GlowCard from "@components/shared/GlowCard";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
 import spendingsText from "@components/spendings/config/text";
 import useClickSort from "@components/spendings/helpers/useClickSort";
@@ -79,12 +80,7 @@ const SpendingDayItem = ({
     categorySpendings.find((s) => s.category === category)?.categoryColor ?? CATEGORY_FALLBACK;
 
   return (
-    <div
-      className={cn(
-        "relative bg-gradient-to-br from-[#121212] via-[#0a0a0a] to-black rounded-lg border overflow-hidden transition-all shadow-xl flex flex-col h-full",
-        isToday ? "border-elec" : "border-line-soft hover:border-line",
-      )}
-    >
+    <GlowCard className={cn("relative overflow-hidden transition-all flex flex-col h-full", isToday && "border-elec")}>
       {/* Header */}
       <div className="bg-linear-to-r from-surface-hi/60 to-surface-hi/40 px-4 py-2.5 border-b border-line shrink-0">
         <div className="flex items-center justify-between mb-2">
@@ -180,7 +176,7 @@ const SpendingDayItem = ({
           month={month}
         />
       )}
-    </div>
+    </GlowCard>
   );
 };
 


### PR DESCRIPTION
GlowCard is the DS card primitive ("shared by every private-screen card so the KPIs, charts and panels all read as the same material"), but three cards painted themselves instead.

Worst was SpendingDayItem, which hand-rolled a near-black gradient (from-[#121212] via-[#0a0a0a] to-black) + shadow-xl. That made the day card DARKER than the page (L 0.19->0 vs --bg 0.14) while the DS convention is the inverse: a card is a raised surface, lighter than the page (--surface-elev 0.205). Dépenses read as dark wells while the rest of the app read as raised cards. The isToday highlight survives — border-elec overrides the gradient border.

ExceptionalStatsCards was using StatTile's className to hand-roll card chrome; GlowCard now owns the card and StatTile the stat layout. ExceptionalsList's month card got the same treatment.

The 5 dashboard sections and CategoryItem used the raw pfa-card class rather than the component — no visual change, but two ways to build a card is itself the inconsistency. No raw pfa-card remains outside GlowCard.tsx.

Radius: drop the local rounded-lg (10px) overrides that were beating .pfa-card's --r-lg (14px), so every card matches.

Payoff: reworking the card gradient is now one rule in chrome.css.