### PR TITLE
fix(ui): restore hairlines and borders (COS-105)

### DIFF
--- a/front/src/components/dashboard/sections/InsightsRibbon.tsx
+++ b/front/src/components/dashboard/sections/InsightsRibbon.tsx
@@ -6,6 +6,7 @@
 // are derived from real data. See REFACTO_NOTES.md §6.
 
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { DividedStrip } from "@components/shared/DividedStrip";
 import { Overline } from "@components/shared/Overline";
 import { MONTHLY } from "@components/spendings/config/constants";
 import dailyRemainingBudget from "@components/spendings/helpers/dailyBudget";
@@ -66,7 +67,7 @@ const InsightsRibbon = () => {
   const lastDayLabel = format(endOfMonth(monthRef), "d MMMM", { locale: fr });
 
   return (
-    <section className="grid grid-cols-1 gap-px overflow-hidden rounded-lg border border-line-soft bg-line-soft sm:grid-cols-3">
+    <DividedStrip className="grid-cols-1 sm:grid-cols-3">
       <Insight
         tone="bg-accent-strong/10 text-accent-strong"
         icon={<TrendingUp className="size-3.5" />}
@@ -100,7 +101,7 @@ const InsightsRibbon = () => {
         /jour à dépenser d&apos;ici le <b className="font-semibold text-ink">{lastDayLabel}</b> pour rester dans ton
         budget.
       </Insight>
-    </section>
+    </DividedStrip>
   );
 };
 

--- a/front/src/components/shared/DividedStrip.tsx
+++ b/front/src/components/shared/DividedStrip.tsx
@@ -1,0 +1,30 @@
+import GlowCard from "@components/shared/GlowCard";
+import { cn } from "@lib/utils";
+
+import type { ReactNode } from "react";
+
+interface DividedStripProps {
+  /** Grid track classes, e.g. `grid-cols-1 sm:grid-cols-3`. */
+  className?: string;
+  /** Cells — each supplies its own opaque fill (`bg-card`) and padding. */
+  children: ReactNode;
+}
+
+/**
+ * Top-of-page stat strip: a `GlowCard` pane whose cells are split by hairlines.
+ *
+ * The dividers are the `--line-soft` fill showing through a 1px grid gap, which
+ * means the grid must own its `background` — and `.pfa-card` paints its gradient
+ * border through `background` too. The two cannot share one box, hence the inner
+ * grid element.
+ */
+const DividedStrip = ({ className, children }: DividedStripProps) => (
+  <GlowCard
+    as="section"
+    className="overflow-hidden"
+  >
+    <div className={cn("grid gap-px bg-line-soft", className)}>{children}</div>
+  </GlowCard>
+);
+
+export { DividedStrip };

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
+import GlowCard from "@components/shared/GlowCard";
 import { WEEKLY } from "@components/spendings/config/constants";
 import SpendingsListModal from "@components/spendings/spendingsListModal/SpendingsListModal";
 import { mockCategoryTrend } from "@components/spendings/view/helpers/mockSpending";
@@ -33,7 +34,10 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
   }
 
   return (
-    <section className="sp-catrep">
+    <GlowCard
+      as="section"
+      className="sp-catrep"
+    >
       {/* Compact margins (mb-3 / mb-2.5): this pane lives in the sticky zone,
           where height is taken directly from the day cards (COS-101). */}
       <CardSectionHeader
@@ -99,7 +103,7 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
           total={selected.total}
         />
       )}
-    </section>
+    </GlowCard>
   );
 };
 

--- a/front/src/components/spendings/view/SpendingSummary.tsx
+++ b/front/src/components/spendings/view/SpendingSummary.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { DividedStrip } from "@components/shared/DividedStrip";
 import { MoneyAmount } from "@components/shared/MoneyAmount";
 import { Overline } from "@components/shared/Overline";
 import { StatTile } from "@components/shared/StatTile";
@@ -77,7 +78,7 @@ const SpendingSummary = ({
     );
 
   return (
-    <section className="grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-line-soft bg-line-soft min-[760px]:grid-cols-5">
+    <DividedStrip className="grid-cols-2 min-[760px]:grid-cols-5">
       {/* Hero — full-width banner on mobile, one equal-width cell (1/5) on desktop
           like the other four. Its font stays big; the four keep theirs too. */}
       <div className="col-span-2 bg-card px-5 py-4 min-[760px]:col-span-1">
@@ -133,7 +134,7 @@ const SpendingSummary = ({
         }
         sub={biggest ? `${biggest.label} · ${format(biggest.date, "dd MMM", { locale: fr })}` : "—"}
       />
-    </section>
+    </DividedStrip>
   );
 };
 

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -10,10 +10,8 @@
 /* Vertically compact on purpose (COS-101): it lives in the sticky zone, and
    every pixel it takes is a pixel the day cards lose on a 13" screen. The
    title/bar margins live in the component (mb-3 / mb-2.5). */
+/* Surface, gradient border and radius come from `.pfa-card` (GlowCard). */
 .sp-catrep {
-  background: var(--surface-elev);
-  border: 1px solid var(--line-soft);
-  border-radius: var(--r-lg);
   padding: 14px 22px;
 }
 .sp-cat-bar {

--- a/front/styles/tokens/colors.css
+++ b/front/styles/tokens/colors.css
@@ -46,7 +46,11 @@
   --surface-hi:      oklch(0.215 0.007 250);
   --surface-hover:   oklch(0.22 0.006 250);
   --line:       oklch(0.27 0.008 250);
-  --line-soft:  oklch(0.20 0.006 250);
+  /* Must stay ABOVE every surface it draws on (bg, surface-elev, surface-hi):
+     a hairline is only a line if it is lighter than the fill behind it. At 0.20
+     it sat *under* surface-elev (0.205) and every separator on a card vanished.
+     0.24 restores the design's spacing: ~.035 above the card, ~.03 below --line. */
+  --line-soft:  oklch(0.24 0.006 250);
 
   /* Ink (text) */
   --ink:        oklch(0.975 0.004 250);


### PR DESCRIPTION
--line-soft doit rester plus clair que toutes les surfaces sur lesquelles il dessine : une hairline n'est une ligne que si elle est plus claire que le fond derrière elle. La refonte du DS a monté les surfaces (bg-elev .165 -> surface-elev .205) mais laissé --line-soft à .20, qui est donc passé SOUS la surface des cartes -> ΔL 0.005, invisible. Le markup n'avait pas bougé : les bandeaux portaient toujours leurs classes de bordure, elles peignaient juste une couleur indiscernable du fond.

--line-soft .20 -> .24 restore l'ordre de la maquette (bg < surface-elev < surface-hi < line-soft < line) et ses écarts (~.035 au-dessus de la carte, ~.03 sous --line). Répare d'un coup les 2 bandeaux du haut et la vingtaine d'autres séparateurs devenus invisibles (WeeklyCeiling, CategoryBreakdown, FixedExpenses, StatisticsTopCategories, grilles de graphes).

Les 2 bandeaux portaient une chaîne de classes identique au caractère près -> extraction de DividedStrip, bâti sur GlowCard pour leur donner la bordure dégradée des autres panes. SpendingCategoryBreakdown passe aussi sur GlowCard.

.pfa-card peint sa bordure dégradée via background, et le truc des dividers (gap-px + fond qui transparaît) a besoin du background du conteneur aussi : les deux ne peuvent pas partager la même boîte, d'où la grille intérieure dans DividedStrip.