### PR TITLE
feat(spendings): global spending search (COS-114)

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -43,6 +43,7 @@
     "math-expression-evaluator": "^2.0.5",
     "next": "16.1.0",
     "next-themes": "^0.4.6",
+    "nuqs": "^2.9.0",
     "query-string": "^7.1.1",
     "react": "19.2.3",
     "react-day-picker": "7.4.8",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      nuqs:
+        specifier: ^2.9.0
+        version: 2.9.0(next@16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       query-string:
         specifier: ^7.1.1
         version: 7.1.1
@@ -1086,6 +1089,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@standard-schema/spec@1.0.0':
+    resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1547,6 +1553,27 @@ packages:
       babel-plugin-react-compiler:
         optional: true
       sass:
+        optional: true
+
+  nuqs@2.9.0:
+    resolution: {integrity: sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==}
+    peerDependencies:
+      '@remix-run/react': '>=2'
+      '@tanstack/react-router': ^1
+      next: '>=14.2.0'
+      react: '>=18.2.0 || ^19.0.0-0'
+      react-router: ^5 || ^6 || ^7 || ^8
+      react-router-dom: ^5 || ^6 || ^7
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      next:
+        optional: true
+      react-router:
+        optional: true
+      react-router-dom:
         optional: true
 
   object-assign@4.1.1:
@@ -2722,6 +2749,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@standard-schema/spec@1.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@standard-schema/utils@0.3.0': {}
@@ -3123,6 +3152,13 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nuqs@2.9.0(next@16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      react: 19.2.3
+    optionalDependencies:
+      next: 16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   object-assign@4.1.1: {}
 

--- a/front/src/app/providers.tsx
+++ b/front/src/app/providers.tsx
@@ -2,6 +2,7 @@
 
 import { Toaster } from "@components/ui/sonner";
 import { ThemeProvider } from "next-themes";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { ReactQueryDevtools } from "react-query/devtools";
@@ -16,10 +17,12 @@ export default function Providers({ children }: { children: React.ReactNode }) {
       enableSystem={false}
       disableTransitionOnChange
     >
-      <QueryClientProvider client={queryClient}>
-        {children}
-        <ReactQueryDevtools initialIsOpen={false} />
-      </QueryClientProvider>
+      <NuqsAdapter>
+        <QueryClientProvider client={queryClient}>
+          {children}
+          <ReactQueryDevtools initialIsOpen={false} />
+        </QueryClientProvider>
+      </NuqsAdapter>
       <Toaster
         richColors
         closeButton

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -9,6 +9,7 @@ import { ROUTES } from "@components/shared/config/constants";
 import useGlobalStore from "@components/shared/globalStore";
 import { IconButton } from "@components/shared/IconButton";
 import UserMenu from "@components/shared/navBar/userMenu/UserMenu";
+import SpendingSearchTrigger from "@components/spendings/search/SpendingSearchTrigger";
 import { buildSpendingsPath, getTodayIsoDate, isValidIsoDate, SPENDINGS_PATH } from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
 import text from "@text/navBar";
@@ -143,6 +144,9 @@ const NavBar = () => {
         </nav>
 
         <div className="ml-auto flex items-center gap-2.5">
+          {/* Whole-history spending search (COS-114) — Dashboard only, left of the
+              month selector; on mobile it collapses to a magnifier icon. */}
+          {isDashboard && <SpendingSearchTrigger />}
           {isDashboard ? (
             <div className="hidden items-center md:flex">
               <MonthSelector />

--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -14,7 +14,13 @@ export const QUERY_KEYS = {
   CATEGORY_STATS: "categoryStats",
   EXCEPTIONALS: "exceptionals",
   EXCEPTIONAL_YEARS: "exceptionalYears",
+  SPENDINGS_SEARCH: "spendingsSearch",
+  SPENDINGS_YEARS: "spendingsYears",
 };
+
+// Whole-history search (COS-114): minimum query length before the modal hits the
+// backend, kept in sync with the server-side guard.
+export const SEARCH_MIN_LENGTH = 2;
 
 export const DATE_FORMAT = "yyyy-MM-dd";
 

--- a/front/src/components/spendings/search/SpendingSearchModal.tsx
+++ b/front/src/components/spendings/search/SpendingSearchModal.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { EmptyState } from "@components/shared/EmptyState";
+import { FilterChip } from "@components/shared/FilterChip";
+import { DATE_FORMAT } from "@components/spendings/config/constants";
+import { groupSpendingsByMonth } from "@components/spendings/search/groupByMonth";
+import SpendingSearchResultRow from "@components/spendings/search/SpendingSearchResultRow";
+import { spendingSearchParsers, spendingSearchUrlOptions } from "@components/spendings/search/searchParams";
+import useDebouncedValue from "@components/spendings/search/useDebouncedValue";
+import useSpendingSearch from "@components/spendings/services/useSpendingSearch";
+import useSpendingYears from "@components/spendings/services/useSpendingYears";
+import { Dialog, DialogContent, DialogTitle } from "@components/ui/dialog";
+import { buildSpendingsPath } from "@helpers/dateRoute";
+import spendingSearch from "@text/spendingSearch";
+import format from "date-fns/format";
+import parseISO from "date-fns/parseISO";
+import { Search } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useQueryStates } from "nuqs";
+import { useEffect, useLayoutEffect, useRef } from "react";
+
+import type { SpendingItem } from "@components/spendings/types";
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+// Scroll offset of the results list, stashed when the user leaves for a spending
+// so browser Back can restore the list where they were. Module-level so it
+// survives the modal unmounting during SPA navigation; lost on hard refresh
+// (fine — the react-query page cache is gone then too).
+let savedScroll: { q: string; year: number | null; top: number } | null = null;
+
+/**
+ * Whole-history spending search palette (COS-114). Its state — open flag, query,
+ * year — lives in the URL (nuqs), so browser Back reopens it where the user left
+ * off. A debounced query (optionally scoped to a year) hits the backend, results
+ * are grouped by month (newest-first) and paged in on scroll. Picking a result
+ * navigates to the Dépenses page on the week that contains it.
+ */
+const SpendingSearchModal = () => {
+  const [{ search, q, year }, setSearchState] = useQueryStates(spendingSearchParsers, spendingSearchUrlOptions);
+  const debounced = useDebouncedValue(q, SEARCH_DEBOUNCE_MS);
+  const { results, total, isSearching, isFetchingNextPage, hasNextPage, fetchNextPage, hasQuery, error } =
+    useSpendingSearch(debounced, year);
+  const years = useSpendingYears();
+  const { setScrollToDayIso } = useDatePickerWrapperStore();
+  const router = useRouter();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const close = () => {
+    savedScroll = null;
+    setSearchState({ search: null, q: null, year: null });
+  };
+
+  const scrollToTop = () => scrollRef.current?.scrollTo({ top: 0 });
+
+  const onQueryChange = (value: string) => {
+    setSearchState({ q: value });
+    scrollToTop();
+  };
+
+  const onYearChange = (value: number | null) => {
+    setSearchState({ year: value });
+    scrollToTop();
+  };
+
+  // Infinite scroll: load the next page as the sentinel nears the bottom of the
+  // results (not the viewport — the list scrolls inside the dialog). Re-arms when
+  // the page set changes so the sentinel is observed once it exists.
+  useEffect(() => {
+    const root = scrollRef.current;
+    const sentinel = sentinelRef.current;
+    if (!root || !sentinel || !hasNextPage) {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { root, rootMargin: "160px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage, results.length]);
+
+  // Restore the saved scroll offset when reopening (browser Back) onto the same
+  // query/year, once the cached rows have rendered.
+  useLayoutEffect(() => {
+    if (!search || !savedScroll || results.length === 0) {
+      return;
+    }
+    if (savedScroll.q !== q || savedScroll.year !== year) {
+      return;
+    }
+    scrollRef.current?.scrollTo({ top: savedScroll.top });
+    savedScroll = null;
+  }, [search, q, year, results.length]);
+
+  const groups = groupSpendingsByMonth(results);
+
+  // Picking a result jumps to the Dépenses page on the week that contains it (and
+  // asks that page to scroll the day into view). We stash the scroll offset first
+  // and leave the URL search state intact, so Back restores the modal + list.
+  const goToSpendingWeek = (spending: SpendingItem) => {
+    const dateISO = format(parseISO(spending.date), DATE_FORMAT);
+    savedScroll = { q, year, top: scrollRef.current?.scrollTop ?? 0 };
+    setScrollToDayIso(dateISO);
+    router.push(buildSpendingsPath(dateISO));
+  };
+
+  return (
+    <Dialog
+      open={search}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          close();
+        }
+      }}
+    >
+      <DialogContent
+        aria-describedby={undefined}
+        className="gap-0 overflow-hidden border-line bg-surface-elev p-0 sm:max-w-[560px]"
+      >
+        <DialogTitle className="sr-only">{spendingSearch.title}</DialogTitle>
+
+        <div className="flex items-center gap-2.5 border-b border-line-soft px-4 py-3.5 pr-14">
+          <Search className="size-4 shrink-0 text-ink-4" />
+          <input
+            type="search"
+            autoFocus
+            value={q}
+            onChange={(e) => onQueryChange(e.target.value)}
+            placeholder={spendingSearch.placeholder}
+            className="min-w-0 flex-1 bg-transparent text-sm text-ink outline-none placeholder:text-ink-4"
+          />
+          {hasQuery && !isSearching && (
+            <span className="shrink-0 text-xs text-ink-4">{spendingSearch.resultsCount(total)}</span>
+          )}
+        </div>
+
+        {years.length > 0 && (
+          <div className="flex gap-2 overflow-x-auto border-b border-line-soft px-4 py-2.5">
+            <FilterChip
+              active={year === null}
+              onClick={() => onYearChange(null)}
+              className="rounded-full px-3"
+            >
+              {spendingSearch.yearsAll}
+            </FilterChip>
+            {years.map((y) => (
+              <FilterChip
+                key={y}
+                active={year === y}
+                onClick={() => onYearChange(y)}
+                className="rounded-full px-3"
+              >
+                {y}
+              </FilterChip>
+            ))}
+          </div>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="max-h-[min(60vh,440px)] overflow-y-auto"
+        >
+          {error ? (
+            <EmptyState className="py-10">{spendingSearch.error}</EmptyState>
+          ) : !hasQuery ? (
+            <EmptyState className="py-10">{spendingSearch.hint}</EmptyState>
+          ) : isSearching && results.length === 0 ? (
+            <EmptyState className="py-10">{spendingSearch.loading}</EmptyState>
+          ) : results.length === 0 ? (
+            <EmptyState className="py-10">{spendingSearch.noResults}</EmptyState>
+          ) : (
+            <>
+              {groups.map((group) => (
+                <div key={group.key}>
+                  <div className="sticky top-0 z-10 bg-surface-elev px-4 py-1.5 text-xs font-medium text-ink-4">
+                    {group.label}
+                  </div>
+                  {group.items.map((item) => (
+                    <SpendingSearchResultRow
+                      key={item.ID}
+                      spending={item}
+                      onSelect={goToSpendingWeek}
+                    />
+                  ))}
+                </div>
+              ))}
+              <div ref={sentinelRef} />
+              {isFetchingNextPage && (
+                <div className="px-4 py-3 text-center text-xs text-ink-4">{spendingSearch.loadingMore}</div>
+              )}
+            </>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SpendingSearchModal;

--- a/front/src/components/spendings/search/SpendingSearchResultRow.tsx
+++ b/front/src/components/spendings/search/SpendingSearchResultRow.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+import { euro } from "@lib/format";
+import format from "date-fns/format";
+import fr from "date-fns/locale/fr";
+import parseISO from "date-fns/parseISO";
+
+import type { SpendingItem } from "@components/spendings/types";
+
+interface SpendingSearchResultRowProps {
+  spending: SpendingItem;
+  onSelect: (spending: SpendingItem) => void;
+}
+
+/**
+ * One result line in the whole-history search modal (COS-114): date · colour pill
+ * + label · category tag · amount. Clicking it opens the edit modal. Deliberately
+ * standalone (no useSpendings / hover actions) — unlike the week-scoped
+ * SpendingTxRow it isn't tied to the day-card grid or delete flow.
+ */
+const SpendingSearchResultRow = ({ spending, onSelect }: SpendingSearchResultRowProps) => {
+  const color = spending.categoryColor || CATEGORY_FALLBACK;
+  const category = spending.category ?? null;
+  const dateLabel = format(parseISO(spending.date), "d MMM", { locale: fr });
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(spending)}
+      className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-surface-hi"
+    >
+      <span className="w-12 shrink-0 text-xs text-ink-4">{dateLabel}</span>
+      <span className="flex min-w-0 flex-1 items-center gap-2 text-sm text-ink">
+        <span
+          className="size-2 shrink-0 rounded-full"
+          style={{ background: color }}
+        />
+        <span className="truncate">{spending.label}</span>
+      </span>
+      {category && (
+        <span
+          className="shrink-0 text-xs font-medium"
+          style={{ color }}
+        >
+          {category}
+        </span>
+      )}
+      <span className="w-20 shrink-0 text-right text-sm font-semibold text-ink tabular-nums">
+        {euro(spending.amount)} €
+      </span>
+    </button>
+  );
+};
+
+export default SpendingSearchResultRow;

--- a/front/src/components/spendings/search/SpendingSearchTrigger.tsx
+++ b/front/src/components/spendings/search/SpendingSearchTrigger.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { IconButton } from "@components/shared/IconButton";
+import SpendingSearchModal from "@components/spendings/search/SpendingSearchModal";
+import { spendingSearchParsers, spendingSearchUrlOptions } from "@components/spendings/search/searchParams";
+import spendingSearch from "@text/spendingSearch";
+import { Search } from "lucide-react";
+import { useQueryStates } from "nuqs";
+import { useEffect } from "react";
+
+/**
+ * Dashboard entry point for the whole-history spending search (COS-114). Rendered
+ * in the NavBar right cluster, gated by `isDashboard`. Opening writes the modal's
+ * open flag to the URL (a pushed history entry) so browser Back can restore it;
+ * the modal itself reads that state. Primary access is the click target (field on
+ * desktop, magnifier on mobile); ⌘K / Ctrl+K is an optional desktop shortcut.
+ */
+const SpendingSearchTrigger = () => {
+  const [, setSearchState] = useQueryStates(spendingSearchParsers, spendingSearchUrlOptions);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setSearchState({ search: true }, { history: "push" });
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [setSearchState]);
+
+  const openSearch = () => setSearchState({ search: true }, { history: "push" });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openSearch}
+        className="hidden items-center gap-2 rounded-sm border border-line bg-surface-elev px-2.5 py-2 text-sm text-ink-3 transition-colors hover:text-ink md:flex"
+      >
+        <Search className="size-3.5 text-ink-4" />
+        <span>{spendingSearch.trigger}</span>
+        <kbd className="ml-1 rounded-sm border border-line px-1 py-0.5 text-[11px] leading-none text-ink-4">
+          {spendingSearch.shortcutHint}
+        </kbd>
+      </button>
+
+      <IconButton
+        variant="bordered"
+        size={9}
+        onClick={openSearch}
+        aria-label={spendingSearch.trigger}
+        className="md:hidden"
+      >
+        <Search />
+      </IconButton>
+
+      <SpendingSearchModal />
+    </>
+  );
+};
+
+export default SpendingSearchTrigger;

--- a/front/src/components/spendings/search/__tests__/groupByMonth.test.ts
+++ b/front/src/components/spendings/search/__tests__/groupByMonth.test.ts
@@ -1,0 +1,36 @@
+import { groupSpendingsByMonth } from "@components/spendings/search/groupByMonth";
+
+import type { SpendingItem } from "@components/spendings/types";
+
+const makeItem = (ID: string, date: string): SpendingItem =>
+  ({ ID, date, label: ID, amount: 1, itemType: "spending", userID: "u1" }) as SpendingItem;
+
+describe("groupSpendingsByMonth", () => {
+  it("returns an empty array for no items", () => {
+    expect(groupSpendingsByMonth([])).toEqual([]);
+  });
+
+  it("groups consecutive items of the same month into one bucket, newest-first order preserved", () => {
+    const items = [
+      makeItem("a", "2026-07-12"),
+      makeItem("b", "2026-07-04"),
+      makeItem("c", "2026-05-28"),
+      makeItem("d", "2026-02-09"),
+    ];
+
+    const groups = groupSpendingsByMonth(items);
+
+    expect(groups.map((g) => g.key)).toEqual(["2026-07", "2026-05", "2026-02"]);
+    expect(groups[0].label).toBe("Juillet 2026");
+    expect(groups[0].items.map((i) => i.ID)).toEqual(["a", "b"]);
+    expect(groups[1].items.map((i) => i.ID)).toEqual(["c"]);
+    expect(groups[2].items.map((i) => i.ID)).toEqual(["d"]);
+  });
+
+  it("keeps a separate bucket per year even for the same month number", () => {
+    const groups = groupSpendingsByMonth([makeItem("a", "2026-01-10"), makeItem("b", "2025-01-10")]);
+
+    expect(groups.map((g) => g.key)).toEqual(["2026-01", "2025-01"]);
+    expect(groups.map((g) => g.label)).toEqual(["Janvier 2026", "Janvier 2025"]);
+  });
+});

--- a/front/src/components/spendings/search/groupByMonth.ts
+++ b/front/src/components/spendings/search/groupByMonth.ts
@@ -1,0 +1,37 @@
+import format from "date-fns/format";
+import fr from "date-fns/locale/fr";
+import parseISO from "date-fns/parseISO";
+
+import type { SpendingItem } from "@components/spendings/types";
+
+export interface SpendingMonthGroup {
+  key: string;
+  label: string;
+  items: SpendingItem[];
+}
+
+const capitalize = (value: string): string => (value ? value.charAt(0).toUpperCase() + value.slice(1) : value);
+
+/**
+ * Buckets spendings by calendar month, preserving the incoming order. The search
+ * API returns matches newest-first, so both the buckets and the rows inside them
+ * stay newest-first (COS-114). Each group carries a "Juillet 2026"-style label.
+ */
+export const groupSpendingsByMonth = (items: SpendingItem[]): SpendingMonthGroup[] => {
+  const groups: SpendingMonthGroup[] = [];
+  const byKey = new Map<string, SpendingMonthGroup>();
+
+  for (const item of items) {
+    const date = parseISO(item.date);
+    const key = format(date, "yyyy-MM");
+    let group = byKey.get(key);
+    if (!group) {
+      group = { key, label: capitalize(format(date, "MMMM yyyy", { locale: fr })), items: [] };
+      byKey.set(key, group);
+      groups.push(group);
+    }
+    group.items.push(item);
+  }
+
+  return groups;
+};

--- a/front/src/components/spendings/search/searchParams.ts
+++ b/front/src/components/spendings/search/searchParams.ts
@@ -1,0 +1,18 @@
+import { parseAsBoolean, parseAsInteger, parseAsString } from "nuqs";
+
+/**
+ * URL-state shape for the Dashboard spending-search modal (COS-114). Keeping the
+ * open flag + query + year in the URL is what lets browser Back reopen the modal
+ * where the user left it. Shared by the trigger (which opens it) and the modal
+ * (which reads/updates it) so both stay in sync.
+ */
+export const spendingSearchParsers = {
+  search: parseAsBoolean.withDefault(false),
+  q: parseAsString.withDefault(""),
+  year: parseAsInteger,
+};
+
+// Default to replacing the entry — typing / filtering must not spam history — and
+// drop each param at its default so a closed modal leaves a clean `/dashboard` URL.
+// Opening overrides this with `{ history: "push" }` so Back can return to it.
+export const spendingSearchUrlOptions = { history: "replace", clearOnDefault: true } as const;

--- a/front/src/components/spendings/search/useDebouncedValue.ts
+++ b/front/src/components/spendings/search/useDebouncedValue.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns `value` delayed by `delayMs`, resetting the timer on every change — so
+ * a fast-typed search box only propagates once the user pauses. Used by the
+ * whole-history spending search (COS-114) to avoid a request per keystroke.
+ */
+const useDebouncedValue = <T>(value: T, delayMs: number): T => {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+};
+
+export default useDebouncedValue;

--- a/front/src/components/spendings/services/useSpendingSearch.ts
+++ b/front/src/components/spendings/services/useSpendingSearch.ts
@@ -1,0 +1,61 @@
+import { useAuth } from "@auth/context/AuthContext";
+import { QUERY_KEYS, QUERY_OPTIONS, SEARCH_MIN_LENGTH } from "@components/spendings/config/constants";
+import useRequestHelper from "@helpers/useRequestHelper";
+import { SpendingSearchPageSchema } from "@src/schemas/spendings";
+import { useInfiniteQuery } from "react-query";
+
+/**
+ * Whole-history spending search (COS-114), keyset-paginated. Hits
+ * `GET /spendings/search` once the (trimmed) query reaches the minimum length OR
+ * a year filter is set, then follows `nextCursor` page by page as the caller asks
+ * for more. `keepPreviousData` avoids the list flashing empty between keystrokes.
+ * Debouncing is the caller's job.
+ */
+const useSpendingSearch = (query: string, year: number | null) => {
+  const { privateRequest } = useRequestHelper();
+  const { user } = useAuth();
+  const userID = user?.id;
+  const trimmed = query.trim();
+  const enabled = !!userID && (trimmed.length >= SEARCH_MIN_LENGTH || year !== null);
+
+  const fetchPage = async ({ pageParam }: { pageParam?: string }) => {
+    const yearParam = year !== null ? `&year=${year}` : "";
+    const cursorParam = pageParam ? `&cursor=${encodeURIComponent(pageParam)}` : "";
+    const response = await privateRequest(
+      `/spendings/search?q=${encodeURIComponent(trimmed)}${yearParam}${cursorParam}`,
+    );
+    return SpendingSearchPageSchema.parse(response.data);
+  };
+
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage, error } = useInfiniteQuery(
+    [QUERY_KEYS.SPENDINGS_SEARCH, trimmed, year],
+    fetchPage,
+    {
+      enabled,
+      retry: false,
+      keepPreviousData: true,
+      getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+      ...QUERY_OPTIONS,
+      // Keep the loaded pages around longer than the default 5 min so returning
+      // to the modal (browser Back) after a detour restores the full list, not
+      // just the first page (COS-114).
+      cacheTime: 30 * 60 * 1000,
+    },
+  );
+
+  const results = data?.pages.flatMap((page) => page.items) ?? [];
+  const total = data?.pages[0]?.total ?? results.length;
+
+  return {
+    results,
+    total,
+    isSearching: enabled && isLoading,
+    isFetchingNextPage,
+    hasNextPage: !!hasNextPage,
+    fetchNextPage,
+    hasQuery: enabled,
+    error,
+  };
+};
+
+export default useSpendingSearch;

--- a/front/src/components/spendings/services/useSpendingYears.ts
+++ b/front/src/components/spendings/services/useSpendingYears.ts
@@ -1,0 +1,31 @@
+import { useAuth } from "@auth/context/AuthContext";
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@helpers/useRequestHelper";
+import { SpendingYearsSchema } from "@src/schemas/spendings";
+import { useQuery } from "react-query";
+
+/**
+ * Years the user has spendings in (newest first), backing the search modal's year
+ * filter (COS-114). Independent of the search term so the chips stay stable while
+ * filtering.
+ */
+const useSpendingYears = () => {
+  const { privateRequest } = useRequestHelper();
+  const { user } = useAuth();
+  const userID = user?.id;
+
+  const fetchYears = async () => {
+    const response = await privateRequest("/spendings/years");
+    return SpendingYearsSchema.parse(response.data);
+  };
+
+  const { data } = useQuery([QUERY_KEYS.SPENDINGS_YEARS], fetchYears, {
+    enabled: !!userID,
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return data ?? [];
+};
+
+export default useSpendingYears;

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -83,6 +83,9 @@ const useSpendings = () => {
     await queryClient.invalidateQueries([QUERY_KEYS.CATEGORY_STATS]);
     await queryClient.invalidateQueries([QUERY_KEYS.INITIAL_AMOUNT, monthBeginning]);
     await queryClient.invalidateQueries([QUERY_KEYS.CHARTS, monthBeginning]);
+    // Whole-history search results (COS-114) can include the mutated row — refresh
+    // them too. Inactive when the search modal is closed, so this is a no-op then.
+    await queryClient.invalidateQueries([QUERY_KEYS.SPENDINGS_SEARCH]);
   };
 
   const deleteSpendingService = async (spending: DeletableSpending) => {

--- a/front/src/schemas/spendings.ts
+++ b/front/src/schemas/spendings.ts
@@ -31,6 +31,19 @@ export const SpendingItemSchema = z.object({
 export const SpendingListSchema = z.array(SpendingItemSchema);
 export type SpendingItem = z.infer<typeof SpendingItemSchema>;
 
+// Whole-history search page (COS-114): one keyset page of matches, the cursor to
+// fetch the next page (null at the end), and the unbounded total — sent only on
+// the first page, so the UI can say "N résultats" without recounting every page.
+export const SpendingSearchPageSchema = z.object({
+  items: SpendingListSchema,
+  nextCursor: z.string().nullable(),
+  total: z.number().optional(),
+});
+export type SpendingSearchPage = z.infer<typeof SpendingSearchPageSchema>;
+
+// Years the user has spendings in (newest first) — the search modal's year filter.
+export const SpendingYearsSchema = z.array(z.number());
+
 export const RecurringItemSchema = z.object({
   ID: z.string(),
   amount: numberLikeSchema,

--- a/front/src/text/index.ts
+++ b/front/src/text/index.ts
@@ -5,5 +5,6 @@ export { default as dashboard } from "@text/dashboard";
 export { default as exceptionals } from "@text/exceptionals";
 export { default as login } from "@text/login";
 export { default as navBar } from "@text/navBar";
+export { default as spendingSearch } from "@text/spendingSearch";
 export { default as spendings } from "@text/spendings";
 export { default as statistics } from "@text/statistics";

--- a/front/src/text/spendingSearch.ts
+++ b/front/src/text/spendingSearch.ts
@@ -1,0 +1,15 @@
+const spendingSearch = {
+  trigger: "Rechercher une dépense",
+  shortcutHint: "⌘K",
+  title: "Rechercher une dépense",
+  placeholder: "Rechercher une dépense…",
+  hint: "Saisir au moins 2 caractères ou choisir une année",
+  yearsAll: "Toutes",
+  loading: "Recherche…",
+  loadingMore: "Chargement…",
+  error: "La recherche a échoué. Réessayer.",
+  noResults: "Aucune dépense ne correspond",
+  resultsCount: (n: number) => `${n} résultat${n > 1 ? "s" : ""}`,
+};
+
+export default spendingSearch;

--- a/nest-api/src/spendings/dto/spendings-search-query.dto.ts
+++ b/nest-api/src/spendings/dto/spendings-search-query.dto.ts
@@ -1,0 +1,17 @@
+import { IsOptional, IsString } from "class-validator";
+
+export class SpendingsSearchQueryDto {
+  @IsString()
+  q: string;
+
+  // Keyset cursor = the ID of the last row of the previous page. A string param,
+  // so it needs no numeric transform (the global ValidationPipe has none).
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+
+  // Optional year filter (as a string; parsed and validated in the service).
+  @IsOptional()
+  @IsString()
+  year?: string;
+}

--- a/nest-api/src/spendings/spendings.controller.ts
+++ b/nest-api/src/spendings/spendings.controller.ts
@@ -20,6 +20,7 @@ import { CreateSpendingDto } from "@spendings/dto/create-spending.dto";
 import { UpdateSpendingDto } from "@spendings/dto/update-spending.dto";
 import { DeleteInvoiceImageDto } from "@spendings/dto/delete-invoice-image.dto";
 import { SpendingsQueryDto } from "@spendings/dto/spendings-query.dto";
+import { SpendingsSearchQueryDto } from "@spendings/dto/spendings-search-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 import { invoiceUploadOptions } from "@spendings/upload/upload.config";
@@ -38,6 +39,16 @@ export class SpendingsController {
   @Post()
   async createSpending(@Body() dto: CreateSpendingDto, @GetUserId() userID: string) {
     return this.spendingsService.createSpending(dto, userID);
+  }
+
+  @Get("search")
+  async searchSpendings(@Query() query: SpendingsSearchQueryDto, @GetUserId() userID: string) {
+    return this.spendingsService.searchSpendings(query.q, userID, query.cursor, query.year);
+  }
+
+  @Get("years")
+  async getSpendingYears(@GetUserId() userID: string) {
+    return this.spendingsService.getSpendingYears(userID);
   }
 
   @Get("charts")

--- a/nest-api/src/spendings/spendings.service.spec.ts
+++ b/nest-api/src/spendings/spendings.service.spec.ts
@@ -1,0 +1,263 @@
+import { SpendingsService } from "./spendings.service";
+
+/**
+ * Unit tests for SpendingsService.searchSpendings — the whole-history, keyset-
+ * paginated text search backing the Dashboard "Rechercher une dépense" modal
+ * (COS-114). Prisma is mocked, so these assert the query shape and the JS
+ * transformation without touching the DB.
+ */
+describe("SpendingsService.searchSpendings", () => {
+  const makeService = (findManyResult: unknown[], countResult = 0) => {
+    const findMany = jest.fn().mockResolvedValue(findManyResult);
+    const count = jest.fn().mockResolvedValue(countResult);
+    // Only spendings.findMany / count are exercised; the other deps are unused.
+    const prisma = { spendings: { findMany, count } } as unknown as never;
+    const service = new SpendingsService(prisma, {} as never, {} as never);
+    return { service, findMany, count };
+  };
+
+  const makeRow = (ID: string) => ({
+    ID,
+    userID: "user-1",
+    label: `row-${ID}`,
+    amount: 1,
+    date: new Date("2026-01-01"),
+    category: null,
+  });
+
+  it("returns empty without hitting the DB when the trimmed query is shorter than 2 chars", async () => {
+    const { service, findMany, count } = makeService([]);
+
+    await expect(service.searchSpendings(" a ", "user-1")).resolves.toEqual({
+      items: [],
+      nextCursor: null,
+      total: 0,
+    });
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(count).not.toHaveBeenCalled();
+  });
+
+  it("fetches the first page: label OR category name, scoped to the user, newest-first with ID tiebreaker, no cursor", async () => {
+    const { service, findMany, count } = makeService([], 12);
+
+    const result = await service.searchSpendings("carre", "user-1");
+
+    const where = {
+      userID: "user-1",
+      OR: [{ label: { contains: "carre" } }, { category: { is: { name: { contains: "carre" } } } }],
+    };
+    expect(findMany).toHaveBeenCalledWith({
+      where,
+      orderBy: [{ date: "desc" }, { ID: "desc" }],
+      include: { category: true },
+      // Over-fetch one row to detect a further page without a spurious empty call.
+      take: 51,
+    });
+    // First page has no cursor / skip.
+    expect(findMany.mock.calls[0][0]).not.toHaveProperty("cursor");
+    expect(findMany.mock.calls[0][0]).not.toHaveProperty("skip");
+    // The unbounded total is counted once, on the first page.
+    expect(count).toHaveBeenCalledWith({ where });
+    expect(result.total).toBe(12);
+  });
+
+  it("continues from a cursor and does NOT recount the total on later pages", async () => {
+    const { service, findMany, count } = makeService([], 0);
+
+    const result = await service.searchSpendings("carre", "user-1", "cursor-id");
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 51, cursor: { ID: "cursor-id" }, skip: 1 }),
+    );
+    expect(count).not.toHaveBeenCalled();
+    expect(result.total).toBeUndefined();
+  });
+
+  it("returns one page and a nextCursor when the over-fetch row shows more remain", async () => {
+    // 51 rows come back (page size + 1 probe) → page is 50 rows, more follow.
+    const overFetched = Array.from({ length: 51 }, (_, i) => makeRow(`s${i}`));
+    const { service } = makeService(overFetched, 120);
+
+    const result = await service.searchSpendings("carre", "user-1");
+
+    expect(result.items).toHaveLength(50);
+    expect(result.items.at(-1)?.ID).toBe("s49");
+    expect(result.nextCursor).toBe("s49");
+  });
+
+  it("sets nextCursor to null when the over-fetch row is absent (end of results)", async () => {
+    // Exactly page size → no extra row → last page, no spurious next fetch.
+    const lastPage = Array.from({ length: 50 }, (_, i) => makeRow(`s${i}`));
+    const { service } = makeService(lastPage, 50);
+
+    const result = await service.searchSpendings("carre", "user-1");
+
+    expect(result.items).toHaveLength(50);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("trims the query before matching", async () => {
+    const { service, findMany } = makeService([]);
+
+    await service.searchSpendings("  carrefour  ", "user-1");
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [{ label: { contains: "carrefour" } }, { category: { is: { name: { contains: "carrefour" } } } }],
+        }),
+      }),
+    );
+  });
+
+  it("escapes LIKE wildcards so % and _ match literally", async () => {
+    const { service, findMany } = makeService([]);
+
+    await service.searchSpendings("100%_x", "user-1");
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { label: { contains: "100\\%\\_x" } },
+            { category: { is: { name: { contains: "100\\%\\_x" } } } },
+          ],
+        }),
+      }),
+    );
+  });
+
+  it("adds a half-open year date range to the where clause when a year is given", async () => {
+    const { service, findMany } = makeService([]);
+
+    await service.searchSpendings("carre", "user-1", undefined, "2025");
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          date: {
+            gte: new Date("2025-01-01T00:00:00.000Z"),
+            lt: new Date("2026-01-01T00:00:00.000Z"),
+          },
+        }),
+      }),
+    );
+  });
+
+  it("allows a year-only query (short/empty text) to still search, without a text OR clause", async () => {
+    const { service, findMany } = makeService([]);
+
+    await service.searchSpendings("", "user-1", undefined, "2025");
+
+    expect(findMany).toHaveBeenCalled();
+    expect(findMany.mock.calls[0][0].where).not.toHaveProperty("OR");
+    expect(findMany.mock.calls[0][0].where).toHaveProperty("date");
+  });
+
+  it("ignores a non-numeric year and, with too-short text, searches nothing", async () => {
+    const { service, findMany } = makeService([]);
+
+    const result = await service.searchSpendings("a", "user-1", undefined, "abc");
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ items: [], nextCursor: null, total: 0 });
+  });
+
+  it("flattens the category to name/color", async () => {
+    const row = {
+      ID: "s1",
+      userID: "user-1",
+      label: "Carrefour Market",
+      amount: 42.8,
+      date: new Date("2026-05-03"),
+      category: { userID: "user-1", name: "Courses", color: "#0F6E56" },
+    };
+    const { service } = makeService([row], 1);
+
+    const result = await service.searchSpendings("carre", "user-1");
+
+    expect(result.items[0]).toMatchObject({
+      ID: "s1",
+      label: "Carrefour Market",
+      category: "Courses",
+      categoryColor: "#0F6E56",
+    });
+    // The nested relation object is flattened away, not leaked.
+    expect(result.items[0]).not.toHaveProperty("category.name");
+  });
+
+  it("nulls a category that belongs to another user (defensive, mirrors getSpendings)", async () => {
+    const row = {
+      ID: "s1",
+      userID: "user-1",
+      label: "Secret",
+      amount: 1,
+      date: new Date("2026-01-01"),
+      category: { userID: "other-user", name: "Secret", color: "#000000" },
+    };
+    const { service } = makeService([row], 1);
+
+    const result = await service.searchSpendings("sec", "user-1");
+
+    expect(result.items[0].category).toBeNull();
+    expect(result.items[0].categoryColor).toBeNull();
+  });
+
+  it("keeps a shared (userID null) category", async () => {
+    const row = {
+      ID: "s1",
+      userID: "user-1",
+      label: "Loyer",
+      amount: 500,
+      date: new Date("2026-01-01"),
+      category: { userID: null, name: "Logement", color: "#185FA5" },
+    };
+    const { service } = makeService([row], 1);
+
+    const result = await service.searchSpendings("loy", "user-1");
+
+    expect(result.items[0].category).toBe("Logement");
+    expect(result.items[0].categoryColor).toBe("#185FA5");
+  });
+});
+
+describe("SpendingsService.getSpendingYears", () => {
+  const makeYearsService = (aggregateResult: unknown) => {
+    const aggregate = jest.fn().mockResolvedValue(aggregateResult);
+    const prisma = { spendings: { aggregate } } as unknown as never;
+    const service = new SpendingsService(prisma, {} as never, {} as never);
+    return { service, aggregate };
+  };
+
+  it("returns the years spanned by the data, newest first, scoped to the user", async () => {
+    const { service, aggregate } = makeYearsService({
+      _min: { date: new Date("2023-03-10") },
+      _max: { date: new Date("2026-07-01") },
+    });
+
+    const years = await service.getSpendingYears("user-1");
+
+    expect(aggregate).toHaveBeenCalledWith({
+      where: { userID: "user-1" },
+      _min: { date: true },
+      _max: { date: true },
+    });
+    expect(years).toEqual([2026, 2025, 2024, 2023]);
+  });
+
+  it("returns a single year when min and max fall in the same year", async () => {
+    const { service } = makeYearsService({
+      _min: { date: new Date("2026-02-01") },
+      _max: { date: new Date("2026-11-30") },
+    });
+
+    await expect(service.getSpendingYears("user-1")).resolves.toEqual([2026]);
+  });
+
+  it("returns an empty array when the user has no spendings", async () => {
+    const { service } = makeYearsService({ _min: { date: null }, _max: { date: null } });
+
+    await expect(service.getSpendingYears("user-1")).resolves.toEqual([]);
+  });
+});

--- a/nest-api/src/spendings/spendings.service.ts
+++ b/nest-api/src/spendings/spendings.service.ts
@@ -19,6 +19,11 @@ const MIME_BY_EXT: Record<string, string> = {
   gif: "image/gif",
 };
 
+// Whole-history search (COS-114): require a minimal query so a stray keystroke
+// can't scan the entire table, and stream results a page at a time.
+const MIN_SEARCH_LENGTH = 2;
+const SEARCH_PAGE_SIZE = 50;
+
 @Injectable()
 export class SpendingsService {
   private readonly logger = new Logger(SpendingsService.name);
@@ -241,6 +246,97 @@ export class SpendingsService {
       category: category && (category.userID === userID || category.userID === null) ? category.name : null,
       categoryColor: category && (category.userID === userID || category.userID === null) ? category.color : null,
     }));
+  }
+
+  // Whole-history text search over the user's spendings (COS-114). Matches the
+  // label OR the (accessible) category name, newest first, capped. Returns the
+  // capped page plus the unbounded total so the UI can say "N résultats". The
+  // category is flattened to name/color exactly like getSpendings, and a category
+  // owned by another user is nulled out defensively.
+  async searchSpendings(query: string, userID: string, cursor?: string, year?: string) {
+    const q = query.trim();
+    const hasText = q.length >= MIN_SEARCH_LENGTH;
+    const yearNum = year ? Number(year) : Number.NaN;
+    const hasYear = Number.isInteger(yearNum);
+
+    // Need at least a usable term OR a year filter, else there is nothing to search.
+    if (!hasText && !hasYear) {
+      return { items: [], nextCursor: null, total: 0 };
+    }
+
+    // Escape LIKE metacharacters so a literal % or _ in the term (e.g. "100%",
+    // "T_Mobile") matches literally instead of acting as a wildcard. MySQL's
+    // default LIKE escape is backslash; the single pass escapes the backslash too.
+    const escaped = q.replace(/[\\%_]/g, "\\$&");
+
+    const where = {
+      userID,
+      ...(hasText
+        ? { OR: [{ label: { contains: escaped } }, { category: { is: { name: { contains: escaped } } } }] }
+        : {}),
+      // Year filter: half-open [year-01-01, next-year-01-01) covers the whole year
+      // regardless of any time component on the date column.
+      ...(hasYear
+        ? {
+            date: {
+              gte: new Date(`${yearNum}-01-01T00:00:00.000Z`),
+              lt: new Date(`${yearNum + 1}-01-01T00:00:00.000Z`),
+            },
+          }
+        : {}),
+    };
+
+    // Keyset (cursor) pagination: a common term (e.g. a category name) can match
+    // thousands of rows, so results stream a page at a time as the user scrolls,
+    // rather than capping (which would hide older months) or shipping everything.
+    // Ordered newest-first with the unique ID as tiebreaker so the cursor is
+    // stable. We over-fetch one row to know whether a further page exists without
+    // a spurious empty request at exact page-size multiples. `total` is counted
+    // once, on the first page only (COS-114).
+    const rows = await this.prisma.spendings.findMany({
+      where,
+      orderBy: [{ date: "desc" }, { ID: "desc" }],
+      include: { category: true },
+      take: SEARCH_PAGE_SIZE + 1,
+      ...(cursor ? { cursor: { ID: cursor }, skip: 1 } : {}),
+    });
+
+    const hasMore = rows.length > SEARCH_PAGE_SIZE;
+    const pageRows = hasMore ? rows.slice(0, SEARCH_PAGE_SIZE) : rows;
+
+    const items = pageRows.map(({ category, ...spending }) => ({
+      ...spending,
+      category: category && (category.userID === userID || category.userID === null) ? category.name : null,
+      categoryColor: category && (category.userID === userID || category.userID === null) ? category.color : null,
+    }));
+
+    const nextCursor = hasMore ? items[items.length - 1].ID : null;
+    const total = cursor ? undefined : await this.prisma.spendings.count({ where });
+
+    return { items, nextCursor, total };
+  }
+
+  // Years the user has spendings in, newest first — powers the search modal's
+  // year filter (COS-114). Derived from the min/max spending date, so a
+  // continuously-used account yields a contiguous range.
+  async getSpendingYears(userID: string): Promise<number[]> {
+    const range = await this.prisma.spendings.aggregate({
+      where: { userID },
+      _min: { date: true },
+      _max: { date: true },
+    });
+
+    const min = range._min.date;
+    const max = range._max.date;
+    if (!min || !max) {
+      return [];
+    }
+
+    const years: number[] = [];
+    for (let y = max.getUTCFullYear(); y >= min.getUTCFullYear(); y--) {
+      years.push(y);
+    }
+    return years;
   }
 
   async getSpendingsCharts(from: string, to: string, userID: string) {


### PR DESCRIPTION
Add a whole-history spending search reachable from the Dashboard, distinct from the week-scoped Dépenses filter.

Back (nest-api):
- GET /spendings/search?q=&cursor=&year= — keyset pagination (page 50, newest-first with ID tiebreaker), matches label OR category name with LIKE wildcards escaped, optional year range, total counted once.
- GET /spendings/years — years spanned by the user's data for the filter.
- Service unit tests.

Front:
- SpendingSearchTrigger in the NavBar (Dashboard only): search field on desktop with a ⌘K shortcut, magnifier on mobile.
- SpendingSearchModal: debounced search, month-grouped results, infinite scroll, year-chip filter (year-only browsing too), empty/loading/error states. Clicking a result navigates to the Dépenses week.
- Modal state (open/query/year) is URL-driven via nuqs so browser Back reopens it with query/year/scroll restored; NuqsAdapter in providers.
- FR copy in @text/spendingSearch.