### PR TITLE
feat(spendings): move search to Dépenses (COS-118)

### DIFF
--- a/front/src/components/dashboard/DashboardPageClient.tsx
+++ b/front/src/components/dashboard/DashboardPageClient.tsx
@@ -3,44 +3,56 @@
 import DashboardView from "@components/dashboard/DashboardView";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import useGlobalStore from "@components/shared/globalStore";
+import { isValidMonthParam, MONTH_QUERY_PARAM, parseMonthParam } from "@helpers/dateRoute";
 import { endOfMonth } from "date-fns";
 import addDays from "date-fns/addDays";
 import eachDayOfInterval from "date-fns/eachDayOfInterval";
 import startOfMonth from "date-fns/startOfMonth";
-import { useEffect } from "react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useEffect, useLayoutEffect, useState } from "react";
 
 import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
 
+// Sync the store before paint on the client so stepping months / Back never flash
+// a stale month; a plain effect on the server (layout effects don't run in SSR).
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
 /**
- * Dashboard (monthly) page. Uses a MONTH selector — not the weekly date-picker
- * (hidden here). Normalizes the shared date store to whole-month bounds so the
- * monthly hooks read the right period.
+ * Dashboard (monthly) page. The viewed month is the URL's ?month=YYYY-MM param
+ * (single source of truth), defaulting to the current month resolved CLIENT-side
+ * (COS-73) — so /dashboard always shows the current month and is never polluted
+ * by the week a previous Dépenses visit left in the shared store (COS-118). We
+ * sync that store (the monthly hooks read from/to) and only render once it
+ * reflects the URL month, so the hooks never fire against a stale week.
  */
 export default function DashboardPageClient() {
   const { setIsCalendarVisible } = useGlobalStore();
   const { from, to, setFrom, setTo, setRange } = useDatePickerWrapperStore();
+  const [monthParam] = useQueryState(MONTH_QUERY_PARAM, parseAsString);
+  const [currentMonthStart] = useState(() => startOfMonth(new Date()));
 
   useEffect(() => {
     setIsCalendarVisible(false);
   }, [setIsCalendarVisible]);
 
-  useEffect(() => {
-    const alreadyMonth =
-      from && to && from.getTime() === startOfMonth(from).getTime() && to.getTime() === endOfMonth(from).getTime();
-    if (alreadyMonth) return;
-    const base = from ?? new Date();
-    const start = startOfMonth(base);
-    const end = endOfMonth(base);
+  const param = monthParam ?? "";
+  const targetStart = isValidMonthParam(param) ? startOfMonth(parseMonthParam(param)) : currentMonthStart;
+  const targetEnd = endOfMonth(targetStart);
+  const storeMatchesTarget = from?.getTime() === targetStart.getTime() && to?.getTime() === targetEnd.getTime();
+
+  useIsomorphicLayoutEffect(() => {
+    if (storeMatchesTarget) return;
+    const start = isValidMonthParam(param) ? startOfMonth(parseMonthParam(param)) : currentMonthStart;
+    const end = endOfMonth(start);
     setFrom(start);
     setTo(end);
     setRange(eachDayOfInterval({ start, end: addDays(start, 6) }));
-  }, [from, to, setFrom, setTo, setRange]);
+  }, [storeMatchesTarget, param, currentMonthStart, setFrom, setTo, setRange]);
 
-  const month: MonthRange | null = from && to ? { start: startOfMonth(from), end: endOfMonth(to) } : null;
-
-  if (!month) {
+  if (!storeMatchesTarget) {
     return null;
   }
 
+  const month: MonthRange = { start: targetStart, end: targetEnd };
   return <DashboardView month={month} />;
 }

--- a/front/src/components/dashboard/MonthSelector.tsx
+++ b/front/src/components/dashboard/MonthSelector.tsx
@@ -1,34 +1,42 @@
 "use client";
 
-import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { IconButton } from "@components/shared/IconButton";
+import { formatMonthParam, isValidMonthParam, MONTH_QUERY_PARAM, parseMonthParam } from "@helpers/dateRoute";
 import dashboardText from "@text/dashboard";
-import addDays from "date-fns/addDays";
 import addMonths from "date-fns/addMonths";
-import eachDayOfInterval from "date-fns/eachDayOfInterval";
-import endOfMonth from "date-fns/endOfMonth";
 import format from "date-fns/format";
 import fr from "date-fns/locale/fr";
 import startOfMonth from "date-fns/startOfMonth";
 import { Calendar, ChevronLeft, ChevronRight } from "lucide-react";
+import { parseAsString, useQueryState } from "nuqs";
+import { useState, useSyncExternalStore } from "react";
 
 /**
- * Month period selector shown in the app header on the Dashboard (mirrors the
- * `.period` control in the mockup). Drives the shared date store to whole-month
- * bounds, which every monthly hook (useDashboard / useWeeklyStats / useCharts /
- * useReccurings) reads from.
+ * Month period selector shown in the app header on the Dashboard. The month is
+ * the URL's ?month= param (single source of truth, COS-118); DashboardPageClient
+ * syncs the shared store from it. Landing on the current month clears the param,
+ * keeping /dashboard clean.
  */
 const MonthSelector = () => {
-  const { from, setFrom, setTo, setRange } = useDatePickerWrapperStore();
-  const month = from ? startOfMonth(from) : startOfMonth(new Date());
+  const [monthParam, setMonthParam] = useQueryState(MONTH_QUERY_PARAM, parseAsString);
+  const isClientHydrated = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false,
+  );
+  const [currentMonthStart] = useState(() => startOfMonth(new Date()));
 
-  const applyMonth = (target: Date) => {
-    const start = startOfMonth(target);
-    const end = endOfMonth(target);
-    setFrom(start);
-    setTo(end);
-    // keep a valid 7-day range around for any hook that still reads it
-    setRange(eachDayOfInterval({ start, end: addDays(start, 6) }));
+  const paramMonth = isValidMonthParam(monthParam ?? "") ? startOfMonth(parseMonthParam(monthParam ?? "")) : null;
+  // Fall back to the current month only AFTER hydration: `new Date()` must never
+  // decide the rendered month on the server (server UTC ≠ browser tz), or a month
+  // boundary would flash the wrong month and throw a hydration mismatch (COS-73).
+  // Until then the label is blank (the control keeps its fixed width).
+  const month = paramMonth ?? (isClientHydrated ? currentMonthStart : null);
+
+  const stepMonth = (delta: number) => {
+    if (!month) return;
+    const start = startOfMonth(addMonths(month, delta));
+    setMonthParam(start.getTime() === currentMonthStart.getTime() ? null : formatMonthParam(start));
   };
 
   return (
@@ -38,7 +46,7 @@ const MonthSelector = () => {
         <IconButton
           variant="ghost"
           size={5}
-          onClick={() => applyMonth(addMonths(month, -1))}
+          onClick={() => stepMonth(-1)}
           aria-label={dashboardText.monthSelector.prevMonth}
         >
           <ChevronLeft />
@@ -46,12 +54,12 @@ const MonthSelector = () => {
         {/* fixed width (fits the longest month, "septembre") so the control
             never resizes as the month changes */}
         <span className="num w-[116px] text-center capitalize tracking-normal">
-          {format(month, "MMMM yyyy", { locale: fr })}
+          {month ? format(month, "MMMM yyyy", { locale: fr }) : ""}
         </span>
         <IconButton
           variant="ghost"
           size={5}
-          onClick={() => applyMonth(addMonths(month, 1))}
+          onClick={() => stepMonth(1)}
           aria-label={dashboardText.monthSelector.nextMonth}
         >
           <ChevronRight />

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -9,13 +9,24 @@ import { ROUTES } from "@components/shared/config/constants";
 import useGlobalStore from "@components/shared/globalStore";
 import { IconButton } from "@components/shared/IconButton";
 import UserMenu from "@components/shared/navBar/userMenu/UserMenu";
-import SpendingSearchTrigger from "@components/spendings/search/SpendingSearchTrigger";
-import { buildSpendingsPath, getTodayIsoDate, isValidIsoDate, SPENDINGS_PATH } from "@helpers/dateRoute";
+import {
+  buildDashboardPath,
+  buildSpendingsPath,
+  formatMonthParam,
+  getTodayIsoDate,
+  isValidIsoDate,
+  isValidMonthParam,
+  MONTH_QUERY_PARAM,
+  SPENDINGS_PATH,
+} from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
 import text from "@text/navBar";
+import parseISO from "date-fns/parseISO";
+import startOfMonth from "date-fns/startOfMonth";
 import { BarChart3, LayoutDashboard, Menu, Receipt, Sparkles, Tag, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import { parseAsString, useQueryState } from "nuqs";
 import { useEffect, useState, useSyncExternalStore } from "react";
 
 import type { LucideIcon } from "lucide-react";
@@ -53,6 +64,7 @@ const NavBar = () => {
   const { selectedDateIso, setScrollToDayIso } = useDatePickerWrapperStore();
   const pathname = usePathname();
   const router = useRouter();
+  const [monthParam, setMonthParam] = useQueryState(MONTH_QUERY_PARAM, parseAsString);
   const isClientHydrated = useSyncExternalStore(
     () => () => {},
     () => true,
@@ -80,11 +92,38 @@ const NavBar = () => {
   // month selector; every other private page keeps the weekly date-picker.
   const isDashboard = isActiveRoute(ROUTES.dashboard.path);
 
+  // "Current month" shortcut on the Dashboard: always shown, but disabled while
+  // already on the current month (COS-118) — it stays put and greys out instead
+  // of disappearing. Client-only (isClientHydrated) so `new Date()` never runs on
+  // the server (COS-73) and can't cause a hydration mismatch; before hydration it
+  // renders disabled, matching SSR.
+  const currentMonthDisabled =
+    !isClientHydrated ||
+    !isValidMonthParam(monthParam ?? "") ||
+    (monthParam ?? "") === formatMonthParam(startOfMonth(new Date()));
+
+  const goToCurrentMonth = () => setMonthParam(null);
+
+  const currentMonthButtonClass = cn(
+    PERIOD_BTN,
+    "disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:text-ink-2",
+  );
+
   const hrefFor = (route: NavRoute): string => {
     const storedDate = selectedDateIso ?? undefined;
-    return route.path === ROUTES.spendings.path && isClientHydrated && isValidIsoDate(storedDate)
-      ? buildSpendingsPath(storedDate)
-      : route.path;
+    if (route.path === ROUTES.spendings.path && isClientHydrated && isValidIsoDate(storedDate)) {
+      return buildSpendingsPath(storedDate);
+    }
+    // The Dashboard link carries the month of the currently selected week, so
+    // jumping from a past week lands on that month's dashboard (COS-118). The
+    // current month links to a clean /dashboard.
+    if (route.path === ROUTES.dashboard.path && isClientHydrated && isValidIsoDate(storedDate)) {
+      const weekMonth = formatMonthParam(startOfMonth(parseISO(storedDate)));
+      return weekMonth === formatMonthParam(startOfMonth(new Date()))
+        ? ROUTES.dashboard.path
+        : buildDashboardPath(weekMonth);
+    }
+    return route.path;
   };
 
   const handleGoToToday = () => {
@@ -144,12 +183,17 @@ const NavBar = () => {
         </nav>
 
         <div className="ml-auto flex items-center gap-2.5">
-          {/* Whole-history spending search (COS-114) — Dashboard only, left of the
-              month selector; on mobile it collapses to a magnifier icon. */}
-          {isDashboard && <SpendingSearchTrigger />}
           {isDashboard ? (
-            <div className="hidden items-center md:flex">
+            <div className="hidden items-center gap-2 md:flex">
               <MonthSelector />
+              <button
+                type="button"
+                onClick={goToCurrentMonth}
+                disabled={currentMonthDisabled}
+                className={currentMonthButtonClass}
+              >
+                {text.currentMonth}
+              </button>
             </div>
           ) : (
             isCalendarVisible && (
@@ -169,8 +213,16 @@ const NavBar = () => {
         </div>
 
         {isDashboard ? (
-          <div className="w-full md:hidden">
+          <div className="flex w-full items-center gap-2 md:hidden">
             <MonthSelector />
+            <button
+              type="button"
+              onClick={goToCurrentMonth}
+              disabled={currentMonthDisabled}
+              className={currentMonthButtonClass}
+            >
+              {text.currentMonth}
+            </button>
           </div>
         ) : (
           isCalendarVisible && (

--- a/front/src/components/spendings/search/SpendingSearchTrigger.tsx
+++ b/front/src/components/spendings/search/SpendingSearchTrigger.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { IconButton } from "@components/shared/IconButton";
 import SpendingSearchModal from "@components/spendings/search/SpendingSearchModal";
 import { spendingSearchParsers, spendingSearchUrlOptions } from "@components/spendings/search/searchParams";
 import spendingSearch from "@text/spendingSearch";
@@ -9,11 +8,13 @@ import { useQueryStates } from "nuqs";
 import { useEffect } from "react";
 
 /**
- * Dashboard entry point for the whole-history spending search (COS-114). Rendered
- * in the NavBar right cluster, gated by `isDashboard`. Opening writes the modal's
- * open flag to the URL (a pushed history entry) so browser Back can restore it;
- * the modal itself reads that state. Primary access is the click target (field on
- * desktop, magnifier on mobile); ⌘K / Ctrl+K is an optional desktop shortcut.
+ * Whole-history spending search entry point (COS-114/COS-118), rendered in the
+ * Dépenses toolbar next to the week filter. Opening writes the modal's open flag
+ * to the URL (a pushed history entry) so browser Back can restore it; the modal
+ * itself reads that state. Two presentations of the same click target: a compact
+ * labelled button with a ⌘K hint on desktop (md+), and a full-width field styled
+ * like the week filter on mobile — so it reads as a search field, not a stray
+ * icon. ⌘K / Ctrl+K is an optional desktop shortcut.
  */
 const SpendingSearchTrigger = () => {
   const [, setSearchState] = useQueryStates(spendingSearchParsers, spendingSearchUrlOptions);
@@ -45,15 +46,14 @@ const SpendingSearchTrigger = () => {
         </kbd>
       </button>
 
-      <IconButton
-        variant="bordered"
-        size={9}
+      <button
+        type="button"
         onClick={openSearch}
-        aria-label={spendingSearch.trigger}
-        className="md:hidden"
+        className="relative flex w-full items-center rounded-md border border-line bg-surface-elev py-2 pl-8 pr-3 text-left text-sm text-ink-4 transition-colors hover:text-ink md:hidden"
       >
-        <Search />
-      </IconButton>
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-ink-4" />
+        {spendingSearch.trigger}
+      </button>
 
       <SpendingSearchModal />
     </>

--- a/front/src/components/spendings/view/SpendingCategoryFilter.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryFilter.tsx
@@ -2,8 +2,11 @@
 
 import { FilterChip } from "@components/shared/FilterChip";
 import { Overline } from "@components/shared/Overline";
+import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from "@components/ui/popover";
 import { cn } from "@lib/utils";
 import spendings from "@text/spendings";
+import { ChevronDown } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 export interface FilterCategory {
   key: string;
@@ -25,17 +28,19 @@ const Chip = ({
   color,
   label,
   count,
+  className,
 }: {
   active: boolean;
   onClick: () => void;
   color?: string;
   label: string;
   count: number;
+  className?: string;
 }) => (
   <FilterChip
     active={active}
     onClick={onClick}
-    className="gap-1.5 rounded-lg px-2.5 capitalize"
+    className={cn("shrink-0 gap-1.5 rounded-lg px-2.5 capitalize", className)}
   >
     {color && (
       <span
@@ -49,34 +54,138 @@ const Chip = ({
 );
 
 /**
- * Global category filter strip for the Dépenses timeline. Selecting a chip
- * filters every day card to that category (null = all).
+ * Global category filter for the Dépenses timeline (null = all). Boxed and sized
+ * exactly like the toolbar search inputs. Only on WIDE screens (xl+, where it sits
+ * inline with real room) do the chips stay on a single clipped line
+ * (`xl:h-[38px] xl:overflow-hidden`); a ResizeObserver measures how many actually
+ * fit so the caret's overflow popover lists ONLY the hidden ones — never a chip
+ * already visible on the line. "Toutes" and the active category are pinned, so the
+ * current filter is always in view. Below xl (narrow desktop → mobile) the inline
+ * line would crush to an unusable sliver, so the box goes full-width and wraps the
+ * chips to the height it needs instead (COS-118).
  */
 const SpendingCategoryFilter = ({ categories, total, selected, onSelect }: SpendingCategoryFilterProps) => {
+  const [open, setOpen] = useState(false);
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(categories.length);
+
+  // Chips that compete for the clipped line — the active one is pinned separately,
+  // so it can never fall into the hidden overflow.
+  const selectedCategory = selected === null ? undefined : categories.find((c) => c.key === selected);
+  const lineCategories = selected === null ? categories : categories.filter((c) => c.key !== selected);
+  const lineSignature = lineCategories.map((c) => c.key).join(",");
+
+  // Measure, on mount and whenever the row resizes, how many chips fit fully on
+  // the single desktop line. The caret reserves its own width permanently (it only
+  // toggles visibility), so the fit never oscillates as the caret appears.
+  useEffect(() => {
+    const row = rowRef.current;
+    if (!row) return;
+    const measure = () => {
+      const rowRight = row.getBoundingClientRect().right;
+      // The row's only children are the category chips themselves.
+      let count = 0;
+      for (const chip of Array.from(row.children)) {
+        if (chip.getBoundingClientRect().right > rowRight + 0.5) break;
+        count++;
+      }
+      setVisibleCount(count);
+    };
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(row);
+    return () => observer.disconnect();
+  }, [lineSignature]);
+
   if (categories.length === 0) {
     return null;
   }
 
+  const hiddenCategories = lineCategories.slice(visibleCount);
+  const hiddenCount = hiddenCategories.length;
+
+  const pick = (key: string | null) => onSelect(key);
+  const pickAndClose = (key: string | null) => {
+    onSelect(key);
+    setOpen(false);
+  };
+
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Overline className="mr-1">{spendings.filter.label}</Overline>
-      <Chip
-        active={selected === null}
-        onClick={() => onSelect(null)}
-        label={spendings.filter.all}
-        count={total}
-      />
-      {categories.map((c) => (
-        <Chip
-          key={c.key}
-          active={selected === c.key}
-          onClick={() => onSelect(selected === c.key ? null : c.key)}
-          color={c.color}
-          label={c.name}
-          count={c.count}
-        />
-      ))}
-    </div>
+    <Popover
+      open={open}
+      onOpenChange={setOpen}
+    >
+      {/* The whole boxed line is the positioning anchor, so the overlay opens at
+          exactly its (responsive) width, reading as the continuation of the line. */}
+      <PopoverAnchor asChild>
+        <div className="flex w-full items-start gap-2 rounded-md border border-line bg-surface-elev px-2.5 py-2 xl:h-[38px] xl:items-center xl:overflow-hidden xl:py-0">
+          <Overline className="shrink-0 pt-1 xl:pt-0">{spendings.filter.label}</Overline>
+          <Chip
+            active={selected === null}
+            onClick={() => pick(null)}
+            label={spendings.filter.all}
+            count={total}
+          />
+          {selectedCategory && (
+            <Chip
+              active
+              onClick={() => pick(null)}
+              color={selectedCategory.color}
+              label={selectedCategory.name}
+              count={selectedCategory.count}
+            />
+          )}
+          {/* Below xl: chips wrap to the height they need. xl+: one clipped line —
+              overflow chips go invisible and live in the caret popover. */}
+          <div
+            ref={rowRef}
+            className="flex min-w-0 flex-1 flex-wrap items-center gap-2 xl:flex-nowrap xl:overflow-hidden"
+          >
+            {lineCategories.map((c, i) => (
+              <Chip
+                key={c.key}
+                className={cn(i >= visibleCount && "xl:invisible")}
+                active={selected === c.key}
+                onClick={() => pick(selected === c.key ? null : c.key)}
+                color={c.color}
+                label={c.name}
+                count={c.count}
+              />
+            ))}
+          </div>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={hiddenCount === 0}
+              aria-label={spendings.filter.showAllAria}
+              className={cn(
+                "hidden shrink-0 items-center self-stretch border-l border-line pl-2 text-ink-4 transition-colors hover:text-ink xl:flex",
+                hiddenCount === 0 && "xl:invisible",
+              )}
+            >
+              <ChevronDown className={cn("size-4 transition-transform", open && "rotate-180")} />
+            </button>
+          </PopoverTrigger>
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        className="w-(--radix-popover-trigger-width) rounded-lg border border-line bg-surface-elev p-2 shadow-popover"
+      >
+        <div className="flex max-h-[60vh] flex-wrap gap-2 overflow-y-auto">
+          {hiddenCategories.map((c) => (
+            <Chip
+              key={c.key}
+              active={selected === c.key}
+              onClick={() => pickAndClose(selected === c.key ? null : c.key)}
+              color={c.color}
+              label={c.name}
+              count={c.count}
+            />
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 };
 

--- a/front/src/components/spendings/view/SpendingToolbar.tsx
+++ b/front/src/components/spendings/view/SpendingToolbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import ExportButton from "@components/shared/ExportButton";
+import SpendingSearchTrigger from "@components/spendings/search/SpendingSearchTrigger";
 import spendings from "@text/spendings";
 import { Search } from "lucide-react";
 
@@ -24,13 +25,20 @@ const SpendingToolbar = ({ search, onSearchChange, children }: SpendingToolbarPr
       />
     </div>
 
-    {/* order-last stacks it under the search field on mobile — the field is itself
-        pushed down there by its own order-10, so anything less would land above it.
-        From sm both reset and this fills the span left before the export button.
-        empty:hidden because a slot that renders null (the filter does, on a week
-        with no categories) still leaves this wrapper holding a full-width flex
-        line, i.e. a phantom gap-3 row. */}
-    <div className="order-last w-full min-w-0 empty:hidden sm:order-none sm:flex-1">{children}</div>
+    {/* Whole-history search (COS-118): full-width field stacked under the week
+        filter on mobile, compact button beside it from sm. */}
+    <div className="order-10 w-full sm:order-none sm:w-auto">
+      <SpendingSearchTrigger />
+    </div>
+
+    {/* Only from xl (wide desktop) does the category filter sit inline between the
+        search and export, flex-1 so it fills the span and stays on one line —
+        saving the card height a whole extra row would cost. Below xl the inline
+        span crushes to an unusable sliver, so order-last + w-full drops it to its
+        own full-width wrapping row (COS-118). empty:hidden because a slot that
+        renders null (the filter does, on a week with no categories) would still
+        hold a full-width flex line, i.e. a phantom gap-3 row. */}
+    <div className="order-last w-full min-w-0 empty:hidden xl:order-none xl:flex-1">{children}</div>
 
     <div className="ml-auto flex items-center gap-2.5">
       <ExportButton />

--- a/front/src/helpers/dateRoute.ts
+++ b/front/src/helpers/dateRoute.ts
@@ -18,3 +18,25 @@ export const isValidIsoDate = (value?: string): value is string => {
 };
 
 export const buildSpendingsPath = (date = getTodayIsoDate()): string => `${SPENDINGS_PATH}?${DATE_QUERY_PARAM}=${date}`;
+
+// The Dashboard carries its viewed month as a ?month=YYYY-MM query param (COS-118).
+// Absent = current month (resolved client-side, COS-73), keeping /dashboard clean.
+export const MONTH_QUERY_PARAM = "month";
+export const DASHBOARD_PATH = "/dashboard";
+
+const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export const isValidMonthParam = (value?: string): value is string => !!value && MONTH_PATTERN.test(value);
+
+/** A month as "YYYY-MM" on the local calendar (matches date-fns startOfMonth). */
+export const formatMonthParam = (date: Date): string =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+
+/** Parse a validated "YYYY-MM" to the first day of that month (local). */
+export const parseMonthParam = (value: string): Date => {
+  const [year, month] = value.split("-").map(Number);
+  return new Date(year, month - 1, 1);
+};
+
+export const buildDashboardPath = (month?: string): string =>
+  month ? `${DASHBOARD_PATH}?${MONTH_QUERY_PARAM}=${month}` : DASHBOARD_PATH;

--- a/front/src/text/navBar.ts
+++ b/front/src/text/navBar.ts
@@ -1,5 +1,6 @@
 const navBar = {
   today: "Aujourd'hui",
+  currentMonth: "Mois en cours",
   links: {
     dashboard: "Dashboard",
     spendings: "Dépenses",

--- a/front/src/text/spendings.ts
+++ b/front/src/text/spendings.ts
@@ -50,9 +50,13 @@ const spendings = {
   filter: {
     label: "Filtrer",
     all: "Toutes",
+    // Caret at the end of the one-line category strip; opens the full list overlay.
+    showAllAria: "Afficher toutes les catégories",
   },
   toolbar: {
-    searchPlaceholder: "Rechercher une dépense…",
+    // Week-scoped client-side filter — distinct from the whole-history search
+    // (COS-118), which lives next to it and opens the search modal.
+    searchPlaceholder: "Filtrer la semaine…",
   },
   view: {
     newSpending: "Nouvelle dépense",


### PR DESCRIPTION
Move the whole-history spending search off the Dashboard NavBar into the Dépenses toolbar, decoupling it from the dashboard period.

Make the Dashboard month URL-driven (?month=YYYY-MM via nuqs, default current month resolved client-side), so it is never polluted by the week a Dépenses visit left in the shared store. The NavBar Dashboard link carries the selected week's month, plus a "Mois en cours" shortcut that disables in place while on the current month.

Redesign the Dépenses category filter as a boxed single-line control matching the search inputs: on xl+ it clips to one line with an overflow caret popover listing only the hidden chips; below xl it goes full-width and wraps. Guard MonthSelector's current-month label behind hydration to avoid a month-boundary mismatch (COS-73).