### PR TITLE
fix(spendings): Dépenses link month sync (COS-119)

### DIFF
--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -12,11 +12,13 @@ import UserMenu from "@components/shared/navBar/userMenu/UserMenu";
 import {
   buildDashboardPath,
   buildSpendingsPath,
+  formatIsoDate,
   formatMonthParam,
   getTodayIsoDate,
   isValidIsoDate,
   isValidMonthParam,
   MONTH_QUERY_PARAM,
+  parseMonthParam,
   SPENDINGS_PATH,
 } from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
@@ -111,8 +113,25 @@ const NavBar = () => {
 
   const hrefFor = (route: NavRoute): string => {
     const storedDate = selectedDateIso ?? undefined;
-    if (route.path === ROUTES.spendings.path && isClientHydrated && isValidIsoDate(storedDate)) {
-      return buildSpendingsPath(storedDate);
+    if (route.path === ROUTES.spendings.path && isClientHydrated) {
+      // On the Dashboard, the Dépenses link follows the viewed month (?month=) so
+      // "Mois en cours" / month stepping can't strand you on an old searched week
+      // (COS-119). Keep the exact selected day when it falls inside that month;
+      // otherwise today for the current month, else the month's first day.
+      if (isDashboard) {
+        const currentMonth = formatMonthParam(startOfMonth(new Date()));
+        const rawMonth = monthParam ?? "";
+        const dashMonth = isValidMonthParam(rawMonth) ? rawMonth : currentMonth;
+        if (isValidIsoDate(storedDate) && formatMonthParam(parseISO(storedDate)) === dashMonth) {
+          return buildSpendingsPath(storedDate);
+        }
+        return buildSpendingsPath(
+          dashMonth === currentMonth ? getTodayIsoDate() : formatIsoDate(parseMonthParam(dashMonth)),
+        );
+      }
+      if (isValidIsoDate(storedDate)) {
+        return buildSpendingsPath(storedDate);
+      }
     }
     // The Dashboard link carries the month of the currently selected week, so
     // jumping from a past week lands on that month's dashboard (COS-118). The

--- a/front/src/components/spendings/search/SpendingSearchModal.tsx
+++ b/front/src/components/spendings/search/SpendingSearchModal.tsx
@@ -101,6 +101,17 @@ const SpendingSearchModal = () => {
 
   const groups = groupSpendingsByMonth(results);
 
+  // A single placeholder message (or null when there are rows) so the scroll area
+  // keeps its fixed height and the modal never resizes as the query starts empty,
+  // matches, or stops matching (COS-119).
+  const resolveEmptyMessage = (): string | null => {
+    if (error) return spendingSearch.error;
+    if (!hasQuery) return spendingSearch.hint;
+    if (results.length === 0) return isSearching ? spendingSearch.loading : spendingSearch.noResults;
+    return null;
+  };
+  const emptyMessage = resolveEmptyMessage();
+
   // Picking a result jumps to the Dépenses page on the week that contains it (and
   // asks that page to scroll the day into view). We stash the scroll offset first
   // and leave the URL search state intact, so Back restores the modal + list.
@@ -122,11 +133,15 @@ const SpendingSearchModal = () => {
     >
       <DialogContent
         aria-describedby={undefined}
-        className="gap-0 overflow-hidden border-line bg-surface-elev p-0 sm:max-w-[560px]"
+        className="gap-0 overflow-hidden border-line bg-surface-elev p-0 sm:max-w-[700px]"
       >
         <DialogTitle className="sr-only">{spendingSearch.title}</DialogTitle>
 
-        <div className="flex items-center gap-2.5 border-b border-line-soft px-4 py-3.5 pr-14">
+        {/* Keep the DS dialog's own top-right close (absolute top-4, centre at 30px)
+            and mirror the p-0 modal header pattern (SpendingModal): py-4.5 + a
+            text-base row so the content centres at that same 30px, pr-14 clears the
+            close. No overriding the DS close. */}
+        <div className="flex items-center gap-2.5 border-b border-line-soft py-4.5 pl-5.5 pr-14">
           <Search className="size-4 shrink-0 text-ink-4" />
           <input
             type="search"
@@ -134,7 +149,7 @@ const SpendingSearchModal = () => {
             value={q}
             onChange={(e) => onQueryChange(e.target.value)}
             placeholder={spendingSearch.placeholder}
-            className="min-w-0 flex-1 bg-transparent text-sm text-ink outline-none placeholder:text-ink-4"
+            className="min-w-0 flex-1 bg-transparent p-0 text-base text-ink outline-none placeholder:text-ink-4"
           />
           {hasQuery && !isSearching && (
             <span className="shrink-0 text-xs text-ink-4">{spendingSearch.resultsCount(total)}</span>
@@ -165,16 +180,12 @@ const SpendingSearchModal = () => {
 
         <div
           ref={scrollRef}
-          className="max-h-[min(60vh,440px)] overflow-y-auto"
+          className="h-[min(72vh,590px)] overflow-y-auto"
         >
-          {error ? (
-            <EmptyState className="py-10">{spendingSearch.error}</EmptyState>
-          ) : !hasQuery ? (
-            <EmptyState className="py-10">{spendingSearch.hint}</EmptyState>
-          ) : isSearching && results.length === 0 ? (
-            <EmptyState className="py-10">{spendingSearch.loading}</EmptyState>
-          ) : results.length === 0 ? (
-            <EmptyState className="py-10">{spendingSearch.noResults}</EmptyState>
+          {emptyMessage !== null ? (
+            <div className="flex h-full items-center justify-center px-6">
+              <EmptyState className="text-base">{emptyMessage}</EmptyState>
+            </div>
           ) : (
             <>
               {groups.map((group) => (

--- a/front/src/helpers/dateRoute.ts
+++ b/front/src/helpers/dateRoute.ts
@@ -6,7 +6,10 @@ export const SPENDINGS_PATH = "/spendings";
 
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-export const getTodayIsoDate = (): string => formatISO(new Date(), { representation: "date" });
+/** A Date as an ISO calendar day ("YYYY-MM-DD") on the local calendar. */
+export const formatIsoDate = (date: Date): string => formatISO(date, { representation: "date" });
+
+export const getTodayIsoDate = (): string => formatIsoDate(new Date());
 
 export const isValidIsoDate = (value?: string): value is string => {
   if (!value || !ISO_DATE_PATTERN.test(value)) {


### PR DESCRIPTION
On the Dashboard, the NavBar Dépenses link now derives its ?date= week from the viewed month (?month=): keep the exact selected day when it's inside that month, else today for the current month, else the month's first day. Fixes landing on a stale searched week after "Mois en cours" or month stepping. Adds a formatIsoDate() helper.

Also polish the whole-history search modal (COS-114): the results area is now a fixed height (h-[min(72vh,590px)]) so the modal opens at its max ~700x700 square and never resizes as the query matches/empties; larger centred placeholder text; keep the DS dialog's native close and align the header to it via the p-0 modal pattern instead of overriding it.