### PR TITLE
feat(deploy): per-deploy changelog (COS-108)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -40,3 +40,60 @@ location /api {
 2. **If no Set-Cookie**: issue on Nest or proxy side (missing headers)
 3. **If Set-Cookie present but cookie not stored**: likely `Secure` on an HTTP site → add `COOKIE_SECURE=false` in `.env`
 4. **If cookie stored but requests return 401**: `withCredentials` must be `true` (already configured in `useRequestHelper.js`)
+
+## Deploy changelog
+
+Each successful deploy appends an entry (newest first) to a per-app text log listing the commits that
+ship in that version, with their Linear ticket numbers:
+
+| App | URL | File on server |
+|-----|-----|----------------|
+| Front | `https://pfa.1991computer.com/deploys-front.txt` | `/var/www/pfa/deploy-logs/deploys-front.txt` |
+| API | `https://pfa.1991computer.com/deploys-api.txt` | `/var/www/pfa/deploy-logs/deploys-api.txt` |
+
+Both URLs are protected by HTTP Basic Auth. The logs live at a stable path outside the release
+directories, so they survive the atomic release switch. Only the commits added **since that app's
+previous deploy** are recorded (tracked via `/var/www/pfa/deploy-logs/.last-<app>` marker files).
+
+### One-time server setup
+
+```bash
+# 1. Create the Basic Auth credentials (needs apache2-utils)
+htpasswd -bc /var/www/pfa/deploy-logs/.htpasswd <user> <password>
+```
+
+```nginx
+# 2. Add to the nginx server block (same file that proxies /api).
+#    Exact-match locations, so they take priority over the Next proxy and expose ONLY these two files.
+location = /deploys-front.txt {
+  alias /var/www/pfa/deploy-logs/deploys-front.txt;
+  default_type text/plain; charset utf-8;
+  add_header X-Robots-Tag "noindex, nofollow" always;
+  add_header Cache-Control "no-store" always;
+  auth_basic "PFA deploys";
+  auth_basic_user_file /var/www/pfa/deploy-logs/.htpasswd;
+}
+location = /deploys-api.txt {
+  alias /var/www/pfa/deploy-logs/deploys-api.txt;
+  default_type text/plain; charset utf-8;
+  add_header X-Robots-Tag "noindex, nofollow" always;
+  add_header Cache-Control "no-store" always;
+  auth_basic "PFA deploys";
+  auth_basic_user_file /var/www/pfa/deploy-logs/.htpasswd;
+}
+```
+
+```bash
+# 3. Reload nginx
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+### First run
+
+- **Front**: automatic — the current live commit is read from the newest `public_html/releases/` folder,
+  so the first entry already shows the correct delta.
+- **API**: the API deploy leaves no hash on the server, so the first run seeds the marker and prints a
+  labeled *last 10 commits* baseline. To make even that first entry a precise delta, pass the currently
+  deployed commit once: `PFA_SINCE=<hash> ./nest-api/deploy-api.sh`.
+
+Every deploy after the first is fully automatic for both apps.

--- a/front/deploy-front.sh
+++ b/front/deploy-front.sh
@@ -111,6 +111,13 @@ deploy() {
   local STAGING_DIR="$RELEASES_DIR/$RELEASE_NAME"
   local SWITCH_DONE="false"
 
+  # Current live front commit, read from the newest release folder name (…-<hash>) before this
+  # deploy's own staging folder is created. Used only to seed the changelog on the very first run
+  # (no marker yet). Non-fatal: an empty value just falls back to the last-10 baseline.
+  local PREV_FROM_SERVER
+  PREV_FROM_SERVER=$(ssh "$REMOTE_USER_HOST" "ls -1 '$RELEASES_DIR' 2>/dev/null | sort | tail -1" 2>/dev/null \
+    | sed -nE 's/.*-([0-9a-f]{7,40})$/\1/p' || true)
+
   on_error() {
     local lineno=$1
     log "❌ ERROR: Deployment failed at line $lineno"
@@ -126,6 +133,70 @@ deploy() {
     else
       log "ℹ️  No rollback needed: production was not modified yet"
     fi
+  }
+
+  # Prepend this deploy's commits (+ Linear tickets) to the served changelog.
+  # Always invoked as `write_deploy_log || log ...`, so errexit is ignored throughout:
+  # a changelog hiccup can never fail or roll back an otherwise successful deploy.
+  write_deploy_log() {
+    local APP="front"
+    local LOG_DIR="$WEB_ROOT_BASE/deploy-logs"
+    local LOG_FILE="$LOG_DIR/deploys-$APP.txt"
+    local MARKER="$LOG_DIR/.last-$APP"
+    local FULL_HASH WHEN PREV_HASH TICKETS COMMITS ENTRY_TMP
+    local -a RANGE
+    FULL_HASH=$(git rev-parse HEAD)
+    WHEN=$(date +'%Y-%m-%d %H:%M:%S')
+
+    # Resolve the range base (previous deployed commit). Only used when no marker exists yet.
+    # Order: marker (steady state) -> PFA_SINCE override -> newest release folder hash -> last-10 baseline.
+    PREV_HASH=$(ssh "$REMOTE_USER_HOST" "cat '$MARKER' 2>/dev/null || true")
+    [ -z "$PREV_HASH" ] && PREV_HASH="${PFA_SINCE:-}"
+    [ -z "$PREV_HASH" ] && PREV_HASH="${PREV_FROM_SERVER:-}"
+    if [ -n "$PREV_HASH" ] && ! git cat-file -e "${PREV_HASH}^{commit}" 2>/dev/null; then
+      PREV_HASH=""
+    fi
+    if [ -n "$PREV_HASH" ]; then
+      RANGE=("${PREV_HASH}..HEAD")
+    else
+      RANGE=(-n 10 HEAD)
+    fi
+
+    # One git-log call, captured into a var (pipefail-safe: no `| grep -q` on a pipe git may SIGPIPE).
+    COMMITS=$(git log --no-merges --pretty=format:'  %h  %ad  %s' --date=short "${RANGE[@]}")
+    TICKETS=$(printf '%s\n' "$COMMITS" \
+      | grep -oiE 'COS-[0-9]+' | tr 'a-z' 'A-Z' | sort -t- -k2,2n -u | paste -sd ',' - | sed 's/,/, /g' || true)
+
+    ENTRY_TMP=$(mktemp)
+    {
+      echo "=== $WHEN · branch $GIT_BRANCH_RAW · deploy $GIT_HASH ==="
+      [ -n "$TICKETS" ] && echo "Tickets: $TICKETS"
+      [ -z "$PREV_HASH" ] && echo "  (first recorded deploy — baseline: last 10 commits, not full history)"
+      if [ -n "$COMMITS" ]; then
+        printf '%s\n' "$COMMITS"
+      else
+        echo "  (no new commit — redeploy of $GIT_HASH)"
+      fi
+      echo
+    } > "$ENTRY_TMP"
+
+    # Commit messages travel as file content (scp), never interpolated into a shell command.
+    ssh "$REMOTE_USER_HOST" "mkdir -p '$LOG_DIR'"
+    scp -q "$ENTRY_TMP" "$REMOTE_USER_HOST:$LOG_DIR/.entry.tmp"
+    ssh "$REMOTE_USER_HOST" \
+      LOG_DIR="$LOG_DIR" \
+      LOG_FILE="$LOG_FILE" \
+      MARKER="$MARKER" \
+      FULL_HASH="$FULL_HASH" \
+      'bash -s' << 'EOF'
+set -Eeuo pipefail
+touch "$LOG_FILE"
+cat "$LOG_DIR/.entry.tmp" "$LOG_FILE" > "$LOG_FILE.new"
+mv "$LOG_FILE.new" "$LOG_FILE"
+rm -f "$LOG_DIR/.entry.tmp"
+printf '%s\n' "$FULL_HASH" > "$MARKER"
+EOF
+    rm -f "$ENTRY_TMP"
   }
 
   trap 'on_error $LINENO' ERR
@@ -242,6 +313,8 @@ EOF
   remote_pm2_reload
 
   trap - ERR
+
+  write_deploy_log || log "⚠️  Deploy changelog update skipped (non-fatal)"
 
   log "✅ Deployment completed successfully"
   log "ℹ️  Next.js app settings are read from $PM2_ECOSYSTEM_FILE"

--- a/nest-api/deploy-api.sh
+++ b/nest-api/deploy-api.sh
@@ -14,11 +14,11 @@ NEST_DIR="$API_ROOT/nest-api"
 NEST_BACKUP_DIR="$API_ROOT/nest-api.bak"
 NEST_RELEASES_DIR="$API_ROOT/nest-api-releases"
 
-# Local project dir (script location = repo root)
+# Local project dir (= nest-api/, where this script now lives)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Load DATABASE_URL from nest-api/.env (required for prisma generate during Nest build)
-NEST_ENV="$SCRIPT_DIR/nest-api/.env"
+NEST_ENV="$SCRIPT_DIR/.env"
 if [ -f "$NEST_ENV" ]; then
   set -a
   # shellcheck source=/dev/null
@@ -117,6 +117,70 @@ pm2 reload ecosystem.config.js --env production 2>/dev/null || pm2 start ecosyst
 EOF
   }
 
+  # Prepend this deploy's commits (+ Linear tickets) to the served changelog.
+  # Always invoked as `write_deploy_log || log ...`, so errexit is ignored throughout:
+  # a changelog hiccup can never fail or roll back an otherwise successful deploy.
+  write_deploy_log() {
+    local APP="api"
+    local LOG_DIR="$API_ROOT/deploy-logs"
+    local LOG_FILE="$LOG_DIR/deploys-$APP.txt"
+    local MARKER="$LOG_DIR/.last-$APP"
+    local FULL_HASH WHEN PREV_HASH TICKETS COMMITS ENTRY_TMP
+    local -a RANGE
+    FULL_HASH=$(git rev-parse HEAD)
+    WHEN=$(date +'%Y-%m-%d %H:%M:%S')
+
+    # Resolve the range base (previous deployed commit). Only used when no marker exists yet.
+    # Order: marker (steady state) -> PFA_SINCE override -> per-app server hint -> last-10 baseline.
+    PREV_HASH=$(ssh "$REMOTE_USER_HOST" "cat '$MARKER' 2>/dev/null || true")
+    [ -z "$PREV_HASH" ] && PREV_HASH="${PFA_SINCE:-}"
+    [ -z "$PREV_HASH" ] && PREV_HASH="${PREV_FROM_SERVER:-}"
+    if [ -n "$PREV_HASH" ] && ! git cat-file -e "${PREV_HASH}^{commit}" 2>/dev/null; then
+      PREV_HASH=""
+    fi
+    if [ -n "$PREV_HASH" ]; then
+      RANGE=("${PREV_HASH}..HEAD")
+    else
+      RANGE=(-n 10 HEAD)
+    fi
+
+    # One git-log call, captured into a var (pipefail-safe: no `| grep -q` on a pipe git may SIGPIPE).
+    COMMITS=$(git log --no-merges --pretty=format:'  %h  %ad  %s' --date=short "${RANGE[@]}")
+    TICKETS=$(printf '%s\n' "$COMMITS" \
+      | grep -oiE 'COS-[0-9]+' | tr 'a-z' 'A-Z' | sort -t- -k2,2n -u | paste -sd ',' - | sed 's/,/, /g' || true)
+
+    ENTRY_TMP=$(mktemp)
+    {
+      echo "=== $WHEN · branch $GIT_BRANCH_RAW · deploy $GIT_HASH ==="
+      [ -n "$TICKETS" ] && echo "Tickets: $TICKETS"
+      [ -z "$PREV_HASH" ] && echo "  (first recorded deploy — baseline: last 10 commits, not full history)"
+      if [ -n "$COMMITS" ]; then
+        printf '%s\n' "$COMMITS"
+      else
+        echo "  (no new commit — redeploy of $GIT_HASH)"
+      fi
+      echo
+    } > "$ENTRY_TMP"
+
+    # Commit messages travel as file content (scp), never interpolated into a shell command.
+    ssh "$REMOTE_USER_HOST" "mkdir -p '$LOG_DIR'"
+    scp -q "$ENTRY_TMP" "$REMOTE_USER_HOST:$LOG_DIR/.entry.tmp"
+    ssh "$REMOTE_USER_HOST" \
+      LOG_DIR="$LOG_DIR" \
+      LOG_FILE="$LOG_FILE" \
+      MARKER="$MARKER" \
+      FULL_HASH="$FULL_HASH" \
+      'bash -s' << 'EOF'
+set -Eeuo pipefail
+touch "$LOG_FILE"
+cat "$LOG_DIR/.entry.tmp" "$LOG_FILE" > "$LOG_FILE.new"
+mv "$LOG_FILE.new" "$LOG_FILE"
+rm -f "$LOG_DIR/.entry.tmp"
+printf '%s\n' "$FULL_HASH" > "$MARKER"
+EOF
+    rm -f "$ENTRY_TMP"
+  }
+
   trap 'on_error $LINENO' ERR
 
   ######################################
@@ -152,7 +216,9 @@ EOF
     --exclude="prisma.config.js" \
     --exclude="prisma.config.js.map" \
     --exclude="prisma.config.d.ts" \
-    "$SCRIPT_DIR/nest-api/" \
+    --exclude="deploy-api.sh" \
+    --exclude="ecosystem.config.js" \
+    "$SCRIPT_DIR/" \
     "$REMOTE_USER_HOST":"$NEST_RELEASE_REMOTE/"
 
   ######################################
@@ -232,6 +298,8 @@ pm2 reload ecosystem.config.js --env production 2>/dev/null || pm2 start ecosyst
 EOF
 
   trap - ERR
+
+  write_deploy_log || log "⚠️  Deploy changelog update skipped (non-fatal)"
 
   log "✅ API deployment completed successfully"
   log "ℹ️  Nest API (port 6100) is running"


### PR DESCRIPTION
Both deploy scripts prepend, on success only, a per-app entry to /var/www/pfa/deploy-logs/deploys-{front,api}.txt: the commits added since that app's previous deploy (via a .last-<app> marker) with their Linear ticket numbers. Served behind nginx Basic Auth; see DEPLOY.md.

Also colocate the back deploy files into nest-api/ (mirrors front/): move deploy-api.sh and ecosystem.config.js there and rsync-exclude them, so the uploaded release and all server paths stay identical.