### PR TITLE
feat(spendings): sticky search + metrics zone (COS-101)

### DIFF
--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -109,7 +109,11 @@ const NavBar = () => {
 
   return (
     <>
-      <header className="pfa-hdr sticky top-0 z-40 mb-7 flex flex-wrap items-center gap-x-3 gap-y-2.5 px-3.5 py-2.5">
+      {/* top-4 (not 0): the layout's pt-4 scrolls away with the page, so a
+          top-0 header ends up glued to the viewport edge once stuck. Matching
+          the padding keeps the detached-bar look at rest AND while scrolling
+          (COS-101). */}
+      <header className="pfa-hdr sticky top-4 z-40 mb-7 flex flex-wrap items-center gap-x-3 gap-y-2.5 px-3.5 py-2.5">
         <IconButton
           variant="ghost"
           size={9}

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -34,13 +34,15 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
 
   return (
     <section className="sp-catrep">
+      {/* Compact margins (mb-3 / mb-2.5): this pane lives in the sticky zone,
+          where height is taken directly from the day cards (COS-101). */}
       <CardSectionHeader
-        className="mb-4.5"
+        className="mb-3"
         title="Répartition par catégorie"
         meta={`${rangeLabel} · semaine`}
       />
 
-      <div className="sp-cat-bar mb-4.5">
+      <div className="sp-cat-bar mb-2.5">
         {rows.map((r) => (
           <span
             key={r.key}

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -159,24 +159,30 @@ const SpendingView = () => {
 
   return (
     <div className="flex flex-col gap-5">
-      <SpendingToolbar
-        search={search}
-        onSearchChange={setSearch}
-      />
+      {/* Search + summary + breakdown stay pinned under the app header while
+          the timeline scrolls (desktop only — see .sp-sticky-zone). Tighter
+          gap than the page flow (12px vs 20px): pinned chrome is denser than
+          scrolling content, and every pixel here is taken from the cards. */}
+      <div className="sp-sticky-zone flex flex-col gap-3">
+        <SpendingToolbar
+          search={search}
+          onSearchChange={setSearch}
+        />
 
-      <SpendingSummary
-        remaining={remaining}
-        weekTotal={weekTotal}
-        txCount={txCount}
-        weeklyCeiling={weeklyCeiling}
-        avgDailyDelta={mockAvgDailyDelta(from.toISOString().slice(0, 10))}
-        biggest={biggest}
-      />
+        <SpendingSummary
+          remaining={remaining}
+          weekTotal={weekTotal}
+          txCount={txCount}
+          weeklyCeiling={weeklyCeiling}
+          avgDailyDelta={mockAvgDailyDelta(from.toISOString().slice(0, 10))}
+          biggest={biggest}
+        />
 
-      <SpendingCategoryBreakdown
-        rows={breakdownRows}
-        rangeLabel={rangeLabel}
-      />
+        <SpendingCategoryBreakdown
+          rows={breakdownRows}
+          rangeLabel={rangeLabel}
+        />
+      </div>
 
       <SpendingCategoryFilter
         categories={filterCategories}

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -7,11 +7,14 @@
    ============================================================ */
 
 /* ---- Category breakdown pane (full width) ---- */
+/* Vertically compact on purpose (COS-101): it lives in the sticky zone, and
+   every pixel it takes is a pixel the day cards lose on a 13" screen. The
+   title/bar margins live in the component (mb-3 / mb-2.5). */
 .sp-catrep {
   background: var(--surface-elev);
   border: 1px solid var(--line-soft);
   border-radius: var(--r-lg);
-  padding: 20px 22px;
+  padding: 14px 22px;
 }
 .sp-cat-bar {
   display: flex;
@@ -35,7 +38,7 @@
   grid-template-columns: 14px minmax(0, 1fr) 76px 88px 60px;
   align-items: center;
   gap: 12px;
-  padding: 11px 8px;
+  padding: 7px 8px;
   margin: 0 -8px;
   border-radius: 8px;
   border-bottom: 1px solid var(--line-soft);
@@ -87,6 +90,33 @@
    document.body, so it is skinned entirely inline in the component — no class
    here, so a rule that fails to resolve at the portal can't leave it bare. */
 
+/* ---- Sticky search + summary + breakdown zone (COS-101) ---- */
+/* Desktop only: pins the toolbar, the five stat widgets and the category
+   breakdown right under the sticky .pfa-hdr while the timeline scrolls. Opaque
+   page background: translucent/blurred variants were tried and rejected — a
+   see-through band shows the cards sliding through it, and a blurred one frosts
+   a rectangle that lines up with neither the header above nor the card borders
+   beside it. Kept below the header (z-40), far below the drawer/scrim
+   (z-110/120). */
+@media (min-width: 768px) {
+  .sp-sticky-zone {
+    position: sticky;
+    /* Header sticks at 16px (NavBar top-4, matching the layout's pt-4) and is
+       ~60px tall → its bottom sits at 76px. */
+    top: 76px;
+    z-index: 30;
+    background: var(--bg);
+    /* Header ↔ search gap, owned here rather than by the header's own mb-7:
+       the negative margin swallows that 28px whole (leaving other pages
+       untouched), and the padding re-adds the gap we actually want — 12px, the
+       same rhythm as the zone's internal gap-3. Being padding INSIDE the zone,
+       it stays opaque and keeps that gap identical once stuck, instead of
+       scrolling away and letting the search bar touch the header. */
+    margin-top: -28px;
+    padding-top: 12px;
+  }
+}
+
 /* ---- Timeline grid ---- */
 .sp-timeline {
   display: grid;
@@ -131,7 +161,11 @@
 }
 @media (min-width: 768px) {
   .sp-day {
-    scroll-margin-top: 88px;
+    /* Bottom of the stuck zone: 76px (header) + 12px gap-padding + ~38px search
+       row + ~106px widgets + ~110px compressed breakdown + 2 × 12px gaps ≈
+       366px, plus breathing room. The "Aujourd'hui" scroll must land the card
+       BELOW the sticky zone, not under it (COS-101). */
+    scroll-margin-top: 376px;
   }
 }
 .sp-day--today {


### PR DESCRIPTION
On desktop, pin the search/export row, the five stat widgets and the category breakdown under the app header so they stay readable while the day-card timeline scrolls. Below 768px nothing changes.

The zone paints an opaque page background: translucent and blurred variants were both tried and rejected in QA — a see-through band shows the cards sliding through it, and a blurred one frosts a rectangle that lines up with neither the header above nor the card borders beside it.

The header ↔ search gap is owned by the zone rather than the header's own mb-7: a negative margin swallows that 28px whole (leaving the other pages untouched) and padding re-adds the 12px we want, matching the zone's internal rhythm. Being padding inside the zone, it also survives sticking instead of scrolling away and letting the search bar touch the header.

Header goes sticky top-4 rather than top-0: the layout's pt-4 scrolls away with the page, so a top-0 header ended up glued to the viewport edge once stuck, losing the detached-bar look.

Pinned chrome is height the day cards lose, so the breakdown is compressed (padding, title/bar margins, row padding) and the zone uses a tighter gap-3 than the page flow's gap-5. .sp-day scroll-margin-top tracks the taller stuck chrome so "Aujourd'hui" still lands a card below it.