### PR TITLE
chore(ds): sync design system to Claude Design

### DIFF
--- a/front/.design-sync/NOTES.md
+++ b/front/.design-sync/NOTES.md
@@ -1,0 +1,162 @@
+# design-sync notes — pfa
+
+Repo-specific gotchas for future syncs. Read this before re-running.
+
+Project: **PFA DS** — https://claude.ai/design/p/aba2a406-a3d0-41e5-ab59-3481c4a782ba
+First sync: 2026-07-15. 98 components, floor cards only (no authored previews yet).
+
+## The one thing to know
+
+**pfa is a Next app, not a component library.** It has no `dist/`, no `main`/`module`/`exports`,
+and `noEmit: true`. design-sync's two normal inputs — a compiled stylesheet and a shipped `.d.ts`
+tree — therefore don't exist. `.design-sync/prepare.mjs` manufactures both from the app's source.
+**Always run it before the converter** (it is `cfg.buildCmd`):
+
+```sh
+pnpm ds:prepare
+node .ds-sync/resync.mjs --config .design-sync/config.json --node-modules ./node_modules \
+  --out ./ds-bundle --remote .design-sync/.cache/remote-sync.json --no-render-check
+```
+
+## Why each piece exists (don't "simplify" these away)
+
+- **`ds-entry.tsx` uses RELATIVE imports, not `@components/…`.** This deliberately breaks the repo's
+  path-alias rule, and it must stay that way: tsc copies the specifier verbatim into the emitted
+  `.d.ts`, and the converter's ts-morph project has no `paths` mapping — so with aliases it cannot
+  follow the entry to the components, `getExportedDeclarations()` returns nothing, and **all 98
+  `<Name>Props` silently degrade to `[key: string]: unknown`**. That was the state before this fix.
+- **`dist/types/package.json`** (written by prepare.mjs). `loadDts()` walks up from the types root to
+  the nearest `package.json` *with a name* and reads its `types`. Without that manifest it resolves
+  `front/index.d.ts`, which doesn't exist, and the prop-extraction fallback never runs.
+- **The ts-morph symlink lives at `.design-sync/overrides/node_modules`**, not `.design-sync/`.
+  The fork needs it to resolve `ts-morph`; putting it at `.design-sync/` (as the skill's generic
+  instruction says) makes tsc resolve a *second* `@types/react` from `ds-entry.tsx` and fail the
+  declaration build with "Two different types with this name exist".
+- **`overrides/source-kit.mjs` fork** — group from doc frontmatter, not the src path. `src/components/
+  {shared,common,brand,sharedLoginForm}/` are code organization, and package-build only honours a
+  doc `category:` when the derived group is already `general`. Without the fork half the library is
+  grouped by folder and half by taxonomy. Groups now come from `.design-sync/docs/<Name>.md`.
+- **`.dark` is widened to `:root`** in prepare.mjs. pfa is dark-only and `src/app/layout.tsx` sets
+  `dark` on `<html>`; preview cards and generated designs have no app shell, so without this every
+  token falls back to the inert light shadcn scaffolding.
+- **`html body { background-color: var(--bg) }` in `ds-styles.src.css`, deliberately UNLAYERED.**
+  This one shipped broken on the first upload and the user caught it: every card rendered pfa's
+  near-white ink on a white page. Two causes compounding:
+  1. The generated cards carry their own `<style>body{margin:0;padding:24px;background:#fff}</style>`
+     — `lib/emit.mjs` assumes a light DS. That rule is **unlayered**.
+  2. `base.css`'s `html, body { @apply bg-background }` lives in `@layer base`, and **unlayered CSS
+     beats any cascade layer regardless of specificity**. So the card's white always won.
+  The fix is unlayered (depth 0 in the compiled file) and specificity (0,0,2), which outranks the
+  card's `body` (0,0,1). **Do not move this rule inside `@layer`, and do not fork `lib/emit.mjs`**
+  (the skill forbids it — it defines the output contract with the app's self-check). If cards ever
+  render white again, check this rule survived compilation at depth 0.
+- **`@source inline(...)` safelists** in `ds-styles.src.css`. The bundle ships *static* CSS, so the
+  design agent can only use classes the app happened to compile. Before safelisting, `gap-8`, `mt-8`,
+  `space-y-4`, `grid-cols-4`, `ring-elec`, `text-surface-hi` and `text-danger-solid` did not exist.
+  **If you add a token family to `styles/tokens/colors.css`, add it to the safelist too.**
+- **Fonts.** The app gets Geist/Geist Mono from `next/font/google`, which only exists inside Next.
+  `ds-styles.src.css` sources the same families from the Google Fonts host instead, and binds
+  `--font-geist-sans` / `--font-geist-mono` on `:root`. Validate reports `[FONT_REMOTE]` — expected.
+
+## Deliberately excluded from the DS
+
+| Excluded | Why |
+|---|---|
+| `src/components/ui/card.tsx` | **Dead code.** Zero importers since COS-100 unified cards on GlowCard. Its `CardTitle` also collides with the real one in `shared/CardSectionHeader`. Worth deleting from the repo. |
+| `Spinner` (`common/Spinner.tsx`) | `next/image` + a `/assets/…` path. Pulled Next's whole image runtime into the bundle (796 KB → 648 KB once removed) and it can't render outside Next. Excluded via `componentSrcMap: {"Spinner": null}`. |
+| `NavBar`, `UserMenu`, `SessionWatcher`, `SharedLoginForm` | Bound to next/navigation, auth context and zustand. Would drag server-side deps into a browser bundle. Revisit only with a `cfg.provider` chain. |
+
+## Preview authoring — four traps, all now fixed (2026-07-15)
+
+Every one of these failed **silently**: the card still rendered and still looked plausible. They were
+found by fanning subagents over the library, not by reading code. If a card ever looks subtly wrong,
+suspect this list first.
+
+1. **Sizing utilities were not safelisted.** `w-*`/`h-*`/`size-*`/`max-w-*` only existed if the app
+   happened to use them. `w-28`, `w-40`, `h-64`, `max-w-md`, `max-w-sm` did not exist — elements just
+   ignored the class and rendered full-width. It blocked ScrollArea outright (no fixed height → never
+   overflows → no scrollbar) and silently unconstrained the GlowCard preview. Now safelisted.
+   `max-h-72` is NOT a substitute for `h-*`: Radix's Viewport is `size-full`, which can't resolve
+   against auto-height + max-height — content spills outside the box instead of scrolling.
+2. **`.design-sync/previews/` was not in the Tailwind content scan.** Only `../src` was. Any class used
+   in a preview but not in the app compiled to nothing. Fixed with `@source "./previews"`.
+3. **`dark:` utilities were dead in the preview host.** `globals.css` declares
+   `@custom-variant dark (&:is(.dark *))`; the app satisfies it via `<html className="dark">`, the
+   preview host emits a bare `<html><body>`. Measured wrong on 8 shipped components (button, badge,
+   input, checkbox, switch, tabs, select, dropdown-menu) — e.g. Switch's thumb was navy instead of
+   white. Fixed by re-declaring `@custom-variant dark (&)` in `ds-styles.src.css` (pfa is dark-only, so
+   `dark:` is unconditional). The **token** half was already fine via the `:root, .dark` rewrite — this
+   was only the variant half. Note this nuances conventions.md's "never add a dark class": correct for
+   tokens, but the variant needed widening.
+4. **Adding a `viewport` override after a build hard-blocks every targeted rebuild.**
+   `sync-hashes.mjs` strips only `cardMode`/`primaryStory` from the grade key, so `viewport` re-keys the
+   component and `preview-rebuild.mjs` exits `[CONFIG_STALE]` — and the guard is all-or-nothing per
+   invocation, so one stale target blocks its clean siblings. **Always apply config/override changes
+   BEFORE the full `package-build.mjs`**, never after. Only the full build re-stamps.
+
+## Contract-extraction gaps (tooling, not fixable from previews)
+
+- Components typed `React.ComponentProps<"input">` lose their native props: `Input.d.ts` and
+  `TextInput.d.ts` emit only `ref/className/id/style/children` — `type`, `placeholder`, `disabled`,
+  `value`, `onChange`, `aria-invalid` are all absent. Runtime is fine; the contract is thin.
+- `Input.d.ts` wrongly emits `children` — `<input>` is a void element.
+- `PasswordField.d.ts` declares `registration: UseFormRegisterReturn` without importing the type, so it
+  can't typecheck standalone.
+- `Button`/`IconButton` spread `React.ComponentProps<"button">`, so `disabled`/`aria-label` pass through
+  but are undocumented in the `.d.ts`.
+
+## Findings about the app itself (surfaced while authoring — worth a ticket)
+
+- **`src/components/ui/card.tsx` is dead** (see the exclusions table). Also `Badge`, `CategoryComponent`
+  and `Progress` have **zero call sites** in `src` — orphaned shadcn/legacy primitives that are now
+  documented as DS components. Decide whether they belong.
+- `CategoryComponent.isClicked` is dead code (both branches identical), and its `adjustFontColor` helper
+  would break on the `oklch()` strings the design system uses — it only works because category colours
+  come from the backend as hex.
+- `Progress` is unused shadcn leftover; `ProgressTrack` is what the app actually uses for that role and
+  has no card.
+- `src/components/ui/checkbox.tsx` has no `data-[state=indeterminate]` styling and hardcodes `CheckIcon`,
+  so indeterminate would render a checkmark instead of a minus.
+- **`Tooltip` has zero real usage in `src`** — its preview is a plausible invention, not a transcription
+  of app usage. Worth design sign-off before trusting it as canon.
+- `MoneyAmount` does not carry `num` itself (StatTile adds it on the value line), so standalone usages
+  need `className="num …"`. Easy to miss.
+
+## Components that genuinely cannot render statically
+
+Not defects — deliberately skipped, recorded so a future run doesn't chase them: sonner's swipe-dismiss /
+hover-pause / stacking / enter-exit animations; Radix enter/exit animations and backdrop-blur over real
+page content; PasswordField's revealed state (internal `useState`, no prop override); focus-visible rings;
+hover states; drag on Dropzone; `IconButton`'s `bordered` vs `danger` are pixel-identical at rest.
+
+`Toaster` is a special case worth knowing: sonner renders nothing statically and `toast` is not exported
+from `ds-entry.tsx`. Importing `toast` from `"sonner"` inside a preview would bundle a **second** sonner
+instance whose store the DS-bundle Toaster never subscribes to — the toast would silently never appear.
+The preview instead fires the toast through `ExportButton` (the app's only real `toast()` caller, and on
+the DS surface, so it shares the bundle's sonner instance).
+
+## Known render warns
+
+- `[RENDER_SKIPPED]` — the render check has **never** run. The user declined the playwright/chromium
+  install on the first sync, so the bundle is machine-unverified. A future sync that installs
+  playwright will produce genuinely new information; treat the first real run's findings as new, not
+  as regressions.
+- `[FONT_REMOTE]` — expected, see Fonts above.
+- `tokens: 3 missing, below threshold` — not investigated; under the converter's warn threshold.
+
+## Re-sync risks — what can silently go stale
+
+- **`dtsPropsFor.TextInput` is hand-written** and mirrors `Input`'s contract. `TextInput` is typed
+  `React.ComponentProps<typeof Input>` and its emitted `.d.ts` keeps an aliased `import { Input } from
+  "@components/ui/input"` that ts-morph can't resolve. If `Input`'s props change, this rots silently.
+- **The category stubs in `.design-sync/docs/` are a full enumeration** (98 files, one per component).
+  A component added to `ds-entry.tsx` without a matching stub lands in `general`. A stub for a
+  component that no longer exists is harmless but dead.
+- **`componentSrcMap` is a full enumeration too**, because there is no `.d.ts` export list to
+  discover from. New components must be added to both it and `ds-entry.tsx`.
+- **`prepare.mjs` shells out to `./node_modules/.bin/tsc`** and assumes the front package manager
+  installed it. Node ≥ 22 (`nvm use 22.20.0`); the default node on this machine is too old.
+- **tsc emits declarations despite type errors** (`emitDeclarationOnly`). If the app grows real type
+  errors the tree may be partial without the build failing. Check the `[DTS] parsed N` count — it was
+  43 files / 98 components at first sync.
+- **Assumed at build time:** tailwindcss 4.3.2 (`@source inline` needs ≥ 4.1), Next 16.1, React 19.2.

--- a/front/.design-sync/config.json
+++ b/front/.design-sync/config.json
@@ -1,0 +1,215 @@
+{
+  "projectId": "aba2a406-a3d0-41e5-ab59-3481c4a782ba",
+  "shape": "package",
+  "pkg": "pfa-next",
+  "globalName": "PfaDS",
+  "entry": "./.design-sync/ds-entry.tsx",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "componentSrcMap": {
+    "AlertDialog": "src/components/ui/alert-dialog.tsx",
+    "AlertDialogAction": null,
+    "AlertDialogCancel": null,
+    "AlertDialogContent": null,
+    "AlertDialogDescription": null,
+    "AlertDialogFooter": null,
+    "AlertDialogHeader": null,
+    "AlertDialogOverlay": null,
+    "AlertDialogPortal": null,
+    "AlertDialogTitle": null,
+    "AlertDialogTrigger": null,
+    "Badge": "src/components/ui/badge.tsx",
+    "Button": "src/components/ui/button.tsx",
+    "CardSectionHeader": "src/components/shared/CardSectionHeader.tsx",
+    "CardTitle": "src/components/shared/CardSectionHeader.tsx",
+    "CategoryComponent": "src/components/common/Category.tsx",
+    "Checkbox": "src/components/ui/checkbox.tsx",
+    "Command": "src/components/ui/command.tsx",
+    "CommandEmpty": null,
+    "CommandGroup": null,
+    "CommandInput": null,
+    "CommandItem": null,
+    "CommandList": null,
+    "CommandSeparator": null,
+    "CommandShortcut": null,
+    "ConfirmDeleteDialog": "src/components/shared/ConfirmDeleteDialog.tsx",
+    "Dialog": "src/components/ui/dialog.tsx",
+    "DialogClose": null,
+    "DialogContent": null,
+    "DialogDescription": null,
+    "DialogFooter": null,
+    "DialogHeader": null,
+    "DialogOverlay": null,
+    "DialogPortal": null,
+    "DialogTitle": null,
+    "DialogTrigger": null,
+    "DividedStrip": "src/components/shared/DividedStrip.tsx",
+    "DropdownMenu": "src/components/ui/dropdown-menu.tsx",
+    "DropdownMenuCheckboxItem": null,
+    "DropdownMenuContent": null,
+    "DropdownMenuGroup": null,
+    "DropdownMenuItem": null,
+    "DropdownMenuLabel": null,
+    "DropdownMenuPortal": null,
+    "DropdownMenuRadioGroup": null,
+    "DropdownMenuRadioItem": null,
+    "DropdownMenuSeparator": null,
+    "DropdownMenuShortcut": null,
+    "DropdownMenuSub": null,
+    "DropdownMenuSubContent": null,
+    "DropdownMenuSubTrigger": null,
+    "DropdownMenuTrigger": null,
+    "Dropzone": "src/components/shared/Dropzone.tsx",
+    "EmptyState": "src/components/shared/EmptyState.tsx",
+    "ExportButton": "src/components/shared/ExportButton.tsx",
+    "FieldShell": "src/components/shared/FieldShell.tsx",
+    "FilterChip": "src/components/shared/FilterChip.tsx",
+    "GlowCard": "src/components/shared/GlowCard.tsx",
+    "IconButton": "src/components/shared/IconButton.tsx",
+    "Input": "src/components/ui/input.tsx",
+    "Label": "src/components/ui/label.tsx",
+    "LegendItem": "src/components/shared/LegendItem.tsx",
+    "Logo": "src/components/shared/brand/Logo.tsx",
+    "MeterBar": "src/components/shared/MeterBar.tsx",
+    "MoneyAmount": "src/components/shared/MoneyAmount.tsx",
+    "Overline": "src/components/shared/Overline.tsx",
+    "PasswordField": "src/components/shared/sharedLoginForm/PasswordField.tsx",
+    "Popover": "src/components/ui/popover.tsx",
+    "PopoverAnchor": null,
+    "PopoverContent": null,
+    "PopoverTrigger": null,
+    "Progress": "src/components/ui/progress.tsx",
+    "ScrollArea": "src/components/ui/scroll-area.tsx",
+    "ScrollBar": "src/components/ui/scroll-area.tsx",
+    "Select": "src/components/ui/select.tsx",
+    "SelectContent": null,
+    "SelectGroup": null,
+    "SelectItem": null,
+    "SelectLabel": null,
+    "SelectScrollDownButton": null,
+    "SelectScrollUpButton": null,
+    "SelectSeparator": null,
+    "SelectTrigger": null,
+    "SelectValue": null,
+    "Separator": "src/components/ui/separator.tsx",
+    "Skeleton": "src/components/ui/skeleton.tsx",
+    "StatTile": "src/components/shared/StatTile.tsx",
+    "Switch": "src/components/ui/switch.tsx",
+    "Tabs": "src/components/ui/tabs.tsx",
+    "TabsContent": null,
+    "TabsList": null,
+    "TabsTrigger": null,
+    "TextInput": "src/components/shared/TextInput.tsx",
+    "Toaster": "src/components/ui/sonner.tsx",
+    "Tooltip": "src/components/ui/tooltip.tsx",
+    "TooltipContent": null,
+    "TooltipProvider": null,
+    "TooltipTrigger": null,
+    "Spinner": null
+  },
+  "cssEntry": ".design-sync/.cache/pfa-styles.css",
+  "docsDir": ".design-sync/docs",
+  "libOverrides": {
+    "source-kit.mjs": "src/ dirs are code organization here, not design taxonomy — group from docs frontmatter instead"
+  },
+  "buildCmd": "node .design-sync/prepare.mjs",
+  "dtsPropsFor": {
+    "TextInput": "  /** Allows getting a ref to the underlying input. */\n  ref?: React.Ref;\n  className?: string;\n  id?: string;\n  style?: CSSProperties;"
+  },
+  "readmeHeader": ".design-sync/conventions.md",
+  "overrides": {
+    "Dialog": {
+      "cardMode": "single",
+      "viewport": "760x480"
+    },
+    "AlertDialog": {
+      "cardMode": "single",
+      "viewport": "760x480"
+    },
+    "ConfirmDeleteDialog": {
+      "cardMode": "single",
+      "viewport": "760x480"
+    },
+    "DropdownMenu": {
+      "cardMode": "single",
+      "viewport": "620x420"
+    },
+    "Popover": {
+      "cardMode": "single",
+      "viewport": "620x420"
+    },
+    "Tooltip": {
+      "cardMode": "single",
+      "viewport": "620x300"
+    },
+    "Command": {
+      "cardMode": "single",
+      "viewport": "620x460"
+    },
+    "Select": {
+      "cardMode": "single",
+      "viewport": "620x420"
+    },
+    "Toaster": {
+      "cardMode": "single",
+      "viewport": "620x300"
+    },
+    "StatTile": {
+      "cardMode": "column"
+    },
+    "GlowCard": {
+      "cardMode": "column"
+    },
+    "Button": {
+      "viewport": "620x260"
+    },
+    "IconButton": {
+      "viewport": "620x200"
+    },
+    "ExportButton": {
+      "viewport": "620x200"
+    },
+    "Badge": {
+      "viewport": "620x200"
+    },
+    "Checkbox": {
+      "viewport": "620x240",
+      "cardMode": "column"
+    },
+    "Switch": {
+      "viewport": "620x240",
+      "cardMode": "column"
+    },
+    "Label": {
+      "viewport": "620x320",
+      "cardMode": "column"
+    },
+    "Overline": {
+      "viewport": "620x200"
+    },
+    "MoneyAmount": {
+      "viewport": "620x320"
+    },
+    "MeterBar": {
+      "viewport": "620x320"
+    },
+    "Progress": {
+      "viewport": "620x280"
+    },
+    "Separator": {
+      "viewport": "620x240"
+    },
+    "CardTitle": {
+      "viewport": "620x220"
+    },
+    "ScrollArea": {
+      "viewport": "620x340"
+    },
+    "ScrollBar": {
+      "viewport": "620x340"
+    },
+    "Dropzone": {
+      "cardMode": "column"
+    }
+  }
+}

--- a/front/.design-sync/conventions.md
+++ b/front/.design-sync/conventions.md
@@ -1,0 +1,54 @@
+## Building with pfa
+
+pfa is a personal-finance app: **dark-only**, French UI, dense numeric screens (budgets, spendings, categories, statistics).
+
+### Setup — there is nothing to wrap
+
+No provider is required. The tokens are plain CSS custom properties on `:root` in `styles.css`, and **dark is the default** — do *not* add a `dark` class or a theme provider. `Tooltip` mounts its own `TooltipProvider`. The only global is `<Toaster />` (sonner), mounted once near the root, and only if you raise toasts.
+
+### The styling idiom: Tailwind v4 utilities over pfa tokens
+
+CSS-first Tailwind — there is no `tailwind.config.js`; the theme lives in CSS via `@theme`. Style with utilities built on the pfa palette.
+
+**Never** use a raw value (`text-[13px]`, `bg-[#121212]`, `rounded-[6px]`) or a stock Tailwind palette colour (`gray-400`, `cyan-500`). Every one has a canonical token below, and the app source contains zero raw palette colours.
+
+| Family | Names | Meaning |
+|---|---|---|
+| Ink (text) | `ink` `ink-2` `ink-3` `ink-4` `ink-5` | primary → progressively muted |
+| Surface | `background` `surface-elev` `surface-hi` `surface-hover` | page → card → field/track → hover |
+| Line | `line` `line-soft` | borders → discreet separators |
+| Accent | `accent-strong` `accent-d` `accent-bg` | mint green: positive, primary action |
+| Semantic | `neg` `exc` `elec` | over-budget red · exceptional-purchase blue · "today" marker |
+| Danger | `danger-solid` `on-danger` `danger-surface` `danger-border-soft` | delete affordances |
+
+Compose them with the property that fits the family — ink drives text, surfaces drive fills, lines drive borders, and the accent/semantic families drive any of the three: `text-ink-3`, `bg-surface-elev`, `border-line`, `text-neg`, `bg-exc-bg`, `ring-elec`, `from-accent-d`. (`background` is the page fill: `bg-background`.)
+
+**Type:** `text-3xs` `text-2xs` (11px micro-label) … `text-display` `text-display-lg` (hero numbers). `tracking-snug` for titles, `tracking-caps` for uppercase micro-labels. `font-sans` = Geist, `font-mono` = Geist Mono. Spacing stays on the numbered scale (`p-4`, `gap-6`, `px-5.5`).
+
+**Every meaningful number carries `.num`** (Geist Mono + tabular figures): amounts, percentages, dates, counters. For currency prefer the `MoneyAmount` component over hand-formatting — but note `MoneyAmount` does **not** apply `num` itself (`StatTile` adds it on its value line), so a standalone one needs `className="num …"`.
+
+Do not write `dark:` variants. The system is dark-only: the palette above is already the dark palette, and a `dark:` prefix buys nothing.
+
+### Where the truth lives
+
+- `styles.css` and its `@import` closure — the real token values. Read them before inventing anything.
+- `guidelines/docs/design-system.md` — the authoritative write-up: ground rules, every scale, the component catalogue, and the accepted exceptions. Read this first.
+- Each component's `.prompt.md` / `.d.ts` — its actual props.
+
+### Composition rules that matter
+
+- **Cards are `GlowCard`.** Never hand-roll the gradient border; it is the app's signature surface. `hover` adds the lift used by category tiles.
+- Card headings go through `CardSectionHeader` (title + muted `meta` or an `action` control), or `CardTitle` when the header layout is bespoke.
+- `StatTile` for label/value/caption stats, `MeterBar` for progress bars, `FilterChip` for filter pills, `Overline` for uppercase section labels, `EmptyState` for empty lists.
+
+```jsx
+<GlowCard as="section" className="p-5">
+  <CardSectionHeader title="Dépenses fixes" meta="12 prélèvements" />
+  <div className="mt-4 grid grid-cols-3 gap-4">
+    <StatTile label="Total du mois" value={<MoneyAmount value={1240.5} unit="€" />} sub="sur 12 prélèvements" />
+  </div>
+  <MeterBar value={72} height={6} className="mt-4" />
+  <p className="mt-2 text-2xs tracking-caps text-ink-4">RESTE À VIVRE</p>
+  <Button variant="primary" size="sm" className="mt-4">Ajouter</Button>
+</GlowCard>
+```

--- a/front/.design-sync/docs/AlertDialog.md
+++ b/front/.design-sync/docs/AlertDialog.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/docs/Badge.md
+++ b/front/.design-sync/docs/Badge.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/Button.md
+++ b/front/.design-sync/docs/Button.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/front/.design-sync/docs/CardSectionHeader.md
+++ b/front/.design-sync/docs/CardSectionHeader.md
@@ -1,0 +1,3 @@
+---
+category: Typography
+---

--- a/front/.design-sync/docs/CardTitle.md
+++ b/front/.design-sync/docs/CardTitle.md
@@ -1,0 +1,3 @@
+---
+category: Typography
+---

--- a/front/.design-sync/docs/CategoryComponent.md
+++ b/front/.design-sync/docs/CategoryComponent.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/Checkbox.md
+++ b/front/.design-sync/docs/Checkbox.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Command.md
+++ b/front/.design-sync/docs/Command.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/ConfirmDeleteDialog.md
+++ b/front/.design-sync/docs/ConfirmDeleteDialog.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/docs/Dialog.md
+++ b/front/.design-sync/docs/Dialog.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/docs/DividedStrip.md
+++ b/front/.design-sync/docs/DividedStrip.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/DropdownMenu.md
+++ b/front/.design-sync/docs/DropdownMenu.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/docs/Dropzone.md
+++ b/front/.design-sync/docs/Dropzone.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/EmptyState.md
+++ b/front/.design-sync/docs/EmptyState.md
@@ -1,0 +1,3 @@
+---
+category: Feedback
+---

--- a/front/.design-sync/docs/ExportButton.md
+++ b/front/.design-sync/docs/ExportButton.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/front/.design-sync/docs/FieldShell.md
+++ b/front/.design-sync/docs/FieldShell.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/FilterChip.md
+++ b/front/.design-sync/docs/FilterChip.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/front/.design-sync/docs/GlowCard.md
+++ b/front/.design-sync/docs/GlowCard.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/IconButton.md
+++ b/front/.design-sync/docs/IconButton.md
@@ -1,0 +1,3 @@
+---
+category: Actions
+---

--- a/front/.design-sync/docs/Input.md
+++ b/front/.design-sync/docs/Input.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Label.md
+++ b/front/.design-sync/docs/Label.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/LegendItem.md
+++ b/front/.design-sync/docs/LegendItem.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/Logo.md
+++ b/front/.design-sync/docs/Logo.md
@@ -1,0 +1,3 @@
+---
+category: Brand
+---

--- a/front/.design-sync/docs/MeterBar.md
+++ b/front/.design-sync/docs/MeterBar.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/MoneyAmount.md
+++ b/front/.design-sync/docs/MoneyAmount.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/Overline.md
+++ b/front/.design-sync/docs/Overline.md
@@ -1,0 +1,3 @@
+---
+category: Typography
+---

--- a/front/.design-sync/docs/PasswordField.md
+++ b/front/.design-sync/docs/PasswordField.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Popover.md
+++ b/front/.design-sync/docs/Popover.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/docs/Progress.md
+++ b/front/.design-sync/docs/Progress.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/ScrollArea.md
+++ b/front/.design-sync/docs/ScrollArea.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/ScrollBar.md
+++ b/front/.design-sync/docs/ScrollBar.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/Select.md
+++ b/front/.design-sync/docs/Select.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Separator.md
+++ b/front/.design-sync/docs/Separator.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/Skeleton.md
+++ b/front/.design-sync/docs/Skeleton.md
@@ -1,0 +1,3 @@
+---
+category: Feedback
+---

--- a/front/.design-sync/docs/StatTile.md
+++ b/front/.design-sync/docs/StatTile.md
@@ -1,0 +1,3 @@
+---
+category: Data display
+---

--- a/front/.design-sync/docs/Switch.md
+++ b/front/.design-sync/docs/Switch.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Tabs.md
+++ b/front/.design-sync/docs/Tabs.md
@@ -1,0 +1,3 @@
+---
+category: Layout
+---

--- a/front/.design-sync/docs/TextInput.md
+++ b/front/.design-sync/docs/TextInput.md
@@ -1,0 +1,3 @@
+---
+category: Forms
+---

--- a/front/.design-sync/docs/Toaster.md
+++ b/front/.design-sync/docs/Toaster.md
@@ -1,0 +1,3 @@
+---
+category: Feedback
+---

--- a/front/.design-sync/docs/Tooltip.md
+++ b/front/.design-sync/docs/Tooltip.md
@@ -1,0 +1,3 @@
+---
+category: Overlays
+---

--- a/front/.design-sync/ds-entry.tsx
+++ b/front/.design-sync/ds-entry.tsx
@@ -1,0 +1,43 @@
+// DS entry for design-sync — the PFA design-system surface.
+// Generated sync input; not imported by the app. Re-exports existing components only.
+// Excludes ui/card.tsx (dead since COS-100) and the auth/router-bound chrome
+// (NavBar, UserMenu, SessionWatcher, SharedLoginForm).
+export { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogOverlay, AlertDialogPortal, AlertDialogTitle, AlertDialogTrigger } from "../src/components/ui/alert-dialog";
+export { Badge } from "../src/components/ui/badge";
+export { Button } from "../src/components/ui/button";
+export { Checkbox } from "../src/components/ui/checkbox";
+export { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, CommandSeparator, CommandShortcut } from "../src/components/ui/command";
+export { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger } from "../src/components/ui/dialog";
+export { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuGroup, DropdownMenuItem, DropdownMenuLabel, DropdownMenuPortal, DropdownMenuRadioGroup, DropdownMenuRadioItem, DropdownMenuSeparator, DropdownMenuShortcut, DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger } from "../src/components/ui/dropdown-menu";
+export { Input } from "../src/components/ui/input";
+export { Label } from "../src/components/ui/label";
+export { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "../src/components/ui/popover";
+export { Progress } from "../src/components/ui/progress";
+export { ScrollArea, ScrollBar } from "../src/components/ui/scroll-area";
+export { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectScrollDownButton, SelectScrollUpButton, SelectSeparator, SelectTrigger, SelectValue } from "../src/components/ui/select";
+export { Separator } from "../src/components/ui/separator";
+export { Skeleton } from "../src/components/ui/skeleton";
+export { Toaster } from "../src/components/ui/sonner";
+export { Switch } from "../src/components/ui/switch";
+export { Tabs, TabsContent, TabsList, TabsTrigger } from "../src/components/ui/tabs";
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../src/components/ui/tooltip";
+export { CardSectionHeader, CardTitle } from "../src/components/shared/CardSectionHeader";
+export { DividedStrip } from "../src/components/shared/DividedStrip";
+export { Dropzone } from "../src/components/shared/Dropzone";
+export { EmptyState } from "../src/components/shared/EmptyState";
+export { FieldShell } from "../src/components/shared/FieldShell";
+export { FilterChip } from "../src/components/shared/FilterChip";
+export { IconButton } from "../src/components/shared/IconButton";
+export { LegendItem } from "../src/components/shared/LegendItem";
+export { MeterBar } from "../src/components/shared/MeterBar";
+export { MoneyAmount } from "../src/components/shared/MoneyAmount";
+export { Overline } from "../src/components/shared/Overline";
+export { StatTile } from "../src/components/shared/StatTile";
+export { TextInput } from "../src/components/shared/TextInput";
+export { PasswordField } from "../src/components/shared/sharedLoginForm/PasswordField";
+
+export { default as GlowCard } from "../src/components/shared/GlowCard";
+export { default as ConfirmDeleteDialog } from "../src/components/shared/ConfirmDeleteDialog";
+export { default as ExportButton } from "../src/components/shared/ExportButton";
+export { default as Logo } from "../src/components/shared/brand/Logo";
+export { default as CategoryComponent } from "../src/components/common/Category";

--- a/front/.design-sync/ds-styles.src.css
+++ b/front/.design-sync/ds-styles.src.css
@@ -1,0 +1,80 @@
+/* DS stylesheet source for design-sync — compiled by .design-sync/build-css.mjs.
+   Not used by the app; the app compiles styles/globals.css through Next/PostCSS. */
+
+/* The app gets Geist + Geist Mono from next/font/google (src/app/layout.tsx),
+   which only exists inside the Next runtime. Source the same families from the
+   font host so the bundle is self-sufficient. */
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap');
+
+@import '../styles/globals.css';
+
+/* Be explicit about what to scan. Tailwind's automatic detection is anchored on
+   the file that imports it (styles/globals.css) and was silently missing part of
+   the app — e.g. `py-4.5`, used in src/app/(public)/layout.tsx, never compiled. */
+@source "../src";
+
+/* The preview cards are source too. Without this, any class used ONLY in a
+   preview (and not in the app) silently resolves to nothing — the card still
+   renders, just subtly wrong, with no error anywhere. */
+@source "./previews";
+
+/* pfa is dark-only, but globals.css declares `@custom-variant dark (&:is(.dark *))`,
+   so every `dark:` utility compiles gated on a `.dark` ANCESTOR. The app has one
+   (src/app/layout.tsx); the preview host emits a bare <html><body>, so all of it
+   silently no-ops — measurably wrong on button, badge, input, checkbox, switch,
+   tabs, select and dropdown-menu. Re-declaring the variant here (after the import)
+   makes `dark:` unconditional, which is exactly right for a dark-only system and
+   keeps the `:root, .dark` token rewrite intact. */
+@custom-variant dark (&);
+
+/* Tailwind only compiles utilities it finds in the source it scans, so the app's
+   own usage decides the bundle. That is wrong for a design system: the design
+   agent writes NEW markup, and a class the app never happened to use would
+   silently resolve to nothing. Safelist the whole pfa palette across the
+   properties it can legitimately drive. Invalid combinations emit nothing. */
+@source inline(
+  "{text,bg,border,ring,outline,fill,stroke,from,via,to,divide,placeholder,caret,shadow}-{ink,ink-2,ink-3,ink-4,ink-5,surface-elev,surface-hi,surface-hover,line,line-soft,accent-strong,accent-d,accent-bg,neg,danger-solid,on-danger,danger-surface,danger-border-soft,exc,exc-bg,elec}"
+);
+/* Same reasoning for layout glue. The agent writes its own scaffolding, and the
+   app simply never used `gap-8`, `mt-8`, `space-y-4` or `grid-cols-4`, so none
+   of them existed. Safelist the numbered scale the design system documents. */
+@source inline(
+  "{p,px,py,pt,pr,pb,pl,m,mx,my,mt,mr,mb,ml,gap,gap-x,gap-y,space-x,space-y}-{0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,6.5,7,8,9,10,11,12,14,16,20,24}"
+);
+@source inline("grid-cols-{1,2,3,4,5,6,7,8,12}");
+@source inline("col-span-{1,2,3,4,5,6,7,8,9,10,11,12,full}");
+
+/* Sizing. Same reasoning as the spacing scale — and this one bit hard: `h-64` and
+   `max-w-md` did not exist, so ScrollArea could never overflow (no scrollbar) and
+   cards rendered full-width instead of at their intended size. It fails SILENTLY:
+   the element just ignores the class. */
+@source inline(
+  "{w,h,min-w,min-h,max-w,max-h,size}-{0,0.5,1,1.5,2,2.5,3,3.5,4,4.5,5,5.5,6,7,8,9,10,11,12,14,16,20,24,28,32,36,40,44,48,56,64,72,80,96}"
+);
+@source inline("{w,h,min-w,min-h,max-w,max-h}-{full,fit,auto,px,min,max,screen}");
+@source inline("max-w-{3xs,2xs,xs,sm,md,lg,xl,2xl,3xl,4xl,5xl}");
+
+@source inline("text-{2xs,3xs,display,display-lg}");
+@source inline("tracking-{snug,caps}");
+@source inline("font-{sans,mono}");
+@source inline("num");
+
+/* src/app/layout.tsx puts `dark` + next/font's variables on <html>. Preview cards
+   and generated designs have no app shell, so bind the variables here. */
+:root {
+  color-scheme: dark;
+  --font-geist-sans: 'Geist';
+  --font-geist-mono: 'Geist Mono';
+}
+
+/* Paint the page dark — deliberately UNLAYERED and specificity (0,0,2).
+   base.css already says `html, body { @apply bg-background }`, but it sits in
+   `@layer base`, and unlayered CSS beats any layer no matter how specific. The
+   generated preview cards ship their own unlayered `<style>body{background:#fff}`
+   (the converter assumes a light DS), which therefore won every time and rendered
+   pfa's near-white ink on white — invisible. `html body` outranks that `body`.
+   pfa is dark-only, so this is the honest default for cards and for designs. */
+html body {
+  background-color: var(--bg);
+  color: var(--ink);
+}

--- a/front/.design-sync/overrides/source-kit.mjs
+++ b/front/.design-sync/overrides/source-kit.mjs
@@ -1,0 +1,159 @@
+// forked from design-sync lib/source-kit.mjs — src/ dirs are code organization here, not design taxonomy
+//
+// pfa is an app, not a component library: src/components/{shared,common,brand,
+// sharedLoginForm}/ say where a file lives, not what kind of part it is. The
+// stock group heuristic turns those dir names into DS-pane sections, and
+// package-build.mjs only lets a doc's `category:` win when the derived group is
+// already "general" — so half the library would be grouped by folder and half by
+// taxonomy. Deriving `general` here makes .design-sync/docs/<Name>.md the single
+// source of grouping for every component. JSDoc @category still works.
+//
+// Non-storybook `package` adapter. Bundles dist/ when present (the authoritative
+// component list comes from shipped .d.ts; with no dist it synthesizes an
+// entry from src/ as a last resort) and opportunistically enriches each
+// component from src/ — JSDoc and dir-derived group. Every enrichment miss
+// degrades to the plain-dist behaviour.
+//
+// Discovery is heuristic-based; each heuristic has a `.design-sync/config.json`
+// override (ASSUMPTION comments below name them) so repos that don't match the
+// defaults write config, not code. `componentSrcMap` is the single override
+// knob for component inclusion: non-null value = add/pin src path, null =
+// exclude a .d.ts-exported internal.
+
+import { existsSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { Project, Node, ts } from 'ts-morph';
+import { leadingJsdoc, readText, slash, walk } from '../../.ds-sync/lib/common.mjs';
+import { resolveDistEntry } from '../../.ds-sync/lib/bundle.mjs';
+import { exportedNames, isComponentName } from '../../.ds-sync/lib/dts.mjs';
+
+const NON_IMPL_RX = /\.(stories|test|spec)\./;
+const SRC_IMPL_RX = /\.(tsx|jsx)$/;
+// Dir names that don't usefully group components — skip so the emitted path
+// is `components/<group>/<Name>` not `components/components/<Name>`.
+const GENERIC_DIR = new Set(['components', 'component', 'src', 'lib', 'ui', 'packages', 'react']);
+const slug = (s) => s.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'general';
+
+// No .d.ts → scan src files for PascalCase value exports via ts-morph.
+function deriveComponentsFromSrc(srcFiles) {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    compilerOptions: { jsx: ts.JsxEmit.Preserve, allowJs: true, skipLibCheck: true },
+  });
+  const seen = new Set();
+  for (const p of srcFiles) {
+    if (NON_IMPL_RX.test(p) || !SRC_IMPL_RX.test(p)) continue;
+    const sf = project.addSourceFileAtPathIfExists(p);
+    if (!sf) continue;
+    for (const [name, decls] of sf.getExportedDeclarations()) {
+      // `export default function Button()` is keyed as 'default' — recover
+      // the declared name from the function/class node.
+      const real = name === 'default'
+        ? decls.map((d) => d.getName?.()).find((n) => n && n !== 'default')
+        : name;
+      if (!real || !/^[A-Z][A-Za-z0-9]*$/.test(real)) continue;
+      if (decls.some((d) => Node.isVariableDeclaration(d) || Node.isFunctionDeclaration(d) || Node.isClassDeclaration(d))) {
+        seen.add(real);
+      }
+    }
+  }
+  return [...seen].sort().map((name) => ({ name, group: 'general' }));
+}
+
+export async function resolvePackage(ctx) {
+  const { PKG_DIR, pkgJson, ENTRY_OVERRIDE, PKG, OUT, cfg } = ctx;
+  const srcMap = cfg.componentSrcMap ?? {};
+
+  // ── 1. src/ discovery (best-effort; feeds enrichment + synth-entry fallback).
+  // ASSUMPTION: source root is first of src/ | lib/ | components/. Override: cfg.srcDir.
+  const srcRoot = [cfg.srcDir, 'src', 'lib', 'components']
+    .map((d) => d && resolve(PKG_DIR, d))
+    .find((d) => d && existsSync(d));
+  const srcFiles = srcRoot ? walk(srcRoot, (n) => /\.(tsx|jsx|mdx?)$/.test(n)) : [];
+
+  // ── 2. entry: dist if it exists, else synthesize from src/ (last resort).
+  let entry = resolveDistEntry({ pkgDir: PKG_DIR, pkgJson, override: ENTRY_OVERRIDE, pkgName: PKG, soft: true });
+  let synthEntry = false;
+  if (!entry) {
+    if (!srcRoot) {
+      console.error(`[NO_DIST] ${PKG} has no built entry and no src/ to synthesize from — run its build.`);
+      process.exit(1);
+    }
+    const comps = srcFiles.filter((p) => SRC_IMPL_RX.test(p) && !NON_IMPL_RX.test(p));
+    entry = join(OUT, '.pkg-entry.mjs');
+    writeFileSync(entry, comps.map((p) => `export * from ${JSON.stringify(p)};`).join('\n') + '\n');
+    synthEntry = true;
+    console.error(
+      `[NO_DIST] no built entry — synthesizing from ${comps.length} src files (run the package's build for best results)`,
+    );
+  }
+
+  // ── 3. component list: from shipped .d.ts (authoritative when dist exists).
+  // ASSUMPTION: components = PascalCase value exports in the .d.ts tree.
+  // Override: cfg.componentSrcMap (non-null adds/pins, null excludes).
+  const exported = exportedNames(PKG_DIR, pkgJson);
+  const names = new Set([...exported].filter(isComponentName));
+  for (const [k, v] of Object.entries(srcMap)) {
+    if (v === null) { names.delete(k); continue; }
+    // Names reach `<script>` blocks in the emitted HTML — reject anything
+    // that isn't a plain PascalCase identifier.
+    if (!/^[A-Z][A-Za-z0-9]*$/.test(k)) {
+      console.error(`[CONFIG] componentSrcMap: "${k}" is not a valid component name (PascalCase identifiers only)`);
+      continue;
+    }
+    names.add(k);
+  }
+  let components = [...names].sort().map((name) => ({ name, group: 'general' }));
+  if (!components.length && synthEntry) {
+    components = deriveComponentsFromSrc(srcFiles).filter((c) => srcMap[c.name] !== null);
+  }
+  if (!components.length) {
+    if (cfg.cssEntry || existsSync(join(PKG_DIR, 'styles.css'))) {
+      console.error('[ZERO_MATCH] no component exports — treating as tokens-only DS');
+      return { shape: 'package', entry, components: [], tokensOnly: true };
+    }
+    console.error(`[ZERO_MATCH] no PascalCase exports in ${PKG} and no styles — nothing to sync`);
+    process.exit(1);
+  }
+
+  // ── 4. src/ enrichment per component. Every miss degrades to plain-dist.
+  if (srcRoot) {
+    for (const c of components) {
+      // Pinned via config → skip fuzzy-find entirely.
+      let hit = typeof srcMap[c.name] === 'string' ? slash(resolve(PKG_DIR, srcMap[c.name])) : null;
+      if (!hit) {
+        // ASSUMPTION: <Name>.tsx | <name>/<name>.tsx | <Name>/index.tsx |
+        // <kebab-name>.tsx, case-insensitive; dir-match ranks above
+        // bare-file match, then prefer one that actually exports `c.name`.
+        // Override: cfg.componentSrcMap.
+        const kebab = c.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2');
+        const nameRx = new RegExp(
+          `(?:^|/)(?:${c.name}/(?:index|${c.name})\\.(tsx|jsx)|(?:${c.name}|${kebab})\\.(tsx|jsx))$`,
+          'i',
+        );
+        const hits = srcFiles
+          .filter((p) => nameRx.test(p) && !NON_IMPL_RX.test(p))
+          .sort(
+            (a, b) =>
+              (b.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0) -
+              (a.toLowerCase().includes(`/${c.name.toLowerCase()}/`) ? 1 : 0),
+          );
+        const exportRx = new RegExp(`export\\s+(?:default\\s+)?(?:const|let|var|function|class)\\s+${c.name}\\b`);
+        hit = hits.find((p) => exportRx.test(readText(p))) ?? hits[0];
+      }
+      if (!hit || !existsSync(hit)) continue;
+      c.srcPath = hit;
+      c.doc = leadingJsdoc(readText(hit), c.name) || undefined;
+      // FORK: upstream derives the group from the src/ path here. See the header —
+      // pfa's dir names are code organization, so grouping comes from the doc
+      // frontmatter instead. JSDoc @category still wins over the default.
+      c.group = slug((c.doc && /@category\s+(\S+)/.exec(c.doc)?.[1]) || 'general');
+    }
+  }
+
+  console.error(
+    `  package: ${components.length} components` +
+      (srcRoot ? ` (${components.filter((c) => c.srcPath).length} src-matched)` : ' (no src/ — dist-only)'),
+  );
+  return { shape: 'package', entry, components, synthEntry, exported };
+}

--- a/front/.design-sync/prepare.mjs
+++ b/front/.design-sync/prepare.mjs
@@ -1,0 +1,54 @@
+// Pre-converter build step for design-sync. Run from front/ before package-build.mjs:
+//
+//   node .design-sync/prepare.mjs
+//
+// pfa is a Next app, not a published component library, so the converter's two
+// normal inputs — a compiled stylesheet and a shipped .d.ts tree — don't exist.
+// This produces both from the app's own source. Nothing here is app code; all
+// output is gitignored and regenerated every sync.
+//
+//  1. TYPES. tsc emits declarations for the DS barrel into front/dist/types.
+//     design-sync's findTypesRoot() probes `dist/types` under the package, and
+//     loadDts() then walks up to the nearest package.json *with a name* and
+//     reads its `types` field — so we drop a tiny manifest there pointing at the
+//     barrel's .d.ts. Without it the entry .d.ts is never loaded, the call-
+//     signature fallback finds nothing, and all 99 <Name>Props degrade to
+//     `[key: string]: unknown` — i.e. the design agent gets no API contract.
+//
+//  2. STYLES. styles/globals.css is Tailwind v4 source (@import 'tailwindcss',
+//     @theme, @custom-variant), which is not CSS. Compile it with the same
+//     PostCSS plugin Next uses. Then widen `.dark` to also match :root — pfa is
+//     dark-only and src/app/layout.tsx sets `dark` on <html>, but preview cards
+//     and designs built in Claude Design have no app shell, so without this
+//     every token silently falls back to the light shadcn defaults.
+
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import postcss from 'postcss';
+import tailwind from '@tailwindcss/postcss';
+
+// ── 1. types ─────────────────────────────────────────────────────────────
+execFileSync('./node_modules/.bin/tsc', ['-p', '.design-sync/tsconfig.dts.json'], { stdio: 'inherit' });
+writeFileSync(
+  'dist/types/package.json',
+  `${JSON.stringify({ name: 'pfa-ds-types', types: './.design-sync/ds-entry.d.ts' }, null, 2)}\n`,
+);
+console.error('[PFA_TYPES] dist/types + manifest written');
+
+// ── 2. styles ────────────────────────────────────────────────────────────
+const SRC = '.design-sync/ds-styles.src.css';
+const OUT = '.design-sync/.cache/pfa-styles.css';
+const res = await postcss([tailwind()]).process(readFileSync(SRC, 'utf8'), { from: SRC, to: OUT });
+
+// `.dark { --bg: … }` → `:root, .dark { … }`. Same specificity as the light
+// :root block above it, and later in source order, so it wins.
+const css = res.css.replace(/(^|\})(\s*)\.dark(\s*\{)/g, '$1$2:root, .dark$3');
+const widened = (css.match(/:root, \.dark\s*\{/g) ?? []).length;
+if (!widened) {
+  console.error('[PFA_CSS] no .dark block found — tokens would not apply to previews. Aborting.');
+  process.exit(1);
+}
+mkdirSync(dirname(OUT), { recursive: true });
+writeFileSync(OUT, css);
+console.error(`[PFA_CSS] ${OUT}: ${(css.length / 1024).toFixed(0)} KB, ${widened} .dark block(s) widened to :root`);

--- a/front/.design-sync/previews/AlertDialog.tsx
+++ b/front/.design-sync/previews/AlertDialog.tsx
@@ -1,0 +1,76 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "pfa-next";
+
+/**
+ * The canonical destructive confirmation: `AlertDialogAction` carries the danger
+ * tokens (it must override its own default variant), `AlertDialogCancel` is the
+ * muted escape. This is what `ConfirmDeleteDialog` wraps.
+ */
+export const Default = () => (
+  <AlertDialog open>
+    <AlertDialogContent className="border-line bg-surface-elev">
+      <AlertDialogHeader>
+        <AlertDialogTitle className="text-ink">Supprimer la catégorie « Alimentation » ?</AlertDialogTitle>
+        <AlertDialogDescription className="text-ink-3">
+          Cette action est irréversible. Les 24 dépenses associées n'auront plus de catégorie.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>Annuler</AlertDialogCancel>
+        <AlertDialogAction className="bg-danger-solid text-on-danger hover:bg-danger-solid hover:brightness-110">
+          Supprimer
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+/**
+ * The same anatomy with the action left on its default (non-destructive) look —
+ * a confirmation that commits rather than deletes.
+ */
+export const NonDestructiveAction = () => (
+  <AlertDialog open>
+    <AlertDialogContent className="border-line bg-surface-elev">
+      <AlertDialogHeader>
+        <AlertDialogTitle className="text-ink">Reporter le plafond hebdomadaire ?</AlertDialogTitle>
+        <AlertDialogDescription className="text-ink-3">
+          Le reste de la semaine du 11 mai (<span className="num text-ink-2">78,20 €</span>) sera ajouté au plafond de
+          la semaine suivante.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>Annuler</AlertDialogCancel>
+        <AlertDialogAction>Reporter</AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);
+
+/**
+ * Title-only header: the description slot is dropped when the title already says
+ * everything, and the labels name the object being removed.
+ */
+export const TitleOnly = () => (
+  <AlertDialog open>
+    <AlertDialogContent className="border-line bg-surface-elev">
+      <AlertDialogHeader>
+        <AlertDialogTitle className="text-ink">Supprimer l'abonnement Netflix ?</AlertDialogTitle>
+      </AlertDialogHeader>
+      <AlertDialogFooter>
+        <AlertDialogCancel>Conserver</AlertDialogCancel>
+        <AlertDialogAction className="bg-danger-solid text-on-danger hover:bg-danger-solid hover:brightness-110">
+          Supprimer la dépense fixe
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+);

--- a/front/.design-sync/previews/Badge.tsx
+++ b/front/.design-sync/previews/Badge.tsx
@@ -1,0 +1,71 @@
+import { Badge } from "pfa-next";
+
+export const Default = () => <Badge>Récurrent</Badge>;
+
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge variant="default">Récurrent</Badge>
+    <Badge variant="secondary">Alimentation</Badge>
+    <Badge variant="destructive">Dépassé</Badge>
+    <Badge variant="outline">Non catégorisé</Badge>
+  </div>
+);
+
+export const WithIcon = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge variant="secondary">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="m12 3 1.9 5.8h6.1l-4.9 3.6 1.9 5.8-4.9-3.6-4.9 3.6 1.9-5.8L4.1 8.8h6.1Z" />
+      </svg>
+      Achat exceptionnel
+    </Badge>
+    <Badge variant="destructive">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M12 9v4" />
+        <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+        <path d="M12 17h.01" />
+      </svg>
+      Plafond dépassé
+    </Badge>
+  </div>
+);
+
+export const WithCount = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Badge variant="secondary">
+      Transport <span className="num">12</span>
+    </Badge>
+    <Badge variant="outline">
+      Pharmacie <span className="num">3</span>
+    </Badge>
+    <Badge variant="default">
+      <span className="num">+18,4</span> %
+    </Badge>
+  </div>
+);
+
+export const InRow = () => (
+  <div className="flex items-center justify-between gap-4 border-b border-line-soft py-2.5">
+    <div className="flex items-center gap-2.5">
+      <span className="text-sm text-ink">Abonnement Netflix</span>
+      <Badge variant="secondary">Récurrent</Badge>
+    </div>
+    <span className="num text-sm text-ink-2">19,99 €</span>
+  </div>
+);

--- a/front/.design-sync/previews/Button.tsx
+++ b/front/.design-sync/previews/Button.tsx
@@ -1,0 +1,83 @@
+import { Download, Plus, Trash2 } from "lucide-react";
+import { Button, GlowCard, MoneyAmount } from "pfa-next";
+
+export const Variants = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button variant="primary">Ajouter une dépense</Button>
+    <Button variant="default">Enregistrer</Button>
+    <Button variant="secondary">Dupliquer</Button>
+    <Button variant="outline">Exporter</Button>
+    <Button variant="muted">Annuler</Button>
+    <Button variant="ghost">Réinitialiser</Button>
+    <Button variant="destructive">Supprimer</Button>
+    <Button variant="link">Voir le détail</Button>
+  </div>
+);
+
+export const Sizes = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button variant="primary" size="lg">
+      Ajouter une dépense
+    </Button>
+    <Button variant="primary" size="default">
+      Ajouter une dépense
+    </Button>
+    <Button variant="primary" size="sm">
+      Ajouter une dépense
+    </Button>
+    <Button variant="primary" size="icon" aria-label="Ajouter une dépense">
+      <Plus />
+    </Button>
+  </div>
+);
+
+export const WithIcons = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button variant="primary" size="sm">
+      <Plus />
+      Nouvelle dépense
+    </Button>
+    <Button variant="outline" size="sm">
+      <Download />
+      Exporter
+    </Button>
+    <Button variant="destructive" size="sm">
+      <Trash2 />
+      Supprimer
+    </Button>
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <Button variant="primary" disabled>
+      Enregistrer
+    </Button>
+    <Button variant="muted" disabled>
+      Annuler
+    </Button>
+    <Button variant="destructive" disabled>
+      Supprimer
+    </Button>
+  </div>
+);
+
+export const DialogFooter = () => (
+  <GlowCard as="section" className="p-5">
+    <h3 className="text-sm tracking-snug text-ink">Supprimer « Abonnement Netflix » ?</h3>
+    <p className="mt-1 flex flex-wrap items-baseline gap-x-1 text-2xs text-ink-4">
+      Le prélèvement de
+      <MoneyAmount value={13.49} unit="€" className="num text-2xs text-ink-2" decimalClassName="text-ink-4" />
+      du <span className="num">12</span> mai <span className="num">2026</span> sera retiré des dépenses fixes.
+    </p>
+    <div className="mt-4 flex justify-end gap-2">
+      <Button variant="muted" size="sm">
+        Annuler
+      </Button>
+      <Button variant="destructive" size="sm">
+        <Trash2 />
+        Supprimer
+      </Button>
+    </div>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/CardSectionHeader.tsx
+++ b/front/.design-sync/previews/CardSectionHeader.tsx
@@ -1,0 +1,68 @@
+import { Button, CardSectionHeader, GlowCard, MeterBar, MoneyAmount, Overline } from "pfa-next";
+
+export const WithMeta = () => (
+  <GlowCard className="max-w-md p-5">
+    <CardSectionHeader title="Dépenses fixes" meta="12 prélèvements" />
+    <div className="mt-4 flex items-baseline justify-between">
+      <MoneyAmount value={1240.5} className="num text-2xl font-medium text-ink" />
+      <span className="text-xs text-ink-3">soit 14 886,00 € / an</span>
+    </div>
+    <MeterBar value={72} height={6} className="mt-4" />
+  </GlowCard>
+);
+
+export const WithAction = () => (
+  <GlowCard className="max-w-md p-5">
+    <CardSectionHeader
+      title="Achats exceptionnels"
+      action={
+        <Button variant="ghost" size="sm">
+          Tout voir
+        </Button>
+      }
+    />
+    <ul className="mt-4 space-y-3">
+      <li className="flex items-baseline justify-between">
+        <span className="text-sm text-ink-2">Réparation voiture</span>
+        <MoneyAmount value={780} className="num text-sm text-exc" />
+      </li>
+      <li className="flex items-baseline justify-between">
+        <span className="text-sm text-ink-2">Pharmacie · ordonnance</span>
+        <MoneyAmount value={41.35} className="num text-sm text-exc" />
+      </li>
+    </ul>
+  </GlowCard>
+);
+
+export const TitleOnly = () => (
+  <GlowCard className="max-w-md p-5">
+    <CardSectionHeader title="Reste à vivre" />
+    <div className="mt-3 num text-display font-medium leading-none tracking-tight text-accent-strong">
+      <MoneyAmount value={412.8} />
+    </div>
+    <p className="mt-3 text-xs text-ink-3">13,76 € par jour jusqu'au 31 mai</p>
+  </GlowCard>
+);
+
+export const Stacked = () => (
+  <div className="flex max-w-md flex-col gap-4">
+    <GlowCard className="p-5">
+      <CardSectionHeader title="Plafond hebdomadaire" meta="semaine du 18 mai" />
+      <div className="mt-4 flex items-baseline justify-between">
+        <MoneyAmount value={286.4} className="num text-xl font-medium text-neg" />
+        <Overline>36,40 € au-dessus</Overline>
+      </div>
+    </GlowCard>
+    <GlowCard className="p-5">
+      <CardSectionHeader
+        title="Catégories"
+        action={
+          <Button variant="outline" size="sm">
+            Gérer
+          </Button>
+        }
+      />
+      <p className="mt-4 text-xs text-ink-3">Alimentation · Transport · Loyer · Courses</p>
+    </GlowCard>
+  </div>
+);

--- a/front/.design-sync/previews/CardTitle.tsx
+++ b/front/.design-sync/previews/CardTitle.tsx
@@ -1,0 +1,40 @@
+import { Button, CardTitle, GlowCard, MoneyAmount, Overline } from "pfa-next";
+
+export const Default = () => <CardTitle>Dépenses du mois</CardTitle>;
+
+export const InCard = () => (
+  <GlowCard className="max-w-md p-5">
+    <CardTitle>Alimentation</CardTitle>
+    <div className="mt-3 num text-2xl font-medium text-ink">
+      <MoneyAmount value={286.4} />
+    </div>
+    <p className="mt-1 text-2xs text-ink-4">18 % des dépenses · 24 fois</p>
+  </GlowCard>
+);
+
+export const StackedSubtitle = () => (
+  <GlowCard className="max-w-md p-5">
+    <div className="flex flex-col gap-1">
+      <CardTitle>Abonnement Netflix</CardTitle>
+      <span className="text-xs text-ink-4">Prélevé le 5 de chaque mois · depuis mars 2025</span>
+    </div>
+    <div className="mt-4 num text-xl font-medium text-ink">
+      <MoneyAmount value={19.99} />
+    </div>
+  </GlowCard>
+);
+
+export const WithInlineControl = () => (
+  <GlowCard className="max-w-md p-5">
+    <div className="flex items-baseline justify-between gap-3">
+      <div className="flex flex-col gap-1">
+        <Overline>Budget</Overline>
+        <CardTitle>Courses de la semaine</CardTitle>
+      </div>
+      <Button variant="ghost" size="sm">
+        Modifier
+      </Button>
+    </div>
+    <p className="mt-4 text-xs text-ink-3">Plafond 250,00 € · 24 mai 2026</p>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/CategoryComponent.tsx
+++ b/front/.design-sync/previews/CategoryComponent.tsx
@@ -1,0 +1,94 @@
+import { CategoryComponent } from "pfa-next";
+
+/** The 12 palette hues — oklch(0.80 0.09 <hue>) as the hex the backend stores. */
+const ALIMENTATION = "#9fcc95";
+const TRANSPORT = "#72cede";
+const LOYER = "#bcb4f4";
+const COURSES = "#c1c37e";
+const PHARMACIE = "#f0a6b6";
+const LOISIRS = "#d8abe2";
+
+export const Default = () => (
+  <CategoryComponent
+    item={{ category: "Alimentation", categoryColor: ALIMENTATION }}
+    customCss="w-24 py-0.5 pl-2"
+  />
+);
+
+export const Dynamic = () => (
+  <CategoryComponent
+    item={{ category: "Alimentation", categoryColor: ALIMENTATION }}
+    isDynamic
+    customCss="w-24 py-0.5"
+  />
+);
+
+export const Palette = () => (
+  <div className="flex flex-col gap-1.5">
+    <CategoryComponent
+      item={{ category: "Alimentation", categoryColor: ALIMENTATION }}
+      customCss="w-24 py-0.5 pl-2"
+    />
+    <CategoryComponent
+      item={{ category: "Transport", categoryColor: TRANSPORT }}
+      customCss="w-24 py-0.5 pl-2"
+    />
+    <CategoryComponent
+      item={{ category: "Loyer", categoryColor: LOYER }}
+      customCss="w-24 py-0.5 pl-2"
+    />
+    <CategoryComponent
+      item={{ category: "Courses", categoryColor: COURSES }}
+      customCss="w-24 py-0.5 pl-2"
+    />
+    <CategoryComponent
+      item={{ category: "Pharmacie", categoryColor: PHARMACIE }}
+      customCss="w-24 py-0.5 pl-2"
+    />
+  </div>
+);
+
+export const DynamicPalette = () => (
+  <div className="flex flex-wrap gap-1.5">
+    <CategoryComponent
+      item={{ category: "Alimentation", categoryColor: ALIMENTATION }}
+      isDynamic
+      customCss="px-2 py-0.5"
+    />
+    <CategoryComponent
+      item={{ category: "Transport", categoryColor: TRANSPORT }}
+      isDynamic
+      customCss="px-2 py-0.5"
+    />
+    <CategoryComponent
+      item={{ category: "Loyer", categoryColor: LOYER }}
+      isDynamic
+      customCss="px-2 py-0.5"
+    />
+    <CategoryComponent
+      item={{ category: "Loisirs", categoryColor: LOISIRS }}
+      isDynamic
+      customCss="px-2 py-0.5"
+    />
+    {/* Legacy dark colour from the backend — the label flips to white. */}
+    <CategoryComponent
+      item={{ category: "Abonnements", categoryColor: "#2f4858" }}
+      isDynamic
+      customCss="px-2 py-0.5"
+    />
+  </div>
+);
+
+export const NoCategory = () => (
+  <div className="flex flex-col items-start gap-1.5">
+    <CategoryComponent
+      item={{ category: null, categoryColor: null }}
+      customCss="w-fit py-0.5 pl-2 pr-2"
+    />
+    <CategoryComponent
+      item={{ category: null, categoryColor: null }}
+      isDynamic
+      customCss="w-fit py-0.5 px-2"
+    />
+  </div>
+);

--- a/front/.design-sync/previews/Checkbox.tsx
+++ b/front/.design-sync/previews/Checkbox.tsx
@@ -1,0 +1,137 @@
+import { Checkbox, GlowCard, Label, MoneyAmount, Overline } from "pfa-next";
+
+const ROW = "flex items-center gap-2.5";
+const TEXT = "text-sm text-ink-2";
+
+export const FormRows = () => (
+  <GlowCard
+    as="section"
+    className="w-[380px] p-5"
+  >
+    <Overline>Nouvelle dépense</Overline>
+    <div className="mt-4 flex flex-col gap-3.5">
+      <div className={ROW}>
+        <Checkbox
+          id="cb-recurring"
+          defaultChecked
+        />
+        <Label
+          htmlFor="cb-recurring"
+          className={TEXT}
+        >
+          Récurrente mensuelle
+        </Label>
+      </div>
+      <div className={ROW}>
+        <Checkbox id="cb-exceptional" />
+        <Label
+          htmlFor="cb-exceptional"
+          className={TEXT}
+        >
+          Achat exceptionnel
+        </Label>
+      </div>
+      <div className={ROW}>
+        <Checkbox id="cb-receipt" />
+        <Label
+          htmlFor="cb-receipt"
+          className={TEXT}
+        >
+          Joindre un reçu
+        </Label>
+      </div>
+    </div>
+  </GlowCard>
+);
+
+export const States = () => (
+  <div className="flex flex-col gap-3.5">
+    <div className={ROW}>
+      <Checkbox id="cb-s-off" />
+      <Label
+        htmlFor="cb-s-off"
+        className={TEXT}
+      >
+        Non cochée — Joindre un reçu
+      </Label>
+    </div>
+    <div className={ROW}>
+      <Checkbox
+        id="cb-s-on"
+        checked
+      />
+      <Label
+        htmlFor="cb-s-on"
+        className={TEXT}
+      >
+        Cochée — Récurrente mensuelle
+      </Label>
+    </div>
+    <div className={ROW}>
+      <Checkbox
+        id="cb-s-disabled"
+        disabled
+      />
+      <Label
+        htmlFor="cb-s-disabled"
+        className={TEXT}
+      >
+        Désactivée — Plafond hebdomadaire
+      </Label>
+    </div>
+    <div className={ROW}>
+      <Checkbox
+        id="cb-s-disabled-on"
+        disabled
+        checked
+      />
+      <Label
+        htmlFor="cb-s-disabled-on"
+        className={TEXT}
+      >
+        Désactivée cochée — Dépenses fixes
+      </Label>
+    </div>
+  </div>
+);
+
+export const CategoryFilter = () => (
+  <GlowCard
+    as="section"
+    className="w-[380px] p-5"
+  >
+    <Overline>Filtrer par catégorie</Overline>
+    <div className="mt-4 flex flex-col gap-3.5">
+      {[
+        { id: "cat-food", name: "Alimentation", total: 412.8, on: true },
+        { id: "cat-transport", name: "Transport", total: 118.4, on: true },
+        { id: "cat-rent", name: "Loyer", total: 780, on: false },
+        { id: "cat-pharmacy", name: "Pharmacie", total: 41.35, on: false },
+      ].map((c) => (
+        <div
+          key={c.id}
+          className="flex items-center justify-between gap-3"
+        >
+          <div className={ROW}>
+            <Checkbox
+              id={c.id}
+              checked={c.on}
+            />
+            <Label
+              htmlFor={c.id}
+              className={TEXT}
+            >
+              {c.name}
+            </Label>
+          </div>
+          <MoneyAmount
+            value={c.total}
+            unit="€"
+            className={c.on ? "num text-sm text-ink" : "num text-sm text-ink-4"}
+            decimalClassName="text-2xs"
+          />
+        </div>
+      ))}
+    </div>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/Command.tsx
+++ b/front/.design-sync/previews/Command.tsx
@@ -1,0 +1,170 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  FieldShell,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "pfa-next";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+/** Category colours come from the API as hex — the one data-driven colour in the app. */
+const CATEGORIES = [
+  { name: "Alimentation", color: "#4ade80" },
+  { name: "Transport", color: "#60a5fa" },
+  { name: "Loyer", color: "#f472b6" },
+  { name: "Courses", color: "#fbbf24" },
+  { name: "Pharmacie", color: "#a78bfa" },
+  { name: "Abonnement Netflix", color: "#fb7185" },
+];
+
+const Swatch = ({ color }: { color: string }) => (
+  <span
+    className="mr-1 size-2.5 shrink-0 rounded-xs"
+    style={{ backgroundColor: color }}
+  />
+);
+
+/**
+ * The category combobox of the spending modal: a Popover holding the Command,
+ * open on "Alimentation". Search-or-type — closing commits whatever was typed.
+ */
+export const CategoryCombobox = () => (
+  <FieldShell
+    label="Catégorie"
+    className="w-72"
+  >
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        {/* the app's trigger is a raw button — comboboxTriggerClass(open: true) */}
+        <button
+          type="button"
+          className="flex w-full items-center gap-2.5 rounded-md border border-accent-d bg-background px-3 py-2.5 text-left text-sm text-ink transition-colors"
+        >
+          <span
+            className="size-2.5 shrink-0 rounded-xs"
+            style={{ backgroundColor: "#4ade80" }}
+          />
+          <span className="capitalize">Alimentation</span>
+          <ChevronsUpDown className="ml-auto size-4 shrink-0 text-ink-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-[--radix-popover-trigger-width] border-line bg-surface-elev p-0"
+        align="start"
+      >
+        <Command
+          className="bg-transparent"
+          value="Alimentation"
+        >
+          <CommandInput placeholder="Rechercher ou saisir…" />
+          <CommandList>
+            <CommandEmpty>Aucune catégorie.</CommandEmpty>
+            <CommandGroup>
+              <CommandItem value="__none">
+                <span className="text-ink-4">Aucune catégorie</span>
+              </CommandItem>
+              {CATEGORIES.map((c) => (
+                <CommandItem
+                  key={c.name}
+                  value={c.name}
+                >
+                  <Swatch color={c.color} />
+                  <span className="flex-1 capitalize">{c.name}</span>
+                  {c.name === "Alimentation" && <Check className="size-4 text-accent-strong" />}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  </FieldShell>
+);
+
+/** Group headings + a separator: quick-picks above the full category list. */
+export const Grouped = () => (
+  <Command
+    className="w-72 rounded-md border border-line"
+    value="Transport"
+  >
+    <CommandInput placeholder="Rechercher ou saisir…" />
+    <CommandList>
+      <CommandEmpty>Aucune catégorie.</CommandEmpty>
+      <CommandGroup heading="Fréquentes">
+        {CATEGORIES.slice(0, 3).map((c) => (
+          <CommandItem
+            key={c.name}
+            value={c.name}
+          >
+            <Swatch color={c.color} />
+            <span className="flex-1 capitalize">{c.name}</span>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+      <CommandSeparator />
+      <CommandGroup heading="Toutes les catégories">
+        {CATEGORIES.slice(3).map((c) => (
+          <CommandItem
+            key={c.name}
+            value={c.name}
+          >
+            <Swatch color={c.color} />
+            <span className="flex-1 capitalize">{c.name}</span>
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    </CommandList>
+  </Command>
+);
+
+/**
+ * A query with no exact match: the typed value is offered as a plain option
+ * (grey swatch) — selecting it, or just closing, creates the category.
+ */
+export const SearchAndCreate = () => (
+  <Command
+    className="w-72 rounded-md border border-line"
+    shouldFilter={false}
+    value="__new-Pharmacie du centre"
+  >
+    <CommandInput
+      placeholder="Rechercher ou saisir…"
+      value="Pharmacie du centre"
+    />
+    <CommandList>
+      <CommandEmpty>Aucune catégorie.</CommandEmpty>
+      <CommandGroup>
+        <CommandItem value="Pharmacie">
+          <Swatch color="#a78bfa" />
+          <span className="flex-1 capitalize">Pharmacie</span>
+        </CommandItem>
+        <CommandItem value="__new-Pharmacie du centre">
+          <span className="mr-1 size-2.5 shrink-0 rounded-xs bg-ink-4" />
+          <span className="flex-1 capitalize">Pharmacie du centre</span>
+        </CommandItem>
+      </CommandGroup>
+    </CommandList>
+  </Command>
+);
+
+/** No result at all — `CommandEmpty` takes over the list. */
+export const Empty = () => (
+  <Command
+    className="w-72 rounded-md border border-line"
+    shouldFilter={false}
+  >
+    <CommandInput
+      placeholder="Rechercher ou saisir…"
+      value="Assurance vie"
+    />
+    <CommandList>
+      <CommandEmpty>Aucune catégorie.</CommandEmpty>
+    </CommandList>
+  </Command>
+);

--- a/front/.design-sync/previews/ConfirmDeleteDialog.tsx
+++ b/front/.design-sync/previews/ConfirmDeleteDialog.tsx
@@ -1,0 +1,47 @@
+import { ConfirmDeleteDialog } from "pfa-next";
+
+const noop = () => {};
+
+/**
+ * The Catégories story: a quoted category name (capitalized via `titleClassName`,
+ * since names are stored lowercased) plus the consequence spelled out.
+ */
+export const Default = () => (
+  <ConfirmDeleteDialog
+    open
+    onOpenChange={noop}
+    title="Supprimer la catégorie « alimentation » ?"
+    titleClassName="capitalize"
+    description="Cette action est irréversible. Les dépenses associées n'auront plus de catégorie."
+    onConfirm={noop}
+  />
+);
+
+/**
+ * Title only — `description` falls back to the standard irreversible-action
+ * warning, as in the Achats exceptionnels list.
+ */
+export const DefaultDescription = () => (
+  <ConfirmDeleteDialog
+    open
+    onOpenChange={noop}
+    title="Supprimer Canapé Ikea ?"
+    onConfirm={noop}
+  />
+);
+
+/**
+ * Custom `confirmLabel` / `cancelLabel` when the generic verbs would be
+ * ambiguous — here the receipt attached to a spending, not the spending itself.
+ */
+export const CustomLabels = () => (
+  <ConfirmDeleteDialog
+    open
+    onOpenChange={noop}
+    title={<>Supprimer la facture&nbsp;?</>}
+    description="Le reçu de Courses Carrefour du 14 mai 2026 sera détaché de la dépense. La dépense, elle, est conservée."
+    confirmLabel="Supprimer le reçu"
+    cancelLabel="Conserver"
+    onConfirm={noop}
+  />
+);

--- a/front/.design-sync/previews/Dialog.tsx
+++ b/front/.design-sync/previews/Dialog.tsx
@@ -1,0 +1,136 @@
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  FieldShell,
+  Overline,
+  TextInput,
+} from "pfa-next";
+
+/** The 12 category hues, from the hue-only palette `oklch(0.80 0.09 <hue>)`. */
+const PALETTE_HUES = [5, 25, 60, 80, 110, 140, 175, 210, 250, 290, 320, 350];
+
+/**
+ * The canonical form modal — the "Nouvelle dépense" sheet: bordered header,
+ * scrollable field body, bordered footer with cancel + primary action.
+ */
+export const Default = () => (
+  <Dialog open>
+    <DialogContent className="gap-0 overflow-hidden border-line bg-surface-elev p-0 sm:max-w-[480px]">
+      <DialogHeader className="flex-row items-center justify-between space-y-0 border-b border-line-soft px-5.5 py-4.5 text-left">
+        <DialogTitle className="pr-8 text-base font-semibold tracking-normal text-ink">Nouvelle dépense</DialogTitle>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-4.5 px-5.5 py-5.5">
+        <FieldShell label="Date" htmlFor="dlg-date">
+          <TextInput
+            id="dlg-date"
+            type="date"
+            defaultValue="2026-05-14"
+            className="num [color-scheme:dark]"
+          />
+        </FieldShell>
+
+        <FieldShell label="Libellé" htmlFor="dlg-label">
+          <TextInput id="dlg-label" defaultValue="Courses Carrefour" placeholder="Ex. Pharmacie" />
+        </FieldShell>
+
+        <FieldShell label="Montant" htmlFor="dlg-amount">
+          <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-3 py-2.5">
+            <input
+              id="dlg-amount"
+              inputMode="decimal"
+              defaultValue="41,35"
+              className="num min-w-0 flex-1 bg-transparent text-sm font-medium tracking-tight text-ink outline-none placeholder:text-ink-5"
+            />
+            <span className="num text-sm text-ink-3">€</span>
+          </div>
+        </FieldShell>
+      </div>
+
+      <DialogFooter className="gap-2.5 border-t border-line-soft px-5.5 py-4 sm:gap-2.5">
+        <Button type="button" variant="muted">
+          Annuler
+        </Button>
+        <Button type="submit" variant="primary">
+          Ajouter la dépense
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
+/**
+ * Header with a `DialogDescription`, and a `DialogClose` wrapping the cancel
+ * button — the confirm-style dialog used for the copy-recurrings action.
+ */
+export const WithDescription = () => (
+  <Dialog open>
+    <DialogContent className="border-line bg-surface-elev sm:max-w-[452px]">
+      <DialogHeader>
+        <DialogTitle className="text-ink">Copier les dépenses fixes ?</DialogTitle>
+        <DialogDescription className="text-ink-3">
+          Les 12 prélèvements d'avril 2026 seront recréés sur mai 2026, pour un total de{" "}
+          <span className="num text-ink-2">1 240,50 €</span>. Vous pourrez les modifier ensuite.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogFooter>
+        <DialogClose asChild>
+          <Button type="button" variant="muted">
+            Annuler
+          </Button>
+        </DialogClose>
+        <Button type="button" variant="primary">
+          Copier 12 dépenses
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);
+
+/**
+ * The "Nouvelle catégorie" sheet in its error state: the name is already taken,
+ * so `FieldShell` surfaces the message under the invalid input.
+ */
+export const WithFieldError = () => (
+  <Dialog open>
+    <DialogContent className="border-line bg-surface-elev sm:max-w-[452px]">
+      <DialogHeader>
+        <DialogTitle className="text-ink">Nouvelle catégorie</DialogTitle>
+      </DialogHeader>
+
+      <div className="flex flex-col gap-5">
+        <FieldShell label="Nom" htmlFor="dlg-cat-name" error="Cette catégorie existe déjà.">
+          <TextInput id="dlg-cat-name" defaultValue="Alimentation" aria-invalid />
+        </FieldShell>
+
+        <div className="flex flex-col gap-2.5">
+          <Overline>Couleur</Overline>
+          <div className="flex flex-wrap gap-2.5">
+            {PALETTE_HUES.map((hue) => (
+              <span
+                key={hue}
+                className={`size-[30px] rounded-md border-2 ${hue === 140 ? "border-ink" : "border-transparent"}`}
+                style={{ background: `oklch(0.80 0.09 ${hue})` }}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button type="button" variant="ghost">
+          Annuler
+        </Button>
+        <Button type="button" variant="primary">
+          Créer
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+);

--- a/front/.design-sync/previews/DividedStrip.tsx
+++ b/front/.design-sync/previews/DividedStrip.tsx
@@ -1,0 +1,130 @@
+import { TrendingUp, TriangleAlert, Wallet } from "lucide-react";
+import { DividedStrip, MoneyAmount, Overline, StatTile } from "pfa-next";
+
+import type { ReactNode } from "react";
+
+/** Page-level composition used by the dashboard ribbon — each cell owns its opaque `bg-card` fill. */
+const Insight = ({
+  tone,
+  icon,
+  label,
+  children,
+}: {
+  tone: string;
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+}) => (
+  <div className="flex items-start gap-3 bg-card px-4.5 py-3.5">
+    <span className={`mt-0.5 grid size-7 shrink-0 place-items-center rounded-md ${tone}`}>{icon}</span>
+    <div className="flex flex-col gap-0.5">
+      <Overline className="text-ink-3">{label}</Overline>
+      <span className="text-sm text-ink-2">{children}</span>
+    </div>
+  </div>
+);
+
+export const Default = () => (
+  <DividedStrip className="grid-cols-3">
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Total du mois"
+      value={<MoneyAmount value={1240.5} />}
+      sub="12 prélèvements"
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Reste à vivre"
+      value={<MoneyAmount value={780} />}
+      sub="d'ici le 31 mai"
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Transactions"
+      value="24"
+      sub="sur 7 jours"
+    />
+  </DividedStrip>
+);
+
+export const TwoUp = () => (
+  <DividedStrip className="grid-cols-2">
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Dépenses fixes"
+      value={<MoneyAmount value={912.3} />}
+      sub="Loyer · Abonnement Netflix · Mutuelle"
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Achats exceptionnels"
+      value={<MoneyAmount value={328.2} />}
+      subClassName="text-xs text-exc"
+      sub="3 achats en mai 2026"
+    />
+  </DividedStrip>
+);
+
+export const SummaryStrip = () => (
+  <DividedStrip className="grid-cols-5">
+    <div className="bg-card px-5 py-4">
+      <Overline className="mb-2 block">Budget restant</Overline>
+      <div className="num text-4xl font-medium leading-none tracking-tight text-ink">
+        780<span className="text-lg font-normal text-ink-3">,00 €</span>
+      </div>
+    </div>
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Total semaine"
+      value={<MoneyAmount value={286.4} decimalClassName="text-lg" />}
+      sub={<span className="text-accent-strong">−36 € sous plafond</span>}
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Transactions"
+      value="24"
+      sub="sur 7 jours · 3,4/jour"
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Moyenne / jour"
+      value={<MoneyAmount value={40.91} decimalClassName="text-lg" />}
+      sub={<span className="text-neg">+12 € vs sem. dernière</span>}
+    />
+    <StatTile
+      className="bg-card px-5 py-4"
+      label="Plus grosse"
+      value={<MoneyAmount value={78.2} decimalClassName="text-lg" />}
+      sub="Courses · 14 mai"
+    />
+  </DividedStrip>
+);
+
+export const Insights = () => (
+  <DividedStrip className="grid-cols-3">
+    <Insight
+      tone="bg-accent-strong/10 text-accent-strong"
+      icon={<TrendingUp className="size-3.5" />}
+      label="Sur le rythme"
+    >
+      Tu consommes <b className="font-semibold text-ink">~16% moins vite</b> que ta moyenne 3 mois. À ce rythme, tu
+      termines le mois <b className="font-semibold text-ink">sous ton budget</b>.
+    </Insight>
+    <Insight
+      tone="bg-neg/10 text-neg"
+      icon={<TriangleAlert className="size-3.5" />}
+      label="Catégorie en hausse"
+    >
+      <b className="font-semibold text-ink">Alimentation</b> à <b className="num font-semibold text-ink">+24%</b> vs le
+      mois dernier.
+    </Insight>
+    <Insight
+      tone="bg-surface-hi text-ink-2"
+      icon={<Wallet className="size-3.5" />}
+      label="Reste à vivre"
+    >
+      Il te reste <b className="num font-semibold text-ink">46 €</b>/jour à dépenser d&apos;ici le{" "}
+      <b className="font-semibold text-ink">31 mai</b> pour rester dans ton budget.
+    </Insight>
+  </DividedStrip>
+);

--- a/front/.design-sync/previews/DropdownMenu.tsx
+++ b/front/.design-sync/previews/DropdownMenu.tsx
@@ -1,0 +1,174 @@
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "pfa-next";
+import { ChevronDown, Copy, FileSpreadsheet, FileText, KeyRound, LogOut, Pencil, Trash2 } from "lucide-react";
+
+/** The avatar + email + chevron trigger of the navbar user menu, verbatim from `UserMenu`. */
+const AccountTrigger = () => (
+  <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2.5 rounded-md outline-hidden">
+    <span className="grid size-[30px] flex-shrink-0 place-items-center rounded-full border border-line bg-surface-hi text-2xs font-medium text-ink-2">
+      CM
+    </span>
+    <span className="max-w-[200px] truncate text-sm text-ink-2">camille.morel@gmail.com</span>
+    <ChevronDown className="size-4 flex-shrink-0 text-ink-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
+  </DropdownMenuTrigger>
+);
+
+/** A compact row-action trigger, as the spendings table uses. */
+const RowTrigger = ({ label }: { label: string }) => (
+  <DropdownMenuTrigger className="inline-flex cursor-pointer items-center gap-2 rounded-sm border border-line bg-surface-elev px-2.5 py-2 text-sm text-ink-2 outline-hidden transition-colors hover:border-ink-4">
+    {label}
+    <ChevronDown className="size-3 text-ink-4" />
+  </DropdownMenuTrigger>
+);
+
+/**
+ * The canonical story: the navbar account menu — the app's only DropdownMenu.
+ * `defaultOpen` so the portalled content renders; `align="end"` hangs it under
+ * the avatar the way the real navbar does.
+ */
+export const UserMenu = () => (
+  <DropdownMenu defaultOpen>
+    <AccountTrigger />
+    <DropdownMenuContent
+      align="end"
+      sideOffset={12}
+      className="w-64 p-1"
+    >
+      <DropdownMenuItem className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2">
+        <KeyRound className="size-4 text-accent-strong" />
+        Modifier le mot de passe
+      </DropdownMenuItem>
+      <DropdownMenuSeparator className="my-1" />
+      <DropdownMenuItem className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2">
+        <LogOut className="size-4 text-ink-3" />
+        Se déconnecter
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+/**
+ * `DropdownMenuItem`'s variant axis — `default` vs `destructive` (the red delete
+ * affordance) — plus the `disabled` state, and the `Label` / `Group` /
+ * `Separator` / `Shortcut` sub-parts that have no card of their own.
+ */
+export const ItemVariants = () => (
+  <DropdownMenu defaultOpen>
+    <RowTrigger label="Courses — 41,35 €" />
+    <DropdownMenuContent
+      align="start"
+      className="w-64"
+    >
+      <DropdownMenuLabel className="text-ink-3">Dépense du 12 mai 2026</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      <DropdownMenuGroup>
+        <DropdownMenuItem>
+          <Pencil />
+          Modifier
+          <DropdownMenuShortcut>⌘E</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem>
+          <Copy />
+          Dupliquer
+          <DropdownMenuShortcut>⌘D</DropdownMenuShortcut>
+        </DropdownMenuItem>
+        <DropdownMenuItem disabled>
+          <FileText />
+          Voir le justificatif
+        </DropdownMenuItem>
+      </DropdownMenuGroup>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem variant="destructive">
+        <Trash2 />
+        Supprimer
+      </DropdownMenuItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+/** `DropdownMenuCheckboxItem` — multi-select toggles with the check indicator in the left gutter. */
+export const CheckboxItems = () => (
+  <DropdownMenu defaultOpen>
+    <RowTrigger label="Afficher" />
+    <DropdownMenuContent
+      align="start"
+      className="w-64"
+    >
+      <DropdownMenuLabel className="text-ink-3">Lignes affichées</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      <DropdownMenuCheckboxItem checked>Dépenses fixes</DropdownMenuCheckboxItem>
+      <DropdownMenuCheckboxItem checked>Achats exceptionnels</DropdownMenuCheckboxItem>
+      <DropdownMenuCheckboxItem>Catégories archivées</DropdownMenuCheckboxItem>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+/** `DropdownMenuRadioGroup` / `DropdownMenuRadioItem` — one-of-N, dot indicator on the current value. */
+export const RadioItems = () => (
+  <DropdownMenu defaultOpen>
+    <RowTrigger label="Trier par" />
+    <DropdownMenuContent
+      align="start"
+      className="w-64"
+    >
+      <DropdownMenuLabel className="text-ink-3">Trier les dépenses</DropdownMenuLabel>
+      <DropdownMenuSeparator />
+      <DropdownMenuRadioGroup value="date">
+        <DropdownMenuRadioItem value="date">Date — récent → ancien</DropdownMenuRadioItem>
+        <DropdownMenuRadioItem value="amount">Montant décroissant</DropdownMenuRadioItem>
+        <DropdownMenuRadioItem value="category">Catégorie (A → Z)</DropdownMenuRadioItem>
+      </DropdownMenuRadioGroup>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);
+
+/**
+ * `DropdownMenuSub` — both levels pinned open so the sub-trigger's open state and
+ * `SubContent` render.
+ *
+ * The sub is *controlled* (`open`), not `defaultOpen`, and that is load-bearing:
+ * Radix's `MenuSub` runs `useEffect(… , return () => handleOpenChange(false))`, so
+ * the effect's cleanup force-closes the sub and nothing ever reopens it — an
+ * uncontrolled `defaultOpen` sub renders its trigger but never its `SubContent`.
+ * Controlled `open` ignores that close and is the only way to pin a submenu for a
+ * static capture.
+ */
+export const Submenu = () => (
+  <DropdownMenu defaultOpen>
+    <RowTrigger label="Mai 2026" />
+    <DropdownMenuContent
+      align="start"
+      className="w-56"
+    >
+      <DropdownMenuItem>
+        <Pencil />
+        Renommer la période
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuSub open>
+        <DropdownMenuSubTrigger>
+          <FileSpreadsheet className="mr-2 size-4 text-ink-4" />
+          Exporter
+        </DropdownMenuSubTrigger>
+        <DropdownMenuSubContent className="w-44">
+          <DropdownMenuItem>Format CSV</DropdownMenuItem>
+          <DropdownMenuItem>Format PDF</DropdownMenuItem>
+        </DropdownMenuSubContent>
+      </DropdownMenuSub>
+    </DropdownMenuContent>
+  </DropdownMenu>
+);

--- a/front/.design-sync/previews/Dropzone.tsx
+++ b/front/.design-sync/previews/Dropzone.tsx
@@ -1,0 +1,68 @@
+import { Dropzone, GlowCard, Overline } from "pfa-next";
+import { Upload } from "lucide-react";
+
+const IMAGE_TYPES = "image/jpeg,image/png,image/webp,image/gif";
+const noop = () => {};
+
+/**
+ * The receipt field of the spending modal: the compact row shape — icon tile on
+ * the left, label + accepted types stacked next to it.
+ */
+export const ReceiptRow = () => (
+  <Dropzone
+    accept={IMAGE_TYPES}
+    onFile={noop}
+    className="w-[340px] items-center gap-3 rounded-md px-4 py-3.5"
+  >
+    <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-elec/10 text-elec">
+      <Upload className="size-5" />
+    </span>
+    <span className="flex min-w-0 flex-col gap-0.5">
+      <span className="text-sm font-semibold text-ink">
+        Glisser un reçu ou <span className="text-elec underline underline-offset-2">parcourir</span>
+      </span>
+      <span className="num text-xs text-ink-4">jpg, png, webp</span>
+    </span>
+  </Dropzone>
+);
+
+/**
+ * The invoice modal's upload zone: the tall centred column shape, the same
+ * component with a different `className`.
+ */
+export const InvoiceColumn = () => (
+  <Dropzone
+    accept={IMAGE_TYPES}
+    onFile={noop}
+    className="w-[340px] flex-col items-center gap-1.5 rounded-xl px-5.5 py-7.5 text-center"
+  >
+    <Upload className="size-7.5 text-elec" />
+    <span className="text-base font-semibold text-ink">Choisir une facture</span>
+    <span className="num text-sm text-ink-4">jpg, png, webp — 5 Mo max</span>
+  </Dropzone>
+);
+
+/** In context: the receipt zone on a card surface, under its section label. */
+export const InCard = () => (
+  <GlowCard
+    as="section"
+    className="w-[340px] p-5"
+  >
+    <Overline>Reçu</Overline>
+    <Dropzone
+      accept={IMAGE_TYPES}
+      onFile={noop}
+      className="mt-3 items-center gap-3 rounded-md px-4 py-3.5"
+    >
+      <span className="grid size-10 shrink-0 place-items-center rounded-lg bg-elec/10 text-elec">
+        <Upload className="size-5" />
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-sm font-semibold text-ink">
+          Glisser un reçu ou <span className="text-elec underline underline-offset-2">parcourir</span>
+        </span>
+        <span className="num text-xs text-ink-4">Uber — 41,35 € — 14 mai 2026</span>
+      </span>
+    </Dropzone>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/EmptyState.tsx
+++ b/front/.design-sync/previews/EmptyState.tsx
@@ -1,0 +1,29 @@
+import { CardSectionHeader, EmptyState, GlowCard } from "pfa-next";
+
+/** The default `py-6` density, as used under a list that came back empty. */
+export const Default = () => <EmptyState>Aucune dépense fixe ce mois.</EmptyState>;
+
+/** The roomier `py-10` variant — for cards whose body would otherwise collapse. */
+export const Roomy = () => <EmptyState className="py-10">Aucune dépense ce mois.</EmptyState>;
+
+/** Canonical usage: the placeholder standing in for the rows of a card. */
+export const InCard = () => (
+  <GlowCard
+    as="section"
+    className="flex flex-col gap-4 px-6 py-5"
+  >
+    <CardSectionHeader title="Dépenses fixes" meta="mai 2026" />
+    <EmptyState>Aucune dépense fixe ce mois.</EmptyState>
+  </GlowCard>
+);
+
+/** The "no data yet" wording, used before a month has any history to chart. */
+export const NoDataYet = () => (
+  <GlowCard
+    as="section"
+    className="flex flex-col gap-4 px-6 py-5"
+  >
+    <CardSectionHeader title="Plafond hebdomadaire" meta="4 semaines" />
+    <EmptyState className="py-10">Pas encore de données.</EmptyState>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/ExportButton.tsx
+++ b/front/.design-sync/previews/ExportButton.tsx
@@ -1,0 +1,30 @@
+import { CardSectionHeader, ExportButton, FilterChip, GlowCard } from "pfa-next";
+
+const CHIP = "gap-1.5 rounded-full px-3 capitalize";
+
+export const Default = () => <ExportButton />;
+
+export const InCardHeader = () => (
+  <GlowCard as="section" className="p-5">
+    <CardSectionHeader title="Achats exceptionnels" action={<ExportButton />} />
+    <p className="mt-3 text-2xs text-ink-4">
+      Mai 2026 · <span className="num">8</span> dépenses · <span className="num">780,00 €</span>
+    </p>
+  </GlowCard>
+);
+
+/** The real call site: pushed to the far right of the statistics filter bar. */
+export const InFilterBar = () => (
+  <section className="flex flex-wrap items-center gap-2 rounded-lg border border-line bg-surface-elev p-3">
+    <FilterChip active accentColor="oklch(0.80 0.09 150)" className={CHIP}>
+      Alimentation
+    </FilterChip>
+    <FilterChip active accentColor="oklch(0.80 0.09 350)" className={CHIP}>
+      Transport
+    </FilterChip>
+    <FilterChip active={false} className={CHIP}>
+      Loyer
+    </FilterChip>
+    <ExportButton className="ml-auto" />
+  </section>
+);

--- a/front/.design-sync/previews/FieldShell.tsx
+++ b/front/.design-sync/previews/FieldShell.tsx
@@ -1,0 +1,46 @@
+import { FieldShell, TextInput } from "pfa-next";
+
+const FIELD = "w-64";
+
+export const Base = () => (
+  <FieldShell label="Libellé" htmlFor="fs-label" className={FIELD}>
+    <TextInput id="fs-label" placeholder="Courses, Uber, Pharmacie…" />
+  </FieldShell>
+);
+
+export const Filled = () => (
+  <FieldShell label="Montant" htmlFor="fs-amount" className={FIELD}>
+    <TextInput id="fs-amount" className="num" type="number" step="0.01" defaultValue="41.35" />
+  </FieldShell>
+);
+
+export const WithError = () => (
+  <FieldShell
+    label="Montant"
+    htmlFor="fs-amount-err"
+    error="Le montant doit être supérieur à 0."
+    className={FIELD}
+  >
+    <TextInput id="fs-amount-err" className="num" aria-invalid defaultValue="0,00" />
+  </FieldShell>
+);
+
+export const Disabled = () => (
+  <FieldShell label="Catégorie" htmlFor="fs-category" className={FIELD}>
+    <TextInput id="fs-category" disabled defaultValue="Alimentation" />
+  </FieldShell>
+);
+
+export const Form = () => (
+  <div className={`flex flex-col gap-4 ${FIELD}`}>
+    <FieldShell label="Libellé" htmlFor="fs-form-label">
+      <TextInput id="fs-form-label" defaultValue="Abonnement Netflix" />
+    </FieldShell>
+    <FieldShell label="Montant" htmlFor="fs-form-amount">
+      <TextInput id="fs-form-amount" className="num" type="number" step="0.01" defaultValue="13.49" />
+    </FieldShell>
+    <FieldShell label="Date" htmlFor="fs-form-date" error="Date hors du mois en cours.">
+      <TextInput id="fs-form-date" className="num" type="date" aria-invalid defaultValue="2026-05-14" />
+    </FieldShell>
+  </div>
+);

--- a/front/.design-sync/previews/FilterChip.tsx
+++ b/front/.design-sync/previews/FilterChip.tsx
@@ -1,0 +1,53 @@
+import { FilterChip } from "pfa-next";
+
+const SHAPE = "gap-1.5 rounded-full px-3 capitalize";
+
+export const States = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <FilterChip active className={SHAPE}>
+      Toutes
+    </FilterChip>
+    <FilterChip active={false} className={SHAPE}>
+      Alimentation
+    </FilterChip>
+    <FilterChip active={false} className={SHAPE}>
+      Transport
+    </FilterChip>
+  </div>
+);
+
+export const Accents = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <FilterChip active accent="accent" className={SHAPE}>
+      Courantes
+    </FilterChip>
+    <FilterChip active accent="exc" className={SHAPE}>
+      Exceptionnels
+    </FilterChip>
+  </div>
+);
+
+/** Category colours come from the backend as hex — the active tint is `${accentColor}1f`, so hex is required. */
+const Dot = ({ color }: { color: string }) => (
+  <span className="size-2 shrink-0 rounded-xs" style={{ background: color }} />
+);
+
+export const CategoryColours = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <FilterChip active accentColor="#9fcc95" className={SHAPE}>
+      <Dot color="#9fcc95" />
+      Alimentation
+      <span className="num text-2xs opacity-70">24</span>
+    </FilterChip>
+    <FilterChip active accentColor="#eba6c6" className={SHAPE}>
+      <Dot color="#eba6c6" />
+      Subsistance
+      <span className="num text-2xs opacity-70">8</span>
+    </FilterChip>
+    <FilterChip active={false} className={SHAPE}>
+      <Dot color="#72cede" />
+      Pharmacie
+      <span className="num text-2xs text-ink-4">2</span>
+    </FilterChip>
+  </div>
+);

--- a/front/.design-sync/previews/GlowCard.tsx
+++ b/front/.design-sync/previews/GlowCard.tsx
@@ -1,0 +1,46 @@
+import { CardSectionHeader, GlowCard, MeterBar, MoneyAmount, Overline, StatTile } from "pfa-next";
+
+export const Default = () => (
+  <GlowCard className="max-w-md p-5">
+    <CardSectionHeader title="Dépenses fixes" meta="12 prélèvements" />
+    <div className="mt-4 flex items-baseline justify-between">
+      <MoneyAmount value={1240.5} className="num text-2xl font-medium text-ink" />
+      <span className="text-xs text-ink-3">soit 14 886,00 € / an</span>
+    </div>
+    <MeterBar value={72} height={6} className="mt-4" />
+    <p className="mt-2 text-2xs tracking-caps text-ink-4">72 % DU BUDGET MENSUEL</p>
+  </GlowCard>
+);
+
+export const AsSection = () => (
+  <GlowCard as="section" className="max-w-md p-5">
+    <Overline>Reste à vivre</Overline>
+    <div className="mt-2 num text-display font-medium leading-none tracking-tight text-accent-strong">
+      <MoneyAmount value={412.8} />
+    </div>
+    <p className="mt-3 text-xs text-ink-3">13,76 € par jour jusqu'au 31 mai</p>
+  </GlowCard>
+);
+
+export const Hover = () => (
+  <GlowCard hover className="max-w-xs p-4">
+    <div className="flex items-center gap-2">
+      <span className="size-2.5 rounded-full" style={{ background: "oklch(0.80 0.09 150)" }} />
+      <span className="text-sm text-ink">Alimentation</span>
+    </div>
+    <div className="mt-3 num text-lg font-medium text-ink">
+      <MoneyAmount value={286.4} />
+    </div>
+    <p className="mt-1 text-2xs text-ink-4">18 % des dépenses · 24 fois</p>
+  </GlowCard>
+);
+
+export const StatGrid = () => (
+  <GlowCard className="max-w-lg p-5">
+    <div className="grid grid-cols-3 gap-4">
+      <StatTile label="Total" value={<MoneyAmount value={1240.5} />} sub="ce mois" />
+      <StatTile label="Moyenne / jour" value={<MoneyAmount value={41.35} />} sub="sur 30 jours" />
+      <StatTile label="Plus grosse" value={<MoneyAmount value={780} />} sub="Loyer · 5 mai" />
+    </div>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/IconButton.tsx
+++ b/front/.design-sync/previews/IconButton.tsx
@@ -1,0 +1,82 @@
+import { ChevronLeft, ChevronRight, ImageIcon, Menu, Pencil, Plus, Trash2, X } from "lucide-react";
+import { GlowCard, IconButton, MoneyAmount } from "pfa-next";
+
+/**
+ * `bordered` and `danger` share the same resting chrome — `danger` only diverges on
+ * hover (danger border/surface + `text-neg`), which a static capture cannot show.
+ */
+export const Variants = () => (
+  <div className="flex flex-wrap items-start gap-3">
+    <div className="flex flex-col items-center gap-1.5">
+      <IconButton variant="bordered" size={8} aria-label="Modifier la dépense">
+        <Pencil />
+      </IconButton>
+      <span className="text-3xs tracking-caps text-ink-4">BORDERED</span>
+    </div>
+    <div className="flex flex-col items-center gap-1.5">
+      <IconButton variant="ghost" size={8} aria-label="Fermer le menu">
+        <X />
+      </IconButton>
+      <span className="text-3xs tracking-caps text-ink-4">GHOST</span>
+    </div>
+    <div className="flex flex-col items-center gap-1.5">
+      <IconButton variant="danger" size={8} aria-label="Supprimer la dépense">
+        <Trash2 />
+      </IconButton>
+      <span className="text-3xs tracking-caps text-ink-4">DANGER</span>
+    </div>
+  </div>
+);
+
+export const Sizes = () => (
+  <div className="flex flex-wrap items-center gap-3">
+    <IconButton variant="bordered" size={5} aria-label="Mois précédent">
+      <ChevronLeft />
+    </IconButton>
+    <IconButton variant="bordered" size={6} aria-label="Voir la facture">
+      <ImageIcon />
+    </IconButton>
+    <IconButton variant="bordered" size={7} aria-label="Modifier">
+      <Pencil />
+    </IconButton>
+    <IconButton variant="bordered" size={8} aria-label="Ajouter une dépense fixe">
+      <Plus />
+    </IconButton>
+    <IconButton variant="bordered" size={9} aria-label="Ouvrir le menu">
+      <Menu />
+    </IconButton>
+  </div>
+);
+
+export const RowActions = () => (
+  <GlowCard className="flex items-center gap-3 p-4">
+    <div className="min-w-0 flex-1">
+      <p className="truncate text-sm text-ink">Courses — Carrefour</p>
+      <p className="num text-2xs text-ink-4">14 mai 2026 · Alimentation</p>
+    </div>
+    <MoneyAmount value={41.35} unit="€" className="num text-sm text-ink" decimalClassName="text-2xs text-ink-4" />
+    <div className="flex items-center gap-1.5">
+      <IconButton variant="bordered" size={7} title="Voir le reçu">
+        <ImageIcon />
+      </IconButton>
+      <IconButton variant="bordered" size={7} title="Modifier">
+        <Pencil />
+      </IconButton>
+      <IconButton variant="danger" size={7} title="Supprimer">
+        <Trash2 />
+      </IconButton>
+    </div>
+  </GlowCard>
+);
+
+export const MonthNav = () => (
+  <div className="inline-flex items-center gap-2 rounded-md border border-line bg-surface-hi px-2 py-1">
+    <IconButton variant="ghost" size={5} aria-label="Mois précédent">
+      <ChevronLeft />
+    </IconButton>
+    <span className="num text-2xs tracking-caps text-ink-2">MAI 2026</span>
+    <IconButton variant="ghost" size={5} aria-label="Mois suivant">
+      <ChevronRight />
+    </IconButton>
+  </div>
+);

--- a/front/.design-sync/previews/Input.tsx
+++ b/front/.design-sync/previews/Input.tsx
@@ -1,0 +1,32 @@
+import { Input } from "pfa-next";
+
+const FIELD = "w-64";
+
+export const Base = () => (
+  <div className="flex flex-col gap-3">
+    <Input className={FIELD} placeholder="Libellé de la dépense" />
+    <Input className={FIELD} defaultValue="Courses Monoprix" />
+  </div>
+);
+
+export const Types = () => (
+  <div className="flex flex-col gap-3">
+    <Input className={FIELD} type="text" defaultValue="Abonnement Netflix" />
+    <Input className={`${FIELD} num`} type="number" step="0.01" defaultValue="41.35" />
+    <Input className={`${FIELD} num`} type="date" defaultValue="2026-05-14" />
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="flex flex-col gap-3">
+    <Input className={FIELD} disabled placeholder="Catégorie verrouillée" />
+    <Input className={FIELD} disabled defaultValue="Loyer" />
+  </div>
+);
+
+export const Invalid = () => (
+  <div className="flex flex-col gap-3">
+    <Input className={`${FIELD} num`} aria-invalid defaultValue="-12,00" />
+    <Input className={FIELD} aria-invalid placeholder="Champ requis" />
+  </div>
+);

--- a/front/.design-sync/previews/Label.tsx
+++ b/front/.design-sync/previews/Label.tsx
@@ -1,0 +1,166 @@
+import { Checkbox, GlowCard, Label, Overline, Switch, TextInput } from "pfa-next";
+
+const TEXT = "text-sm text-ink-2";
+
+export const FieldLabels = () => (
+  <GlowCard
+    as="section"
+    className="w-[420px] p-5"
+  >
+    <Overline>Nouvelle dépense</Overline>
+    <div className="mt-3 grid grid-cols-2 gap-4">
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="lb-label"
+          className={TEXT}
+        >
+          Label
+        </Label>
+        <TextInput
+          id="lb-label"
+          placeholder="Ex : Boulangerie"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="lb-amount"
+          className={TEXT}
+        >
+          Montant
+        </Label>
+        <TextInput
+          id="lb-amount"
+          className="num"
+          defaultValue="41,35 €"
+        />
+      </div>
+    </div>
+  </GlowCard>
+);
+
+export const WithMeta = () => (
+  <div className="w-[420px]">
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="lb-req"
+          className={TEXT}
+        >
+          Catégorie
+          <span className="text-neg">*</span>
+        </Label>
+        <TextInput
+          id="lb-req"
+          placeholder="Alimentation"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="lb-cap"
+          className={`${TEXT} flex items-baseline justify-between gap-2`}
+        >
+          Plafond hebdomadaire
+          <span className="num text-2xs tracking-caps text-ink-4">Restant 180,00 €</span>
+        </Label>
+        <TextInput
+          id="lb-cap"
+          className="num"
+          placeholder="0,00 €"
+        />
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label
+          htmlFor="lb-err"
+          className={TEXT}
+        >
+          Date de prélèvement
+        </Label>
+        <TextInput
+          id="lb-err"
+          className="num"
+          aria-invalid
+          defaultValue="32/05/2026"
+        />
+        <p className="text-xs text-neg">Date invalide.</p>
+      </div>
+    </div>
+  </div>
+);
+
+export const WithControls = () => (
+  <div className="flex flex-col gap-3.5">
+    <div className="flex items-center gap-2.5">
+      <Checkbox
+        id="lb-cb"
+        defaultChecked
+      />
+      <Label
+        htmlFor="lb-cb"
+        className={TEXT}
+      >
+        Récurrente mensuelle
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Checkbox id="lb-cb2" />
+      <Label
+        htmlFor="lb-cb2"
+        className={TEXT}
+      >
+        Joindre un reçu
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Switch
+        id="lb-sw"
+        checked
+        className="data-[state=checked]:bg-exc"
+      />
+      <Label
+        htmlFor="lb-sw"
+        className={TEXT}
+      >
+        Achats exceptionnels
+      </Label>
+    </div>
+  </div>
+);
+
+export const DisabledPeer = () => (
+  <div className="flex flex-col gap-3.5">
+    <div className="flex items-center gap-2.5">
+      <Checkbox
+        id="lb-d-cb"
+        disabled
+        checked
+      />
+      <Label
+        htmlFor="lb-d-cb"
+        className={TEXT}
+      >
+        Dépenses fixes — verrouillé
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Switch
+        id="lb-d-sw"
+        disabled
+      />
+      <Label
+        htmlFor="lb-d-sw"
+        className={TEXT}
+      >
+        Plafond hebdomadaire — indisponible
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Checkbox id="lb-e-cb" />
+      <Label
+        htmlFor="lb-e-cb"
+        className={TEXT}
+      >
+        Achat exceptionnel — actif
+      </Label>
+    </div>
+  </div>
+);

--- a/front/.design-sync/previews/LegendItem.tsx
+++ b/front/.design-sync/previews/LegendItem.tsx
@@ -1,0 +1,132 @@
+import { LegendItem } from "pfa-next";
+
+/** Dashed rule swatch — reference lines / compare-year series. */
+const DashSwatch = ({ color, opacity = 1 }: { color: string; opacity?: number }) => (
+  <span
+    className="inline-block h-0.5 w-4 align-middle"
+    style={{
+      opacity,
+      backgroundImage: `repeating-linear-gradient(90deg, ${color} 0 3px, transparent 3px 6px)`,
+    }}
+  />
+);
+
+export const Default = () => (
+  <span className="text-2xs text-ink-3">
+    <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-strong" />}>
+      Variables <span className="num text-ink-2">780 €</span>
+    </LegendItem>
+  </span>
+);
+
+export const BudgetSplit = () => (
+  <div className="flex gap-4 text-2xs text-ink-3">
+    <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-d" />}>
+      Fixes <span className="num text-ink-2">1 240 €</span>
+    </LegendItem>
+    <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-strong" />}>
+      Variables <span className="num text-ink-2">780 €</span>
+    </LegendItem>
+  </div>
+);
+
+export const CategorySeries = () => (
+  <div className="flex flex-wrap items-center gap-4.5 text-xs text-ink-3">
+    <LegendItem
+      className="capitalize"
+      swatch={
+        <i
+          className="inline-block size-2.5 rounded-xs"
+          style={{ background: "#9fcc95" }}
+        />
+      }
+    >
+      Alimentation
+    </LegendItem>
+    <LegendItem
+      className="capitalize"
+      swatch={
+        <i
+          className="inline-block size-2.5 rounded-xs"
+          style={{ background: "#72cede" }}
+        />
+      }
+    >
+      Transport
+    </LegendItem>
+    <LegendItem
+      className="capitalize"
+      swatch={
+        <i
+          className="inline-block size-2.5 rounded-xs"
+          style={{ background: "#bcb4f4" }}
+        />
+      }
+    >
+      Loyer
+    </LegendItem>
+    <LegendItem
+      className="capitalize"
+      swatch={
+        <i
+          className="inline-block size-2.5 rounded-xs"
+          style={{ background: "#c1c37e" }}
+        />
+      }
+    >
+      Courses
+    </LegendItem>
+  </div>
+);
+
+export const SwatchVariants = () => (
+  <div className="flex flex-col items-start gap-2.5 text-xs text-ink-3">
+    <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-accent-strong" />}>2026</LegendItem>
+    <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-exc" />}>Achat exceptionnel</LegendItem>
+    <LegendItem
+      swatch={
+        <span
+          className="inline-block h-2 w-3 rounded-xs"
+          style={{ background: "var(--accent-strong)", opacity: 0.55 }}
+        />
+      }
+    >
+      réalisé
+    </LegendItem>
+    <LegendItem
+      swatch={
+        <span
+          className="inline-block h-2 w-3 rounded-xs border border-accent-d"
+          style={{ background: "repeating-linear-gradient(45deg,transparent 0 3px,var(--accent-d) 3px 6px)" }}
+        />
+      }
+    >
+      projection
+    </LegendItem>
+    <LegendItem
+      swatch={
+        <DashSwatch
+          color="var(--accent-strong)"
+          opacity={0.85}
+        />
+      }
+    >
+      2025
+    </LegendItem>
+    <LegendItem swatch={<DashSwatch color="var(--ink-3)" />}>Budget mensuel</LegendItem>
+  </div>
+);
+
+export const ChartHeader = () => (
+  <div className="flex flex-wrap items-baseline justify-between gap-4">
+    <div>
+      <h3 className="text-sm font-medium tracking-snug text-ink">Dépenses mensuelles</h3>
+      <p className="mt-0.5 text-xs text-ink-4">mai 2026 · 2 020,50 € dépensés</p>
+    </div>
+    <div className="flex flex-wrap items-center gap-4.5 text-xs text-ink-3">
+      <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-accent-strong" />}>2026</LegendItem>
+      <LegendItem swatch={<i className="inline-block size-2.5 rounded-xs bg-exc" />}>Achat exceptionnel</LegendItem>
+      <LegendItem swatch={<DashSwatch color="var(--ink-3)" />}>Budget mensuel</LegendItem>
+    </div>
+  </div>
+);

--- a/front/.design-sync/previews/Logo.tsx
+++ b/front/.design-sync/previews/Logo.tsx
@@ -1,0 +1,41 @@
+import { Button, GlowCard, Logo, MoneyAmount, Overline } from "pfa-next";
+
+export const Default = () => <Logo />;
+
+export const Glow = () => <Logo glow size={72} />;
+
+export const Sizes = () => (
+  <div className="flex items-end gap-6">
+    <Logo size={20} />
+    <Logo size={26} />
+    <Logo size={40} />
+    <Logo size={64} />
+  </div>
+);
+
+export const InAppHeader = () => (
+  <GlowCard className="max-w-md p-4">
+    <div className="flex items-center justify-between gap-3">
+      <div className="flex items-center gap-2.5">
+        <Logo size={26} />
+        <span className="text-base font-semibold tracking-snug text-ink">pfa</span>
+      </div>
+      <Button variant="ghost" size="sm">
+        Mai 2026
+      </Button>
+    </div>
+  </GlowCard>
+);
+
+export const LoginHero = () => (
+  <GlowCard className="max-w-xs p-8">
+    <div className="flex flex-col items-center text-center">
+      <Logo glow size={72} />
+      <Overline className="mt-5">Suivi des dépenses</Overline>
+      <div className="mt-2 num text-display font-medium leading-none tracking-tight text-accent-strong">
+        <MoneyAmount value={1240.5} />
+      </div>
+      <p className="mt-3 text-xs text-ink-3">Alimentation, Transport, Loyer — tout au même endroit.</p>
+    </div>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/MeterBar.tsx
+++ b/front/.design-sync/previews/MeterBar.tsx
@@ -1,0 +1,94 @@
+import { MeterBar, MoneyAmount, Overline } from "pfa-next";
+
+export const Default = () => (
+  <div className="w-72">
+    <div className="flex items-baseline justify-between">
+      <span className="text-sm text-ink">Alimentation</span>
+      <MoneyAmount value={286.4} className="num text-sm font-medium text-ink" />
+    </div>
+    <MeterBar value={72} height={6} className="mt-2" />
+    <p className="mt-2 text-2xs tracking-caps text-ink-4">72 % DU PLAFOND · 400,00 €</p>
+  </div>
+);
+
+export const FillLevels = () => (
+  <div className="flex w-72 flex-col gap-3">
+    <Overline>Répartition du mois</Overline>
+    {[
+      { label: "Loyer", value: 100, amount: 780 },
+      { label: "Courses", value: 64, amount: 286.4 },
+      { label: "Transport", value: 38, amount: 118.9 },
+      { label: "Pharmacie", value: 12, amount: 41.35 },
+    ].map((row) => (
+      <div key={row.label}>
+        <div className="flex items-baseline justify-between">
+          <span className="text-xs text-ink-2">{row.label}</span>
+          <MoneyAmount value={row.amount} className="num text-xs text-ink-3" />
+        </div>
+        <MeterBar value={row.value} height={6} className="mt-1.5" />
+      </div>
+    ))}
+  </div>
+);
+
+export const OverBudget = () => (
+  <div className="w-72">
+    <div className="flex items-baseline justify-between">
+      <span className="text-sm text-ink">Plafond hebdomadaire</span>
+      <MoneyAmount value={286.4} className="num text-sm font-medium text-neg" />
+    </div>
+    <MeterBar value={100} height={6} fill="var(--neg)" className="mt-2" />
+    <p className="mt-2 text-2xs tracking-caps text-neg">DÉPASSÉ DE 36,40 € · PLAFOND 250,00 €</p>
+  </div>
+);
+
+export const Exceptional = () => (
+  <div className="w-72">
+    <div className="flex items-baseline justify-between">
+      <span className="text-sm text-ink">Achats exceptionnels</span>
+      <MoneyAmount value={412.8} className="num text-sm font-medium text-exc" />
+    </div>
+    <MeterBar value={46} height={6} fill="var(--exc)" className="mt-2" />
+    <p className="mt-2 text-2xs tracking-caps text-ink-4">46 % DE L'ENVELOPPE ANNUELLE</p>
+  </div>
+);
+
+export const Heights = () => (
+  <div className="flex w-72 flex-col gap-5">
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">HEIGHT 6 · MÉTRIQUE DE CARTE</p>
+      <MeterBar value={58} height={6} />
+    </div>
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">HEIGHT 7 · DÉPENSES FIXES</p>
+      <MeterBar value={58} height={7} opacity={0.9} />
+    </div>
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">HEIGHT 22 · JOUR DE LA SEMAINE</p>
+      <MeterBar value={58} height={22} opacity={0.85} />
+    </div>
+  </div>
+);
+
+export const WeekendFill = () => (
+  <div className="flex w-72 flex-col gap-2">
+    <Overline>Dépenses par jour</Overline>
+    {[
+      { day: "Jeudi", width: 46, weekend: false },
+      { day: "Vendredi", width: 62, weekend: false },
+      { day: "Samedi", width: 100, weekend: true },
+      { day: "Dimanche", width: 71, weekend: true },
+    ].map((row) => (
+      <div key={row.day} className="flex items-center gap-3 text-sm">
+        <span className={row.weekend ? "w-24 text-ink" : "w-24 text-ink-2"}>{row.day}</span>
+        <MeterBar
+          value={row.width}
+          fill={row.weekend ? "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.16 25))" : "var(--bar-fill)"}
+          height={22}
+          opacity={0.85}
+          className="grow"
+        />
+      </div>
+    ))}
+  </div>
+);

--- a/front/.design-sync/previews/MoneyAmount.tsx
+++ b/front/.design-sync/previews/MoneyAmount.tsx
@@ -1,0 +1,82 @@
+import { MoneyAmount, Overline } from "pfa-next";
+
+export const Default = () => <MoneyAmount value={1240.5} className="num text-2xl font-medium text-ink" />;
+
+export const Sizes = () => (
+  <div className="flex flex-col gap-2.5">
+    <div>
+      <Overline className="block">Reste à vivre</Overline>
+      <div className="mt-1.5">
+        <MoneyAmount
+          value={412.8}
+          className="num text-display font-medium leading-none tracking-tight text-ink"
+          decimalClassName="text-2xl"
+        />
+      </div>
+    </div>
+    <MoneyAmount value={1240.5} className="num text-2xl font-medium text-ink" decimalClassName="text-base" />
+    <MoneyAmount value={286.4} className="num text-lg font-medium text-ink-2" />
+    <MoneyAmount value={41.35} className="num text-sm text-ink-3" />
+    <MoneyAmount value={13.49} className="num text-2xs text-ink-4" />
+  </div>
+);
+
+export const Colours = () => (
+  <div className="flex flex-col gap-3">
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Reste à vivre</span>
+      <MoneyAmount value={412.8} className="num text-lg font-medium text-accent-strong" />
+    </div>
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Dépenses fixes</span>
+      <MoneyAmount value={780} className="num text-lg font-medium text-ink" />
+    </div>
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Achats exceptionnels</span>
+      <MoneyAmount value={318.9} className="num text-lg font-medium text-exc" />
+    </div>
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Dépassement du plafond</span>
+      <MoneyAmount value={-36.4} className="num text-lg font-medium text-neg" />
+    </div>
+  </div>
+);
+
+export const OverBudget = () => (
+  <div>
+    <Overline className="block">Dépassement hebdomadaire</Overline>
+    <div className="mt-2">
+      <MoneyAmount
+        value={-36.4}
+        className="num text-display font-medium leading-none tracking-tight text-neg"
+        decimalClassName="text-2xl"
+      />
+    </div>
+    <p className="mt-3 text-xs text-neg">286,40 € dépensés sur un plafond de 250,00 €</p>
+  </div>
+);
+
+export const CustomUnit = () => (
+  <div className="flex flex-col gap-4">
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Moyenne par jour</span>
+      <MoneyAmount value={41.35} unit=" € / j" className="num text-lg font-medium text-ink" />
+    </div>
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Part de l'alimentation</span>
+      <MoneyAmount value={18.4} unit=" %" className="num text-lg font-medium text-ink" />
+    </div>
+    <div className="flex items-baseline justify-between gap-8">
+      <span className="text-xs text-ink-3">Projeté sur l'année</span>
+      <MoneyAmount value={14886} unit=" € / an" className="num text-lg font-medium text-ink" />
+    </div>
+  </div>
+);
+
+export const InlineInText = () => (
+  <p className="w-72 text-sm leading-relaxed text-ink-2">
+    Vous avez dépensé <MoneyAmount value={1240.5} className="num font-medium text-ink" /> en mai 2026, soit{" "}
+    <MoneyAmount value={156.3} className="num font-medium text-neg" /> de plus qu'en avril. Il vous reste{" "}
+    <MoneyAmount value={412.8} className="num font-medium text-accent-strong" /> jusqu'au 31 mai.
+  </p>
+);

--- a/front/.design-sync/previews/Overline.tsx
+++ b/front/.design-sync/previews/Overline.tsx
@@ -1,0 +1,50 @@
+import { GlowCard, MoneyAmount, Overline } from "pfa-next";
+
+export const Default = () => <Overline>Reste à vivre</Overline>;
+
+export const Brighter = () => <Overline className="text-ink-3">Achats exceptionnels</Overline>;
+
+export const AsEyebrow = () => (
+  <GlowCard className="max-w-xs p-5">
+    <Overline>Plafond hebdomadaire</Overline>
+    <div className="mt-2 num text-display font-medium leading-none tracking-tight text-accent-strong">
+      <MoneyAmount value={412.8} />
+    </div>
+    <p className="mt-3 text-xs text-ink-3">13,76 € par jour jusqu'au 31 mai</p>
+  </GlowCard>
+);
+
+export const AsColumnLabels = () => (
+  <GlowCard className="max-w-lg p-5">
+    <div className="grid grid-cols-3 gap-4">
+      <div>
+        <Overline>Alimentation</Overline>
+        <div className="mt-1.5 num text-lg font-medium text-ink">
+          <MoneyAmount value={286.4} />
+        </div>
+      </div>
+      <div>
+        <Overline>Transport</Overline>
+        <div className="mt-1.5 num text-lg font-medium text-ink">
+          <MoneyAmount value={41.35} />
+        </div>
+      </div>
+      <div>
+        <Overline>Loyer</Overline>
+        <div className="mt-1.5 num text-lg font-medium text-ink">
+          <MoneyAmount value={780} />
+        </div>
+      </div>
+    </div>
+  </GlowCard>
+);
+
+export const AsFootnote = () => (
+  <GlowCard className="max-w-xs p-4">
+    <span className="text-sm text-ink">Dépenses fixes</span>
+    <div className="mt-2 num text-lg font-medium text-ink">
+      <MoneyAmount value={1240.5} />
+    </div>
+    <Overline className="mt-2 block">72 % du budget mensuel</Overline>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/PasswordField.tsx
+++ b/front/.design-sync/previews/PasswordField.tsx
@@ -1,0 +1,55 @@
+import { PasswordField } from "pfa-next";
+
+/**
+ * `registration` is a react-hook-form `UseFormRegisterReturn`, spread onto the input.
+ * A static preview has no form context, so this is the inert equivalent.
+ */
+const registration = (name: string) => ({
+  name,
+  onChange: async () => {},
+  onBlur: async () => {},
+  ref: () => {},
+});
+
+export const Base = () => (
+  <div className="w-72">
+    <PasswordField
+      id="pw-base"
+      label="Mot de passe"
+      autoComplete="current-password"
+      invalid={false}
+      registration={registration("password")}
+    />
+  </div>
+);
+
+export const Invalid = () => (
+  <div className="w-72">
+    <PasswordField
+      id="pw-invalid"
+      label="Mot de passe"
+      autoComplete="current-password"
+      invalid
+      registration={registration("password")}
+    />
+  </div>
+);
+
+export const SignupForm = () => (
+  <div className="flex w-72 flex-col gap-4">
+    <PasswordField
+      id="pw-new"
+      label="Mot de passe"
+      autoComplete="new-password"
+      invalid={false}
+      registration={registration("password")}
+    />
+    <PasswordField
+      id="pw-confirm"
+      label="Confirmer le mot de passe"
+      autoComplete="new-password"
+      invalid
+      registration={registration("passwordConfirmation")}
+    />
+  </div>
+);

--- a/front/.design-sync/previews/Popover.tsx
+++ b/front/.design-sync/previews/Popover.tsx
@@ -1,0 +1,128 @@
+import { Input, Popover, PopoverContent, PopoverTrigger } from "pfa-next";
+import { Calendar, Check, ChevronDown, Plus, Search } from "lucide-react";
+
+/** The popover chrome the Statistiques filter bar puts on every `PopoverContent`. */
+const POP_CONTENT = "rounded-lg border border-line bg-surface-elev p-1.5 shadow-popover";
+
+const CATEGORIES = [
+  { name: "Alimentation", color: "#5ec8a0" },
+  { name: "Transport", color: "#6aa9f0" },
+  { name: "Loyer", color: "#c58af0" },
+  { name: "Courses", color: "#f0b45e" },
+  { name: "Pharmacie", color: "#ef7d7d" },
+  { name: "Abonnement Netflix", color: "#8c93f5" },
+];
+
+/**
+ * The canonical story: the period picker of the Statistiques filter bar. The
+ * trigger carries the selected year, the content lists the years with the
+ * current one in the accent tone plus a check. `defaultOpen` renders the portal.
+ */
+export const PeriodPicker = () => (
+  <Popover defaultOpen>
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        className="inline-flex items-center gap-2 rounded-sm border border-line bg-surface-elev px-2.5 py-2 text-sm text-ink-2 transition-colors hover:border-ink-4"
+      >
+        <Calendar className="size-3.5 text-ink-4" />
+        <span className="num text-ink">2026</span>
+        <ChevronDown className="size-3 text-ink-4" />
+      </button>
+    </PopoverTrigger>
+    <PopoverContent
+      align="start"
+      className={`${POP_CONTENT} w-[132px]`}
+    >
+      <div className="flex max-h-[264px] flex-col overflow-y-auto">
+        {[2026, 2025, 2024, 2023, 2022].map((year) => (
+          <button
+            key={year}
+            type="button"
+            className={`num flex items-center justify-between rounded-md px-2.5 py-2 text-left text-sm transition-colors hover:bg-surface-hi ${
+              year === 2026 ? "text-accent-strong" : "text-ink-2"
+            }`}
+          >
+            {year}
+            {year === 2026 && <Check className="size-3.5" />}
+          </button>
+        ))}
+      </div>
+    </PopoverContent>
+  </Popover>
+);
+
+/**
+ * The wider composition: the category picker — a search `Input` above a scrolling
+ * list of colour-dotted categories, with the already-picked one checked.
+ */
+export const CategoryPicker = () => (
+  <Popover defaultOpen>
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded-sm border border-line bg-surface-elev py-2 pl-2.5 pr-3 text-sm text-ink-2 transition-colors hover:border-ink-4"
+      >
+        <Plus className="size-3" />
+        Ajouter une catégorie
+      </button>
+    </PopoverTrigger>
+    <PopoverContent
+      align="start"
+      className={`${POP_CONTENT} w-72`}
+    >
+      <div className="relative mb-1.5">
+        <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-ink-4" />
+        <Input
+          defaultValue=""
+          placeholder="Rechercher…"
+          className="h-9 border-line bg-background pl-8 text-sm"
+        />
+      </div>
+      <div className="max-h-[264px] overflow-y-auto pr-0.5">
+        {CATEGORIES.map((category) => (
+          <button
+            key={category.name}
+            type="button"
+            className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-sm capitalize text-ink-2 transition-colors hover:bg-surface-hi hover:text-ink"
+          >
+            <span
+              className="size-2.5 shrink-0 rounded-full"
+              style={{ background: category.color }}
+            />
+            <span className="flex-1 truncate">{category.name}</span>
+            {category.name === "Alimentation" && <Check className="size-3.5 text-accent-strong" />}
+          </button>
+        ))}
+      </div>
+    </PopoverContent>
+  </Popover>
+);
+
+/** The empty state — a query that matches no category. */
+export const EmptyResults = () => (
+  <Popover defaultOpen>
+    <PopoverTrigger asChild>
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded-sm border border-line bg-surface-elev py-2 pl-2.5 pr-3 text-sm text-ink-2 transition-colors hover:border-ink-4"
+      >
+        <Plus className="size-3" />
+        Ajouter une catégorie
+      </button>
+    </PopoverTrigger>
+    <PopoverContent
+      align="start"
+      className={`${POP_CONTENT} w-72`}
+    >
+      <div className="relative mb-1.5">
+        <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-ink-4" />
+        <Input
+          defaultValue="assurance"
+          className="h-9 border-line bg-background pl-8 text-sm"
+        />
+      </div>
+      <div className="px-2.5 py-3 text-center text-xs text-ink-4">Aucune catégorie</div>
+    </PopoverContent>
+  </Popover>
+);

--- a/front/.design-sync/previews/Progress.tsx
+++ b/front/.design-sync/previews/Progress.tsx
@@ -1,0 +1,59 @@
+import { MoneyAmount, Overline, Progress } from "pfa-next";
+
+export const Default = () => (
+  <div className="w-72">
+    <div className="flex items-baseline justify-between">
+      <span className="text-sm text-ink">Alimentation</span>
+      <MoneyAmount value={286.4} className="num text-sm font-medium text-ink" />
+    </div>
+    <Progress value={72} className="mt-2 h-2" />
+    <p className="mt-2 text-2xs tracking-caps text-ink-4">72 % DU PLAFOND · 400,00 €</p>
+  </div>
+);
+
+export const Values = () => (
+  <div className="flex w-72 flex-col gap-3">
+    <Overline>Consommation des plafonds</Overline>
+    {[
+      { label: "Pharmacie", value: 8 },
+      { label: "Courses", value: 61 },
+      { label: "Loyer", value: 100 },
+    ].map((row) => (
+      <div key={row.label}>
+        <div className="flex items-baseline justify-between">
+          <span className="text-xs text-ink-2">{row.label}</span>
+          <span className="num text-xs text-ink-3">{row.value} %</span>
+        </div>
+        <Progress value={row.value} className="mt-1.5 h-2" />
+      </div>
+    ))}
+  </div>
+);
+
+export const Empty = () => (
+  <div className="w-72">
+    <div className="flex items-baseline justify-between">
+      <span className="text-sm text-ink-3">Achats exceptionnels</span>
+      <MoneyAmount value={0} className="num text-sm text-ink-3" />
+    </div>
+    <Progress value={0} className="mt-2 h-2" />
+    <p className="mt-2 text-2xs tracking-caps text-ink-4">AUCUNE DÉPENSE CE MOIS-CI</p>
+  </div>
+);
+
+export const Thicknesses = () => (
+  <div className="flex w-72 flex-col gap-5">
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">H-2 · HAUTEUR PAR DÉFAUT</p>
+      <Progress value={58} />
+    </div>
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">H-3</p>
+      <Progress value={58} className="h-3" />
+    </div>
+    <div>
+      <p className="mb-1.5 text-2xs tracking-caps text-ink-4">H-4</p>
+      <Progress value={58} className="h-4" />
+    </div>
+  </div>
+);

--- a/front/.design-sync/previews/ScrollArea.tsx
+++ b/front/.design-sync/previews/ScrollArea.tsx
@@ -1,0 +1,74 @@
+import { Badge, CardSectionHeader, GlowCard, MoneyAmount, Overline, ScrollArea, ScrollBar, Separator } from "pfa-next";
+
+const spendings = [
+  { label: "Courses", category: "Alimentation", date: "14 mai 2026", amount: 78.2 },
+  { label: "Uber", category: "Transport", date: "13 mai 2026", amount: 16.4 },
+  { label: "Pharmacie", category: "Santé", date: "12 mai 2026", amount: 23.9 },
+  { label: "Abonnement Netflix", category: "Loisirs", date: "11 mai 2026", amount: 13.49 },
+  { label: "Boulangerie", category: "Alimentation", date: "11 mai 2026", amount: 8.6 },
+  { label: "Essence", category: "Transport", date: "10 mai 2026", amount: 62.3 },
+  { label: "Mutuelle", category: "Santé", date: "5 mai 2026", amount: 41.35 },
+  { label: "Loyer", category: "Logement", date: "5 mai 2026", amount: 780 },
+];
+
+const categories = [
+  { name: "Alimentation", total: 412.8 },
+  { name: "Transport", total: 186.7 },
+  { name: "Logement", total: 780 },
+  { name: "Santé", total: 65.25 },
+  { name: "Loisirs", total: 94.1 },
+  { name: "Courses", total: 231.4 },
+];
+
+export const Default = () => (
+  <ScrollArea type="always" className="h-64 w-full max-w-sm rounded-lg border border-line p-4">
+    <Overline className="mb-3 block">Dépenses de mai 2026</Overline>
+    <div className="flex flex-col">
+      {spendings.map((s) => (
+        <div key={s.label}>
+          <div className="flex items-center justify-between py-2.5">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm text-ink-2">{s.label}</span>
+              <span className="num text-xs text-ink-4">{s.date}</span>
+            </div>
+            <MoneyAmount value={s.amount} className="num text-sm text-ink" />
+          </div>
+          <Separator className="bg-line-soft" />
+        </div>
+      ))}
+    </div>
+  </ScrollArea>
+);
+
+export const Horizontal = () => (
+  <ScrollArea type="always" className="w-full max-w-sm whitespace-nowrap rounded-lg border border-line">
+    <div className="flex w-max gap-3 p-4">
+      {categories.map((c) => (
+        <div key={c.name} className="flex w-36 shrink-0 flex-col gap-1 rounded-md bg-surface-hi px-3.5 py-3">
+          <Overline>{c.name}</Overline>
+          <MoneyAmount value={c.total} className="num text-lg font-medium text-ink" />
+        </div>
+      ))}
+    </div>
+    <ScrollBar orientation="horizontal" />
+  </ScrollArea>
+);
+
+export const InCard = () => (
+  <GlowCard as="section" className="w-full max-w-sm p-5">
+    <CardSectionHeader title="Dépenses fixes" meta="12 prélèvements" />
+    <ScrollArea type="always" className="mt-4 h-56 pr-3">
+      <div className="flex flex-col gap-2.5">
+        {spendings.map((s) => (
+          <div key={s.label} className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-ink-2">{s.label}</span>
+              <Badge variant="secondary">{s.category}</Badge>
+            </div>
+            <MoneyAmount value={s.amount} className="num text-sm text-ink" />
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/ScrollBar.tsx
+++ b/front/.design-sync/previews/ScrollBar.tsx
@@ -1,0 +1,100 @@
+import { MoneyAmount, Overline, ScrollArea, ScrollBar, Separator } from "pfa-next";
+
+// ScrollBar is never mounted on its own — it only renders inside a ScrollArea,
+// which already ships a vertical one. `type="always"` keeps it painted in a
+// static capture (the Radix default only reveals it on hover/scroll).
+
+const spendings = [
+  { label: "Courses", date: "14 mai 2026", amount: 78.2, fixed: false },
+  { label: "Uber", date: "13 mai 2026", amount: 16.4, fixed: false },
+  { label: "Pharmacie", date: "12 mai 2026", amount: 23.9, fixed: false },
+  { label: "Abonnement Netflix", date: "11 mai 2026", amount: 13.49, fixed: true },
+  { label: "Boulangerie", date: "11 mai 2026", amount: 8.6, fixed: false },
+  { label: "Essence", date: "10 mai 2026", amount: 62.3, fixed: false },
+  { label: "Mutuelle", date: "5 mai 2026", amount: 41.35, fixed: true },
+  { label: "Loyer", date: "5 mai 2026", amount: 780, fixed: true },
+];
+
+/** Monthly drift so the matrix reads like real history — fixed debits stay flat. */
+const drift = [0.87, 1.12, 0.94, 1.21, 1, 0.79];
+const monthly = (s: (typeof spendings)[number], i: number) =>
+  s.fixed ? s.amount : Math.round(s.amount * drift[i] * 100) / 100;
+
+const months = [
+  { name: "Janvier", total: 1180.4 },
+  { name: "Février", total: 1042.9 },
+  { name: "Mars", total: 1310.15 },
+  { name: "Avril", total: 998.6 },
+  { name: "Mai", total: 1240.5 },
+  { name: "Juin", total: 1087.3 },
+];
+
+/** The vertical bar ScrollArea mounts by itself — no explicit ScrollBar child needed. */
+export const Vertical = () => (
+  <ScrollArea type="always" className="h-64 w-full max-w-sm rounded-lg border border-line p-4">
+    <Overline className="mb-3 block">Dépenses de mai 2026</Overline>
+    <div className="flex flex-col">
+      {spendings.map((s) => (
+        <div key={s.label}>
+          <div className="flex items-center justify-between py-2.5">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm text-ink-2">{s.label}</span>
+              <span className="num text-xs text-ink-4">{s.date}</span>
+            </div>
+            <MoneyAmount value={s.amount} className="num text-sm text-ink" />
+          </div>
+          <Separator className="bg-line-soft" />
+        </div>
+      ))}
+    </div>
+  </ScrollArea>
+);
+
+/** `orientation="horizontal"` is the one axis you must add yourself. */
+export const Horizontal = () => (
+  <ScrollArea type="always" className="w-full max-w-sm whitespace-nowrap rounded-lg border border-line">
+    <div className="flex w-max gap-3 p-4">
+      {months.map((m) => (
+        <div key={m.name} className="flex w-32 shrink-0 flex-col gap-1 rounded-md bg-surface-hi px-3.5 py-3">
+          <Overline>{m.name} 2026</Overline>
+          <MoneyAmount value={m.total} className="num text-base font-medium text-ink" />
+        </div>
+      ))}
+    </div>
+    <ScrollBar orientation="horizontal" />
+  </ScrollArea>
+);
+
+/** Both axes overflow: the vertical bar, the horizontal bar and the corner all paint. */
+export const BothAxes = () => (
+  <ScrollArea type="always" className="h-56 w-full max-w-sm rounded-lg border border-line">
+    <div className="w-max p-4">
+      <Overline className="mb-3 block">Dépenses par mois</Overline>
+      <table className="border-separate border-spacing-0 text-sm">
+        <thead>
+          <tr>
+            <th className="px-3 py-2 text-left text-2xs font-medium uppercase tracking-caps text-ink-4">Dépense</th>
+            {months.map((m) => (
+              <th key={m.name} className="px-3 py-2 text-right text-2xs font-medium uppercase tracking-caps text-ink-4">
+                {m.name}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {spendings.map((s) => (
+            <tr key={s.label}>
+              <td className="whitespace-nowrap px-3 py-2 text-ink-2">{s.label}</td>
+              {months.map((m, i) => (
+                <td key={m.name} className="px-3 py-2 text-right">
+                  <MoneyAmount value={monthly(s, i)} className="num text-ink" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <ScrollBar orientation="horizontal" />
+  </ScrollArea>
+);

--- a/front/.design-sync/previews/Select.tsx
+++ b/front/.design-sync/previews/Select.tsx
@@ -1,0 +1,138 @@
+import {
+  FieldShell,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "pfa-next";
+
+const FIELD = "w-64";
+
+/**
+ * The currency select of the profile / signup form — the app's only Select.
+ * Open, so the popper content, the grouped items and the check indicator on the
+ * current value are all visible.
+ */
+export const Open = () => (
+  <FieldShell
+    label="Devise"
+    htmlFor="sel-currency"
+    className={FIELD}
+  >
+    <Select
+      defaultValue="EUR"
+      defaultOpen
+    >
+      <SelectTrigger
+        id="sel-currency"
+        className="w-full"
+      >
+        <SelectValue placeholder="Devise" />
+      </SelectTrigger>
+      <SelectContent className="max-h-72">
+        <SelectGroup>
+          <SelectLabel>Zone euro</SelectLabel>
+          <SelectItem value="EUR">Euro : €</SelectItem>
+        </SelectGroup>
+        <SelectSeparator />
+        <SelectGroup>
+          <SelectLabel>Autres devises</SelectLabel>
+          <SelectItem value="CHF">Franc suisse : CHF</SelectItem>
+          <SelectItem value="GBP">Livre sterling : £</SelectItem>
+          <SelectItem value="USD">Dollar américain : $</SelectItem>
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  </FieldShell>
+);
+
+/** The trigger's variant axis: `size="default"` (h-9) vs `size="sm"` (h-8). */
+export const Sizes = () => (
+  <div className={`flex flex-col gap-4 ${FIELD}`}>
+    <FieldShell
+      label="Devise — default"
+      htmlFor="sel-size-default"
+    >
+      <Select defaultValue="EUR">
+        <SelectTrigger
+          id="sel-size-default"
+          className="w-full"
+        >
+          <SelectValue placeholder="Devise" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="EUR">Euro : €</SelectItem>
+          <SelectItem value="CHF">Franc suisse : CHF</SelectItem>
+        </SelectContent>
+      </Select>
+    </FieldShell>
+    <FieldShell
+      label="Devise — sm"
+      htmlFor="sel-size-sm"
+    >
+      <Select defaultValue="EUR">
+        <SelectTrigger
+          id="sel-size-sm"
+          size="sm"
+          className="w-full"
+        >
+          <SelectValue placeholder="Devise" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="EUR">Euro : €</SelectItem>
+          <SelectItem value="CHF">Franc suisse : CHF</SelectItem>
+        </SelectContent>
+      </Select>
+    </FieldShell>
+  </div>
+);
+
+/** Nothing picked yet — `SelectValue`'s placeholder takes the muted tone. */
+export const Placeholder = () => (
+  <FieldShell
+    label="Devise"
+    htmlFor="sel-placeholder"
+    className={FIELD}
+  >
+    <Select>
+      <SelectTrigger
+        id="sel-placeholder"
+        className="w-full"
+      >
+        <SelectValue placeholder="Devise" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="EUR">Euro : €</SelectItem>
+        <SelectItem value="CHF">Franc suisse : CHF</SelectItem>
+      </SelectContent>
+    </Select>
+  </FieldShell>
+);
+
+/** Locked field — the devise can't be changed once des dépenses existent. */
+export const Disabled = () => (
+  <FieldShell
+    label="Devise"
+    htmlFor="sel-disabled"
+    className={FIELD}
+  >
+    <Select
+      defaultValue="EUR"
+      disabled
+    >
+      <SelectTrigger
+        id="sel-disabled"
+        className="w-full"
+      >
+        <SelectValue placeholder="Devise" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="EUR">Euro : €</SelectItem>
+      </SelectContent>
+    </Select>
+  </FieldShell>
+);

--- a/front/.design-sync/previews/Separator.tsx
+++ b/front/.design-sync/previews/Separator.tsx
@@ -1,0 +1,108 @@
+import { CardSectionHeader, GlowCard, MoneyAmount, Overline, Separator } from "pfa-next";
+
+export const Default = () => (
+  <div className="w-full max-w-sm">
+    <div className="pb-3">
+      <p className="text-sm font-medium text-ink">Dépenses fixes</p>
+      <p className="text-xs text-ink-3">Prélevées le 5 de chaque mois</p>
+    </div>
+    <Separator />
+    <div className="pt-3">
+      <p className="text-sm font-medium text-ink">Reste à vivre</p>
+      <p className="text-xs text-ink-3">Recalculé à chaque dépense</p>
+    </div>
+  </div>
+);
+
+export const Horizontal = () => (
+  <div className="flex w-full max-w-sm flex-col gap-3">
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-ink-2">Loyer</span>
+      <MoneyAmount value={780} className="num text-ink" />
+    </div>
+    <Separator />
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-ink-2">Abonnement Netflix</span>
+      <MoneyAmount value={13.49} className="num text-ink" />
+    </div>
+    <Separator />
+    <div className="flex items-center justify-between text-sm">
+      <span className="text-ink-2">Mutuelle</span>
+      <MoneyAmount value={41.35} className="num text-ink" />
+    </div>
+  </div>
+);
+
+export const Vertical = () => (
+  <div className="flex h-5 items-center gap-3 text-xs text-ink-3">
+    <span className="num">24 dépenses</span>
+    <Separator orientation="vertical" />
+    <span className="num">1 240,50 €</span>
+    <Separator orientation="vertical" />
+    <span>mai 2026</span>
+  </div>
+);
+
+/** `bg-line-soft` is the dense-list rule: many rows, so the divider must recede. */
+export const SoftLine = () => {
+  const rows = [
+    { label: "Courses", date: "14 mai", amount: 78.2 },
+    { label: "Pharmacie", date: "12 mai", amount: 23.9 },
+    { label: "Uber", date: "13 mai", amount: 16.4 },
+    { label: "Boulangerie", date: "11 mai", amount: 8.6 },
+    { label: "Essence", date: "10 mai", amount: 62.3 },
+  ];
+  return (
+    <div className="w-full max-w-sm">
+      <Overline className="mb-2 block">Dernières dépenses</Overline>
+      {rows.map((r, i) => (
+        <div key={r.label}>
+          {i > 0 && <Separator className="bg-line-soft" />}
+          <div className="flex items-center justify-between py-1.5 text-sm">
+            <span className="text-ink-2">{r.label}</span>
+            <div className="flex items-center gap-3">
+              <span className="num text-2xs text-ink-4">{r.date}</span>
+              <MoneyAmount value={r.amount} className="num text-ink" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const InCard = () => (
+  <GlowCard
+    as="section"
+    className="w-full max-w-sm p-5"
+  >
+    <CardSectionHeader
+      title="Alimentation"
+      meta="mai 2026"
+    />
+    <div className="mt-4 flex items-center justify-between">
+      <div className="flex flex-col gap-1">
+        <Overline>Dépensé</Overline>
+        <MoneyAmount value={412.8} className="num text-sm text-ink" />
+      </div>
+      <Separator
+        orientation="vertical"
+        className="h-10"
+      />
+      <div className="flex flex-col gap-1">
+        <Overline>Plafond</Overline>
+        <MoneyAmount value={500} className="num text-sm text-ink" />
+      </div>
+      <Separator
+        orientation="vertical"
+        className="h-10"
+      />
+      <div className="flex flex-col gap-1">
+        <Overline>Restant</Overline>
+        <span className="num text-sm text-accent-strong">87,20 €</span>
+      </div>
+    </div>
+    <Separator className="my-4" />
+    <p className="text-xs text-ink-3">12 dépenses · dernière le 14 mai 2026</p>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/Skeleton.tsx
+++ b/front/.design-sync/previews/Skeleton.tsx
@@ -1,0 +1,124 @@
+// Widths here are expressed as 12-column spans rather than `w-40`-style
+// utilities on purpose: the DS stylesheet is compiled from the app's own source
+// (`@source "../src"` in .design-sync/ds-styles.src.css) plus an explicit
+// safelist, and that safelist covers spacing/grid but NOT `w-*`/`h-*`. The app
+// never uses w-40/w-48/w-32, so those classes compile to nothing and every bar
+// silently renders full-width. `grid-cols-12` + `col-span-*` are safelisted, so
+// they are the honest way to size a skeleton today. Note the safelist stops at
+// `col-span-6` (+ `col-span-full`): there is no col-span-7..11, so rows are built
+// from spans <= 6 or given their own grid instead of padded out with a spacer.
+// See learnings/feedback.md.
+
+import { CardSectionHeader, GlowCard, Skeleton } from "pfa-next";
+
+/** The primitive: a skeleton is only ever as big as the box you give it. */
+export const Default = () => (
+  <div className="grid grid-cols-12">
+    <Skeleton className="col-span-4 h-4" />
+  </div>
+);
+
+/** Ragged bars standing in for a block of text or stacked labels. */
+export const TextLines = () => (
+  <div className="flex flex-col gap-2">
+    <div className="grid grid-cols-12">
+      <Skeleton className="col-span-6 h-4" />
+    </div>
+    <div className="grid grid-cols-12">
+      <Skeleton className="col-span-5 h-4" />
+    </div>
+    <div className="grid grid-cols-12">
+      <Skeleton className="col-span-3 h-4" />
+    </div>
+  </div>
+);
+
+/** A loading list of spendings: label on the left, amount right-aligned. */
+export const LoadingList = () => (
+  <div className="grid grid-cols-12 items-center gap-x-2 gap-y-3">
+    <Skeleton className="col-span-4 h-3" />
+    <div className="col-span-6" />
+    <Skeleton className="col-span-2 h-3" />
+
+    <Skeleton className="col-span-5 h-3" />
+    <div className="col-span-5" />
+    <Skeleton className="col-span-2 h-3" />
+
+    <Skeleton className="col-span-3 h-3" />
+    <div className="col-span-6" />
+    <Skeleton className="col-span-3 h-3" />
+
+    <Skeleton className="col-span-4 h-3" />
+    <div className="col-span-6" />
+    <Skeleton className="col-span-2 h-3" />
+  </div>
+);
+
+/** The card-level loading state: real header, skeleton body. */
+export const CardLoading = () => (
+  <GlowCard
+    as="section"
+    className="flex flex-col gap-4 px-6 py-5"
+  >
+    <CardSectionHeader title="Dépenses fixes" meta="mai 2026" />
+    <div className="grid grid-cols-12 items-center gap-x-2 gap-y-3">
+      <Skeleton className="col-span-4 h-3" />
+      <div className="col-span-6" />
+      <Skeleton className="col-span-2 h-3" />
+
+      <Skeleton className="col-span-5 h-3" />
+      <div className="col-span-5" />
+      <Skeleton className="col-span-2 h-3" />
+
+      <Skeleton className="col-span-3 h-3" />
+      <div className="col-span-6" />
+      <Skeleton className="col-span-3 h-3" />
+    </div>
+  </GlowCard>
+);
+
+/** The metrics row while the month's totals are still in flight. */
+export const MetricsLoading = () => (
+  <div className="grid grid-cols-4 gap-6">
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-6 h-3" />
+      </div>
+      <Skeleton className="h-7" />
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-5 h-3" />
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-5 h-3" />
+      </div>
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-6 h-7" />
+      </div>
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-4 h-3" />
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-6 h-3" />
+      </div>
+      <Skeleton className="h-7" />
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-6 h-3" />
+      </div>
+    </div>
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-4 h-3" />
+      </div>
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-5 h-7" />
+      </div>
+      <div className="grid grid-cols-12">
+        <Skeleton className="col-span-5 h-3" />
+      </div>
+    </div>
+  </div>
+);

--- a/front/.design-sync/previews/StatTile.tsx
+++ b/front/.design-sync/previews/StatTile.tsx
@@ -1,0 +1,24 @@
+import { MoneyAmount, StatTile } from "pfa-next";
+
+export const Default = () => <StatTile label="Total du mois" value={<MoneyAmount value={1240.5} />} sub="12 prélèvements" />;
+
+export const Row = () => (
+  <div className="grid grid-cols-4 gap-6">
+    <StatTile label="Total semaine" value={<MoneyAmount value={286.4} />} sub="+36,40 € vs plafond" />
+    <StatTile label="Transactions" value="24" sub="sur 7 jours" />
+    <StatTile label="Moyenne / jour" value={<MoneyAmount value={40.91} />} sub="plafond 250,00 €" />
+    <StatTile label="Plus grosse" value={<MoneyAmount value={78.2} />} sub="Courses · jeudi" />
+  </div>
+);
+
+export const WithoutCaption = () => <StatTile label="Transactions" value="24" />;
+
+export const Emphasised = () => (
+  <StatTile
+    label="Dépassement"
+    value={<MoneyAmount value={36.4} />}
+    valueClassName="num text-display font-medium leading-none tracking-tight text-neg"
+    sub="au-delà du plafond hebdomadaire"
+    subClassName="text-xs text-neg"
+  />
+);

--- a/front/.design-sync/previews/Switch.tsx
+++ b/front/.design-sync/previews/Switch.tsx
@@ -1,0 +1,152 @@
+import { GlowCard, Label, Overline, Switch } from "pfa-next";
+
+const PILL = "inline-flex items-center gap-2 rounded-sm border border-line px-2.5 py-1.5 text-xs";
+const ROW = "flex items-center justify-between gap-6";
+const TEXT = "text-sm text-ink-2";
+
+export const FilterToggles = () => (
+  <div className="flex flex-wrap items-center gap-2">
+    <div className={`${PILL} bg-surface-elev`}>
+      <Switch
+        id="sw-compare"
+        checked
+        className="data-[state=checked]:bg-accent-strong"
+      />
+      <Label
+        htmlFor="sw-compare"
+        className="text-xs text-ink-3"
+      >
+        Comparer à <span className="num text-ink-2">2025</span>
+      </Label>
+    </div>
+    <div className={`${PILL} bg-transparent`}>
+      <Switch
+        id="sw-exceptionals"
+        checked
+        className="data-[state=checked]:bg-exc"
+      />
+      <Label
+        htmlFor="sw-exceptionals"
+        className="text-xs text-ink-2"
+      >
+        Achats exceptionnels
+      </Label>
+    </div>
+    <div className={`${PILL} bg-transparent`}>
+      <Switch id="sw-fixed" />
+      <Label
+        htmlFor="sw-fixed"
+        className="text-xs text-ink-3"
+      >
+        Dépenses fixes
+      </Label>
+    </div>
+  </div>
+);
+
+export const States = () => (
+  <div className="flex flex-col gap-3.5">
+    <div className="flex items-center gap-2.5">
+      <Switch id="sw-off" />
+      <Label
+        htmlFor="sw-off"
+        className={TEXT}
+      >
+        Inactif — Comparer à l’an dernier
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Switch
+        id="sw-on"
+        checked
+      />
+      <Label
+        htmlFor="sw-on"
+        className={TEXT}
+      >
+        Actif — Comparer à l’an dernier
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Switch
+        id="sw-off-disabled"
+        disabled
+      />
+      <Label
+        htmlFor="sw-off-disabled"
+        className={TEXT}
+      >
+        Désactivé — Plafond hebdomadaire
+      </Label>
+    </div>
+    <div className="flex items-center gap-2.5">
+      <Switch
+        id="sw-on-disabled"
+        disabled
+        checked
+      />
+      <Label
+        htmlFor="sw-on-disabled"
+        className={TEXT}
+      >
+        Désactivé actif — Achats exceptionnels
+      </Label>
+    </div>
+  </div>
+);
+
+export const SettingsCard = () => (
+  <GlowCard
+    as="section"
+    className="w-[420px] p-4"
+  >
+    <Overline>Préférences d’affichage</Overline>
+    <div className="mt-3 flex flex-col gap-3">
+      <div className={ROW}>
+        <div className="flex flex-col gap-0.5">
+          <Label
+            htmlFor="sw-p-exc"
+            className={TEXT}
+          >
+            Achats exceptionnels
+          </Label>
+          <span className="text-2xs text-ink-4">Inclus dans le reste à vivre</span>
+        </div>
+        <Switch
+          id="sw-p-exc"
+          checked
+          className="data-[state=checked]:bg-exc"
+        />
+      </div>
+      <div className={ROW}>
+        <div className="flex flex-col gap-0.5">
+          <Label
+            htmlFor="sw-p-cap"
+            className={TEXT}
+          >
+            Plafond hebdomadaire
+          </Label>
+          <span className="text-2xs text-ink-4">
+            Alerte au-delà de <span className="num">180,00 €</span>
+          </span>
+        </div>
+        <Switch
+          id="sw-p-cap"
+          checked
+        />
+      </div>
+      <div className={ROW}>
+        <div className="flex flex-col gap-0.5">
+          <Label
+            htmlFor="sw-p-fixed"
+            className={TEXT}
+          >
+            Dépenses fixes
+          </Label>
+          <span className="text-2xs text-ink-4">Masquer les prélèvements</span>
+        </div>
+        <Switch id="sw-p-fixed" />
+      </div>
+    </div>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/Tabs.tsx
+++ b/front/.design-sync/previews/Tabs.tsx
@@ -1,0 +1,120 @@
+import { ChartPie, ListFilter, Tags } from "lucide-react";
+import { CardSectionHeader, GlowCard, MoneyAmount, StatTile, Tabs, TabsContent, TabsList, TabsTrigger } from "pfa-next";
+
+export const Default = () => (
+  <Tabs defaultValue="depenses" className="w-full max-w-md">
+    <TabsList>
+      <TabsTrigger value="depenses">Dépenses</TabsTrigger>
+      <TabsTrigger value="categories">Catégories</TabsTrigger>
+      <TabsTrigger value="statistiques">Statistiques</TabsTrigger>
+    </TabsList>
+    <TabsContent value="depenses" className="pt-3">
+      <div className="flex flex-col gap-2.5">
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-ink-2">Courses</span>
+          <MoneyAmount value={78.2} className="num text-ink" />
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-ink-2">Pharmacie</span>
+          <MoneyAmount value={23.9} className="num text-ink" />
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-ink-2">Uber</span>
+          <MoneyAmount value={16.4} className="num text-ink" />
+        </div>
+      </div>
+    </TabsContent>
+    <TabsContent value="categories" className="pt-3">
+      <p className="text-sm text-ink-3">8 catégories actives en mai 2026.</p>
+    </TabsContent>
+    <TabsContent value="statistiques" className="pt-3">
+      <p className="text-sm text-ink-3">Répartition mensuelle des dépenses.</p>
+    </TabsContent>
+  </Tabs>
+);
+
+export const Periods = () => (
+  <Tabs defaultValue="mois" className="w-full max-w-md">
+    <TabsList>
+      <TabsTrigger value="semaine">Semaine</TabsTrigger>
+      <TabsTrigger value="mois">Mois</TabsTrigger>
+      <TabsTrigger value="annee">Année</TabsTrigger>
+    </TabsList>
+    <TabsContent value="semaine" className="pt-3">
+      <StatTile label="Total semaine" value={<MoneyAmount value={286.4} />} sub="plafond hebdomadaire 250,00 €" />
+    </TabsContent>
+    <TabsContent value="mois" className="pt-3">
+      <StatTile label="Total du mois" value={<MoneyAmount value={1240.5} />} sub="mai 2026 · 24 dépenses" />
+    </TabsContent>
+    <TabsContent value="annee" className="pt-3">
+      <StatTile label="Total de l'année" value={<MoneyAmount value={14320.75} />} sub="2026 · 287 dépenses" />
+    </TabsContent>
+  </Tabs>
+);
+
+export const WithIcons = () => (
+  <Tabs defaultValue="repartition" className="w-full max-w-md">
+    <TabsList>
+      <TabsTrigger value="liste">
+        <ListFilter />
+        Liste
+      </TabsTrigger>
+      <TabsTrigger value="repartition">
+        <ChartPie />
+        Répartition
+      </TabsTrigger>
+      <TabsTrigger value="categories">
+        <Tags />
+        Catégories
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="repartition" className="pt-3">
+      <p className="text-sm text-ink-3">
+        <b className="font-semibold text-ink">Alimentation</b> pèse <b className="num font-semibold text-ink">33%</b> de
+        tes dépenses de mai 2026.
+      </p>
+    </TabsContent>
+  </Tabs>
+);
+
+export const WithDisabledTab = () => (
+  <Tabs defaultValue="mois" className="w-full max-w-md">
+    <TabsList>
+      <TabsTrigger value="mois">Mois</TabsTrigger>
+      <TabsTrigger value="annee">Année</TabsTrigger>
+      <TabsTrigger value="comparaison" disabled>
+        Comparaison
+      </TabsTrigger>
+    </TabsList>
+    <TabsContent value="mois" className="pt-3">
+      <p className="text-sm text-ink-3">La comparaison N-1 demande un second mois de données.</p>
+    </TabsContent>
+  </Tabs>
+);
+
+export const InCard = () => (
+  <GlowCard as="section" className="w-full max-w-md p-5">
+    <CardSectionHeader title="Achats exceptionnels" meta="mai 2026" />
+    <Tabs defaultValue="valides" className="mt-4">
+      <TabsList>
+        <TabsTrigger value="valides">Validés</TabsTrigger>
+        <TabsTrigger value="attente">En attente</TabsTrigger>
+      </TabsList>
+      <TabsContent value="valides" className="pt-3">
+        <div className="flex flex-col gap-2.5">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-ink-2">Réparation vélo</span>
+            <MoneyAmount value={189} className="num text-exc" />
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-ink-2">Billet de train</span>
+            <MoneyAmount value={139.2} className="num text-exc" />
+          </div>
+        </div>
+      </TabsContent>
+      <TabsContent value="attente" className="pt-3">
+        <p className="text-sm text-ink-3">Aucun achat en attente de validation.</p>
+      </TabsContent>
+    </Tabs>
+  </GlowCard>
+);

--- a/front/.design-sync/previews/TextInput.tsx
+++ b/front/.design-sync/previews/TextInput.tsx
@@ -1,0 +1,31 @@
+import { TextInput } from "pfa-next";
+
+const FIELD = "w-64";
+
+export const Base = () => (
+  <div className="flex flex-col gap-3">
+    <TextInput className={FIELD} placeholder="Libellé de la dépense" />
+    <TextInput className={FIELD} defaultValue="Courses Monoprix" />
+  </div>
+);
+
+export const Amount = () => (
+  <div className="flex flex-col gap-3">
+    <TextInput className={`${FIELD} num`} type="number" step="0.01" defaultValue="1240.50" />
+    <TextInput className={`${FIELD} num`} type="date" defaultValue="2026-05-14" />
+  </div>
+);
+
+export const Disabled = () => (
+  <div className="flex flex-col gap-3">
+    <TextInput className={FIELD} disabled placeholder="Plafond hebdomadaire" />
+    <TextInput className={`${FIELD} num`} disabled defaultValue="780,00 €" />
+  </div>
+);
+
+export const Invalid = () => (
+  <div className="flex flex-col gap-3">
+    <TextInput className={`${FIELD} num`} aria-invalid defaultValue="-12,00" />
+    <TextInput className={FIELD} aria-invalid placeholder="Champ requis" />
+  </div>
+);

--- a/front/.design-sync/previews/Toaster.tsx
+++ b/front/.design-sync/previews/Toaster.tsx
@@ -1,0 +1,69 @@
+import { ExportButton, Toaster } from "pfa-next";
+import { useEffect, useRef } from "react";
+
+/**
+ * Sonner mounts an empty fixed region and renders nothing until something calls
+ * `toast()`. `toast` is not part of the DS surface, but ExportButton is — and it
+ * is pfa's one real toast caller ("Export à venir"), wired to the same sonner
+ * instance as this Toaster. Firing it on mount is therefore the only honest way
+ * to show the Toaster doing its job. The effect runs after the Toaster has
+ * subscribed, and `duration` is pinned so the toast is still up at capture time.
+ */
+const useAutoToast = () => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    ref.current?.querySelector("button")?.click();
+  }, []);
+  return ref;
+};
+
+/**
+ * `Toaster` reads `useTheme()` and defaults to `"system"` when no ThemeProvider
+ * is mounted. The app always resolves dark (`defaultTheme="dark"`,
+ * `enableSystem={false}`), but this host has no provider, so sonner would fall
+ * back to its LIGHT chrome: a white `--gray1` close button under pfa's
+ * dark-theme `--normal-text` ink, i.e. a white X on a white circle. `theme` is
+ * sonner's own prop and the component spreads `...props` after it, so pinning
+ * it here reproduces the app's real resolved state rather than a fake.
+ */
+const THEME = "dark" as const;
+
+/** The app configuration: `richColors`, `closeButton`, pinned top-right. */
+export const Default = () => {
+  const ref = useAutoToast();
+  return (
+    <div
+      ref={ref}
+      className="relative min-h-[220px]"
+    >
+      <ExportButton />
+      <Toaster
+        richColors
+        closeButton
+        theme={THEME}
+        position="top-right"
+        duration={Number.POSITIVE_INFINITY}
+      />
+    </div>
+  );
+};
+
+/** The `position` axis — the same toast anchored bottom-center instead. */
+export const BottomCenter = () => {
+  const ref = useAutoToast();
+  return (
+    <div
+      ref={ref}
+      className="relative min-h-[220px]"
+    >
+      <ExportButton />
+      <Toaster
+        richColors
+        closeButton
+        theme={THEME}
+        position="bottom-center"
+        duration={Number.POSITIVE_INFINITY}
+      />
+    </div>
+  );
+};

--- a/front/.design-sync/previews/Tooltip.tsx
+++ b/front/.design-sync/previews/Tooltip.tsx
@@ -1,0 +1,102 @@
+import { IconButton, MoneyAmount, Tooltip, TooltipContent, TooltipTrigger } from "pfa-next";
+import { Info } from "lucide-react";
+
+/**
+ * The canonical story: the info affordance next to a computed stat. `Tooltip`
+ * mounts its own `TooltipProvider`, so there is nothing to wrap; `defaultOpen`
+ * pins the portalled content (and its arrow) open for the capture.
+ */
+export const Default = () => (
+  // `pt-12` buys the `side="top"` content its clearance: without it the tooltip
+  // collides with the viewport edge and Radix flips it under the row.
+  <div className="flex items-center gap-2 pt-12">
+    <span className="text-2xs tracking-caps text-ink-4">RESTE À VIVRE</span>
+    <Tooltip defaultOpen>
+      <TooltipTrigger asChild>
+        <IconButton
+          variant="ghost"
+          size={5}
+          aria-label="Comment est calculé le reste à vivre ?"
+        >
+          <Info />
+        </IconButton>
+      </TooltipTrigger>
+      <TooltipContent side="top">Revenus moins les dépenses fixes du mois.</TooltipContent>
+    </Tooltip>
+    <MoneyAmount value={780} />
+  </div>
+);
+
+/**
+ * `TooltipContent`'s variant axis: `side` — the arrow follows the placement.
+ *
+ * `avoidCollisions={false}` is load-bearing: the capture viewport is 620x300, so
+ * Radix's collision detection otherwise flips every side back toward the middle
+ * (top→bottom, left→right) and all four cells render identically. Each trigger is
+ * parked so its true side has room — the `left`/`right` pair hug the centre gutter
+ * and point inward, so nothing overflows the card.
+ */
+export const Sides = () => (
+  <div className="grid grid-cols-2 items-center gap-x-8 gap-y-16 px-6 py-12">
+    {(
+      [
+        { side: "top", justify: "justify-center" },
+        { side: "bottom", justify: "justify-center" },
+        { side: "left", justify: "justify-end" },
+        { side: "right", justify: "justify-start" },
+      ] as const
+    ).map(({ side, justify }) => (
+      <div
+        key={side}
+        className={`flex ${justify}`}
+      >
+        <Tooltip defaultOpen>
+          <TooltipTrigger asChild>
+            <IconButton
+              variant="bordered"
+              size={7}
+              aria-label={`Aide — ${side}`}
+            >
+              <Info />
+            </IconButton>
+          </TooltipTrigger>
+          <TooltipContent
+            side={side}
+            sideOffset={6}
+            avoidCollisions={false}
+          >
+            Plafond hebdomadaire
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    ))}
+  </div>
+);
+
+/**
+ * A longer explanation — `TooltipContent` is `w-fit` with `text-balance`, so a
+ * full sentence wraps evenly instead of running off. `className` caps the width.
+ */
+export const LongContent = () => (
+  <div className="flex items-center gap-2">
+    <span className="text-2xs tracking-caps text-ink-4">PROJECTION</span>
+    <Tooltip defaultOpen>
+      <TooltipTrigger asChild>
+        <IconButton
+          variant="ghost"
+          size={5}
+          aria-label="D'où vient cette projection ?"
+        >
+          <Info />
+        </IconButton>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        className="max-w-64"
+      >
+        Projection basée sur mai 2025. À défaut, le même mois de l'année précédente, puis le mois précédent.
+      </TooltipContent>
+    </Tooltip>
+    <MoneyAmount value={1240.5} />
+  </div>
+);

--- a/front/.design-sync/tsconfig.dts.json
+++ b/front/.design-sync/tsconfig.dts.json
@@ -1,0 +1,24 @@
+// Emits a .d.ts tree for the DS barrel so design-sync can extract real prop
+// contracts. The app itself is noEmit; without this every <Name>Props degrades
+// to `[key: string]: unknown` and the design agent codes blind.
+//
+// `include` is only the barrel — tsc follows its imports, so the tree covers
+// exactly the DS surface and nothing else.
+//
+//   npx tsc -p .design-sync/tsconfig.dts.json
+//
+// Output lands in front/dist/types (already gitignored via **/dist).
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "declarationMap": false,
+    "allowJs": false,
+    "skipLibCheck": true,
+    "rootDir": "..",
+    "outDir": "../dist/types"
+  },
+  "include": ["./ds-entry.tsx"]
+}

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -37,3 +37,10 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .claude/worktrees/
+
+# design-sync (claude.ai/design)
+/.ds-sync/
+/ds-bundle/
+/.design-sync/.cache/
+/.design-sync/learnings/
+/.design-sync/node_modules

--- a/front/docs/design-system.md
+++ b/front/docs/design-system.md
@@ -475,3 +475,26 @@ Honest list — worth knowing before you trip on them:
 
 Verify with `pnpm exec tsc --noEmit` and `pnpm exec biome check ./src`.
 Biome is the linter/formatter (not ESLint), `lineWidth` 120. Never run Biome over `styles/` — it's CSS.
+
+---
+
+## 13. Claude Design (`pnpm ds:prepare`)
+
+This design system is also published to **Claude Design** so that new PFA screens designed there are
+built from these real components and tokens, instead of the frozen 2026 mockups in
+`design_handoff_pfa/` that the code has long since diverged from.
+
+Project: https://claude.ai/design/p/aba2a406-a3d0-41e5-ab59-3481c4a782ba (tab **Design systems**).
+To use it: in the Claude Design composer, pick "PFA DS" in the **Design system** dropdown.
+
+**You never run `ds:prepare` by hand.** To re-publish after changing components or tokens, open Claude
+Code in this repo and run `/design-sync` — it does the rest.
+
+`ds:prepare` exists because pfa is an app, not a published component library: it has no `dist/` and
+`noEmit: true`, so the two things the publisher needs don't exist. The script manufactures both from
+this source — a `.d.ts` tree (the API contract the design agent codes against) and a compiled,
+dark-by-default stylesheet. It's wired as the publisher's `buildCmd`, which is what actually calls it.
+
+Everything else lives in `front/.design-sync/` — **read `NOTES.md` there before touching any of it.**
+Several of those choices look wrong and are load-bearing (relative imports in `ds-entry.tsx`, an
+unlayered `html body` rule, the `@source inline` safelists); each one failed *silently* when absent.

--- a/front/package.json
+++ b/front/package.json
@@ -10,7 +10,8 @@
     "lint": "biome check ./src",
     "lint:fix": "biome check --write ./src",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "ds:prepare": "node .design-sync/prepare.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
Publishes the pfa component library to a Claude Design design system, so new designs are built from the real components and tokens instead of the frozen 2026 mockups the code has since diverged from.

pfa is a Next app, not a published library: no dist/, no exports, noEmit. design-sync's two normal inputs — a compiled stylesheet and a shipped .d.ts tree — therefore don't exist. .design-sync/prepare.mjs manufactures both from the app's own source, and is the required pre-converter step.

Sync inputs (nothing here is app code; all output is gitignored):
- ds-entry.tsx     scoped barrel over the 40 design-system components.
                   Relative imports are deliberate: tsc copies the
                   specifier into the emitted .d.ts and the converter's
                   ts-morph has no paths mapping, so aliases silently
                   degrade all 40 prop contracts to `[key: string]: unknown`.
- prepare.mjs      emits dist/types (+ a manifest the extractor probes for)
                   and compiles the Tailwind v4 source to real CSS, widening
                   `.dark` to `:root` — pfa is dark-only, and preview cards
                   and generated designs have no app shell to set the class.
- ds-styles.src.css safelists the palette/spacing/sizing families and makes
                   `dark:` unconditional. The bundle ships static CSS, so a
                   class the app never used silently resolves to nothing.
- overrides/       forks source-kit.mjs: src dirs are code organisation here,
                   not design taxonomy, so grouping comes from docs/ instead.
- previews/        40 authored preview cards, all render-checked and graded.
- NOTES.md         the traps (all four fail silently) + re-sync risks.
- conventions.md   prepended to the README; inlined into the design agent's
                   prompt, so it must only name things that really exist.

Excludes ui/card.tsx (dead since COS-100), Spinner (next/image dragged the whole Next image runtime into the bundle) and the auth/router-bound chrome.

Verified: 40/40 previews render, 0 bad, 0 thin, 0 fallback cards.