### PR TITLE
refactor(ds): rename --bg to --surface-base

### DIFF
--- a/front/.design-sync/ds-styles.src.css
+++ b/front/.design-sync/ds-styles.src.css
@@ -33,7 +33,7 @@
    silently resolve to nothing. Safelist the whole pfa palette across the
    properties it can legitimately drive. Invalid combinations emit nothing. */
 @source inline(
-  "{text,bg,border,ring,outline,fill,stroke,from,via,to,divide,placeholder,caret,shadow}-{ink,ink-2,ink-3,ink-4,ink-5,surface-elev,surface-hi,surface-hover,line,line-soft,accent-strong,accent-d,accent-bg,neg,danger-solid,on-danger,danger-surface,danger-border-soft,exc,exc-bg,elec}"
+  "{text,bg,border,ring,outline,fill,stroke,from,via,to,divide,placeholder,caret,shadow}-{ink,ink-2,ink-3,ink-4,ink-5,surface-base,surface-elev,surface-hi,surface-hover,line,line-soft,accent-strong,accent-d,accent-bg,neg,danger-solid,on-danger,danger-surface,danger-border-soft,exc,exc-bg,elec}"
 );
 /* Same reasoning for layout glue. The agent writes its own scaffolding, and the
    app simply never used `gap-8`, `mt-8`, `space-y-4` or `grid-cols-4`, so none
@@ -75,6 +75,6 @@
    pfa's near-white ink on white — invisible. `html body` outranks that `body`.
    pfa is dark-only, so this is the honest default for cards and for designs. */
 html body {
-  background-color: var(--bg);
+  background-color: var(--surface-base);
   color: var(--ink);
 }

--- a/front/docs/design-system.md
+++ b/front/docs/design-system.md
@@ -88,23 +88,23 @@ All colours are oklch. Lightness is the first number — it's the thing to reaso
 
 | Token | Value | Utility | Use |
 |---|---|---|---|
-| `--bg` | `oklch(0.14 0.042 234)` | `bg-background` ⚠️ | page background — the darkest thing |
+| `--surface-base` | `oklch(0.14 0.042 234)` | `bg-surface-base` | page background — the darkest thing |
 | `--surface-elev` | `oklch(0.205 0.006 250)` | `bg-surface-elev` | cards, modals, popovers |
 | `--surface-hi` | `oklch(0.215 0.007 250)` | `bg-surface-hi` | inset chips, meter tracks, controls |
 | `--surface-hover` | `oklch(0.22 0.006 250)` | `bg-surface-hover` | hover state |
 | `--line` | `oklch(0.27 0.008 250)` | `border-line` | default border |
 | `--line-soft` | `oklch(0.24 0.006 250)` | `border-line-soft` | internal dividers |
 
-> ⚠️ **There is no `bg-bg` utility.** `--bg` is the only surface token *not* exposed in `@theme
-> inline`, so `bg-bg` compiles to nothing and fails silently — no build error, no background. Reach
-> the page colour through the shadcn remap (`--background: var(--bg)`), i.e. **`bg-background`**,
-> which is what `layout.tsx` puts on `<body>`. Four files currently use the dead class (§11.6).
+> **`--surface-base` is the base of the surface ladder** (`surface-base → surface-elev → surface-hi`).
+> Use **`bg-surface-base`** in PFA code. shadcn's own remap (`--background: var(--surface-base)`) gives
+> `bg-background` the same colour — keep that inside `ui/*`, but reach for `bg-surface-base` everywhere
+> else.
 
 **A card is lighter than the page.** Surfaces get *lighter* as they come forward (0.14 → 0.205 →
-0.22). If you find yourself making a card darker than `--bg`, you've inverted the system.
+0.22). If you find yourself making a card darker than `--surface-base`, you've inverted the system.
 
 **A hairline is only a line if it's lighter than the fill behind it.** `--line-soft` must stay above
-*every* surface it draws on — `--bg` 0.14, `--surface-elev` 0.205, `--surface-hi` 0.215,
+*every* surface it draws on — `--surface-base` 0.14, `--surface-elev` 0.205, `--surface-hi` 0.215,
 `--surface-hover` 0.22. At 0.20 it sat *under* `--surface-elev`, and every separator on a card
 vanished (COS-105). 0.24 clears the highest surface by 0.02 and sits ~0.03 under `--line`. **If you
 ever raise a surface above 0.24, raise `--line-soft` with it** — the tightest constraint is
@@ -156,7 +156,7 @@ variant="danger">`, or `<ConfirmDeleteDialog>`.
 
 ### shadcn remap
 
-`--background` → `--bg` · `--card` / `--popover` → `--surface-elev` · `--primary` →
+`--background` → `--surface-base` · `--card` / `--popover` → `--surface-elev` · `--primary` →
 `--accent-strong` · `--muted-foreground` → `--ink-3` · `--border` / `--input` → `--line` ·
 `--destructive` → `--neg` · `--ring` → `--accent-d`.
 
@@ -448,16 +448,7 @@ Honest list — worth knowing before you trip on them:
    `fonts.googleapis.com` for three unused families. Leftovers from the pre-Geist design. Deleting
    the `@import` and the three tokens is safe and is a real performance win; it just hasn't been
    ticketed.
-6. **`bg-bg` is a dead class shipped in four places.** `--bg` is the one surface token missing from
-   `@theme inline`, so `bg-bg` generates no CSS — it fails silently, with no build error. It's
-   currently used at `app/error.tsx:17`, `app/error.tsx:42`,
-   `datePickerWrapper/DatePickerWrapper.tsx:84` and `categories/CategoryFormModal.tsx:12`, all of
-   which render with no background as a result. Two fixes are possible and someone should pick one:
-   swap the call sites to `bg-background`, or add `--color-bg: var(--bg)` to `@theme inline` so the
-   name works as everyone already expects. The second is probably right — the whole palette is
-   exposed this way, `--bg` is the lone exception, and the fact that four independent call sites
-   reached for `bg-bg` is evidence the name is the intuitive one.
-7. **No z-index tokens** (§6b). A real seven-rung ladder exists as bare literals in four files, with
+6. **No z-index tokens** (§6b). A real seven-rung ladder exists as bare literals in four files, with
    30 doubly assigned. Add a rung by reading the table and hoping.
 
 ---

--- a/front/src/app/(private)/layout.tsx
+++ b/front/src/app/(private)/layout.tsx
@@ -17,7 +17,7 @@ export default async function PrivateLayout({ children }: { children: React.Reac
       initialCsrfToken={session.csrfToken}
     >
       <SessionWatcher />
-      <div className="min-h-screen w-full bg-background">
+      <div className="min-h-screen w-full bg-surface-base">
         <div className="pfa-shell mx-auto w-full max-w-[2000px] px-4 pt-4 pb-16 sm:px-6 lg:px-8">
           <NavBar />
           <main>{children}</main>

--- a/front/src/app/(public)/layout.tsx
+++ b/front/src/app/(public)/layout.tsx
@@ -17,7 +17,7 @@ export default async function PublicLayout({ children }: { children: React.React
       initialUser={session?.user ?? null}
       initialCsrfToken={session?.csrfToken ?? null}
     >
-      <div className="relative flex min-h-screen w-full flex-col overflow-x-hidden bg-background">
+      <div className="relative flex min-h-screen w-full flex-col overflow-x-hidden bg-surface-base">
         <div
           className="auth-grain"
           aria-hidden

--- a/front/src/app/error.tsx
+++ b/front/src/app/error.tsx
@@ -14,7 +14,7 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
   }, [error]);
 
   return (
-    <div className="min-h-screen w-full bg-bg px-4 py-16">
+    <div className="min-h-screen w-full bg-surface-base px-4 py-16">
       <div className="mx-auto flex max-w-2xl flex-col items-center rounded-xl border border-line bg-surface-elev p-8 text-ink shadow-card backdrop-blur-sm">
         <p className="mb-2 text-xs uppercase tracking-[0.22em] text-neg">Application Error</p>
         <h1 className="mb-4 text-center text-3xl font-bold">Something went wrong</h1>
@@ -39,7 +39,9 @@ export default function ErrorPage({ error, reset }: ErrorPageProps) {
         </div>
 
         {process.env.NODE_ENV !== "production" && (
-          <pre className="mt-6 w-full overflow-auto rounded-sm bg-bg p-3 text-xs text-neg">{error.message}</pre>
+          <pre className="mt-6 w-full overflow-auto rounded-sm bg-surface-base p-3 text-xs text-neg">
+            {error.message}
+          </pre>
         )}
       </div>
     </div>

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       className={`dark ${geistSans.variable} ${geistMono.variable}`}
       suppressHydrationWarning
     >
-      <body className="bg-background text-foreground antialiased">
+      <body className="bg-surface-base text-foreground antialiased">
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/front/src/components/categories/CategoryFormModal.tsx
+++ b/front/src/components/categories/CategoryFormModal.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from "react";
 
 const LABEL = overlineClass;
 const INPUT =
-  "w-full rounded-sm border border-line bg-bg px-3 py-2.5 text-sm text-ink outline-none transition focus:border-accent-d";
+  "w-full rounded-sm border border-line bg-surface-base px-3 py-2.5 text-sm text-ink outline-none transition focus:border-accent-d";
 
 interface CategoryFormModalProps {
   open: boolean;

--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -128,7 +128,7 @@ const BudgetHero = () => {
                 sur
                 <Input
                   defaultValue={initialAmount}
-                  className="num h-7 w-24 border-accent-d bg-background text-ink"
+                  className="num h-7 w-24 border-accent-d bg-surface-base text-ink"
                   onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
                     if (e.key === "Escape") setEditing(false);
                   }}

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -108,7 +108,7 @@ const WeeklyCeiling = () => {
             >
               <Input
                 defaultValue={ceiling}
-                className="num h-7 w-24 border-accent-d bg-background text-ink"
+                className="num h-7 w-24 border-accent-d bg-surface-base text-ink"
                 onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === "Escape") setEditing(false);
                 }}

--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -81,7 +81,7 @@ const DatePickerWrapper = () => {
           "inline-flex select-none items-center gap-2.5 whitespace-nowrap rounded-lg border px-3.5 py-2 text-sm text-ink-2 shadow-lg transition-colors hover:cursor-pointer",
           isCalendarVisible
             ? "border-accent-d bg-surface-elev"
-            : "border-line bg-bg hover:border-ink-4 hover:bg-surface-elev",
+            : "border-line bg-surface-base hover:border-ink-4 hover:bg-surface-elev",
         )}
       >
         <CalendarIcon className="size-4 shrink-0 text-ink-4" />

--- a/front/src/components/shared/TextInput.tsx
+++ b/front/src/components/shared/TextInput.tsx
@@ -3,7 +3,7 @@ import { cn } from "@lib/utils";
 
 /** The app's field-input treatment, baked onto the shadcn `Input`. */
 const FIELD_INPUT =
-  "border-line bg-background text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0";
+  "border-line bg-surface-base text-ink placeholder:text-ink-5 focus-visible:border-accent-d focus-visible:ring-0";
 
 /** Text input styled for the app's forms. Extra classes (e.g. `num`) merge on top. */
 function TextInput({ className, ...props }: React.ComponentProps<typeof Input>) {

--- a/front/src/components/shared/comboboxTriggerClass.ts
+++ b/front/src/components/shared/comboboxTriggerClass.ts
@@ -6,6 +6,6 @@ import { cn } from "@lib/utils";
  */
 export const comboboxTriggerClass = (open: boolean) =>
   cn(
-    "flex w-full items-center gap-2.5 rounded-md border bg-background px-3 py-2.5 text-left text-sm text-ink transition-colors hover:border-ink-4",
+    "flex w-full items-center gap-2.5 rounded-md border bg-surface-base px-3 py-2.5 text-left text-sm text-ink transition-colors hover:border-ink-4",
     open ? "border-accent-d" : "border-line",
   );

--- a/front/src/components/shared/sharedLoginForm/authInputClass.ts
+++ b/front/src/components/shared/sharedLoginForm/authInputClass.ts
@@ -6,7 +6,7 @@
  * 148→200 tab underline) that matches `AuthCard`'s gradient border and halo.
  * Routing focus through the app's `--accent-d` (hue 148) would clash with the
  * card's teal. The translucent fill is likewise load-bearing — it lets the glass
- * card show through, which an opaque `bg-bg` would kill.
+ * card show through, which an opaque `bg-surface-base` would kill.
  */
 export const authInputClass =
   "w-full rounded-sm border border-line px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";

--- a/front/src/components/spendings/common/spendingModal/Toggle.tsx
+++ b/front/src/components/spendings/common/spendingModal/Toggle.tsx
@@ -21,7 +21,9 @@ const Toggle = ({
     aria-pressed={active}
     className={cn(
       "inline-flex select-none items-center gap-2 rounded-md border px-3 py-2 text-xs transition-colors",
-      active ? "border-accent-d bg-accent-strong/10 text-ink" : "border-line bg-background text-ink-3 hover:text-ink-2",
+      active
+        ? "border-accent-d bg-accent-strong/10 text-ink"
+        : "border-line bg-surface-base text-ink-3 hover:text-ink-2",
       disabled && "cursor-not-allowed opacity-45 hover:text-ink-3",
     )}
   >

--- a/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
@@ -14,7 +14,7 @@ const AmountField = ({ register, errors }: AmountFieldProps) => (
     htmlFor="spendingAmount"
     error={errors.spendingAmount?.message}
   >
-    <div className="flex items-baseline gap-2 rounded-md border border-line bg-background px-3 py-2.5 transition-colors focus-within:border-accent-d">
+    <div className="flex items-baseline gap-2 rounded-md border border-line bg-surface-base px-3 py-2.5 transition-colors focus-within:border-accent-d">
       <input
         id="spendingAmount"
         inputMode="decimal"

--- a/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/DateField.tsx
@@ -36,7 +36,7 @@ const DateField = ({ register, getValues, setValue, asRecurring }: DateFieldProp
     >
       <div
         className={cn(
-          "flex items-stretch overflow-hidden rounded-md border border-line bg-background transition-opacity",
+          "flex items-stretch overflow-hidden rounded-md border border-line bg-surface-base transition-opacity",
           asRecurring ? "opacity-45" : "focus-within:border-accent-d",
         )}
       >

--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -33,7 +33,7 @@ const LabelField = ({
     <TextInput
       id="spendingLabel"
       placeholder="Ex : Boulangerie du coin"
-      className="dark:bg-background"
+      className="dark:bg-surface-base"
       {...register("spendingLabel", {
         onChange: (e) => setLabelQuery(e.target.value),
       })}

--- a/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/ReceiptField.tsx
@@ -30,7 +30,7 @@ const ReceiptField = ({ receiptFile, receiptPreview, onReceiptFile, clearReceipt
         </span>
       </Dropzone>
     ) : (
-      <div className="flex items-center gap-3 rounded-md border border-line bg-background p-2 pr-2.5">
+      <div className="flex items-center gap-3 rounded-md border border-line bg-surface-base p-2 pr-2.5">
         {receiptPreview && (
           <Image
             src={receiptPreview}

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -218,7 +218,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
           <div
             className={cn(
               "mx-5.5 overflow-hidden rounded-xl border border-line",
-              invoiceImage || pendingPreview ? "bg-[#b3ada4]" : "bg-background",
+              invoiceImage || pendingPreview ? "bg-[#b3ada4]" : "bg-surface-base",
             )}
           >
             {isLoading && !isProgress ? (

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -73,7 +73,7 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
             />
             <span className="flex min-w-0 items-baseline gap-2">
               <span className="truncate capitalize text-ink">{r.name}</span>
-              <span className="num shrink-0 rounded-full border border-line-soft bg-background px-1.75 text-2xs leading-normal text-ink-3">
+              <span className="num shrink-0 rounded-full border border-line-soft bg-surface-base px-1.75 text-2xs leading-normal text-ink-3">
                 {r.count}
               </span>
             </span>

--- a/front/src/components/statistics/StatisticsFilters.tsx
+++ b/front/src/components/statistics/StatisticsFilters.tsx
@@ -198,7 +198,7 @@ const StatisticsFilters = ({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Rechercher…"
-              className="h-9 border-line bg-background pl-8 text-sm"
+              className="h-9 border-line bg-surface-base pl-8 text-sm"
             />
           </div>
           <div className="max-h-[264px] overflow-y-auto pr-0.5">

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -110,7 +110,7 @@ const CategoryBarTooltip = ({ point, datum }: CategoryBarTooltipProps) => {
           style={{ background: datum.color }}
         />
         <span className="truncate text-sm font-medium capitalize text-ink">{datum.name}</span>
-        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-background px-2 text-2xs leading-normal text-ink-3">
+        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-surface-base px-2 text-2xs leading-normal text-ink-3">
           {datum.count}
         </span>
       </div>

--- a/front/styles/components/category-detail.css
+++ b/front/styles/components/category-detail.css
@@ -174,7 +174,7 @@
   font-family: inherit;
   font-size: 13.5px;
   color: var(--ink);
-  background: var(--bg);
+  background: var(--surface-base);
   border: 1px solid var(--line);
   border-radius: var(--r-sm);
   outline: none;
@@ -301,7 +301,7 @@
   color: var(--accent-strong);
 }
 .catd-day-list {
-  background: var(--bg);
+  background: var(--surface-base);
   border-top: 1px solid var(--line-soft);
   padding: 6px 18px;
 }

--- a/front/styles/components/chrome.css
+++ b/front/styles/components/chrome.css
@@ -48,7 +48,7 @@
   right: 0;
   height: 1rem;
   z-index: 35;
-  background: var(--bg);
+  background: var(--surface-base);
   pointer-events: none;
 }
 

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -105,7 +105,7 @@
        ~60px tall → its bottom sits at 76px. */
     top: 76px;
     z-index: 30;
-    background: var(--bg);
+    background: var(--surface-base);
     /* Bleeds the opaque background across the layout container's gutter (px-6
        here, px-8 from lg — keep in sync with PrivateLayout). The band and the
        cards are the same width to the pixel, both being in that container, so

--- a/front/styles/tokens/colors.css
+++ b/front/styles/tokens/colors.css
@@ -41,12 +41,12 @@
      ============================================================ */
 
   /* Surfaces (bg → foreground) */
-  --bg:         oklch(0.14 0.042 234);
+  --surface-base:    oklch(0.14 0.042 234);
   --surface-elev:    oklch(0.205 0.006 250);
   --surface-hi:      oklch(0.215 0.007 250);
   --surface-hover:   oklch(0.22 0.006 250);
   --line:       oklch(0.27 0.008 250);
-  /* Must stay ABOVE every surface it draws on (bg, surface-elev, surface-hi):
+  /* Must stay ABOVE every surface it draws on (surface-base, surface-elev, surface-hi):
      a hairline is only a line if it is lighter than the fill behind it. At 0.20
      it sat *under* surface-elev (0.205) and every separator on a card vanished.
      0.24 restores the design's spacing: ~.035 above the card, ~.03 below --line. */
@@ -80,7 +80,7 @@
   --elec:          oklch(0.72 0.15 230); /* "aujourd'hui" */
 
   /* ===== shadcn semantic tokens remapped onto the pfa palette ===== */
-  --background: var(--bg);
+  --background: var(--surface-base);
   --foreground: var(--ink);
   --card: var(--surface-elev);
   --card-foreground: var(--ink);
@@ -98,7 +98,7 @@
   --destructive-foreground: oklch(0.15 0.01 25);
   --border: var(--line);
   --input: var(--line);
-  --input-background: var(--bg);
+  --input-background: var(--surface-base);
   --ring: var(--accent-d);
 
   --chart-1: var(--accent-strong);
@@ -158,6 +158,7 @@
   --color-ink-3: var(--ink-3);
   --color-ink-4: var(--ink-4);
   --color-ink-5: var(--ink-5);
+  --color-surface-base: var(--surface-base);
   --color-surface-elev: var(--surface-elev);
   --color-surface-hi: var(--surface-hi);
   --color-surface-hover: var(--surface-hover);


### PR DESCRIPTION
`--bg` sat outside the surface family and forced two redundant utility names (`bg-bg`, `bg-background`). Renamed to `--surface-base` and exposed `--color-surface-base`, so the elevation ladder is now surface-base -> surface-elev -> surface-hi and `bg-surface-base` works.

- Migrate app code off `bg-background` and the dead no-op `bg-bg` class onto `bg-surface-base`. shadcn `ui/*` keep `bg-background` (their `--background: var(--surface-base)` remap is unchanged).
- Fixes `bg-bg` rendering as nothing on the DatePicker trigger and the CategoryFormModal input (the utility never existed).
- Update the design-system doc and the design-sync source (`ds-styles.src.css` bg reference + palette safelist) so the next sync ships the renamed token instead of an orphaned `var(--bg)`.