### PR TITLE
feat(brand): PFA wordmark in Keania One (COS-116)

### DIFF
--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import "@styles/globals.css";
 import Providers from "@app/providers";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Keania_One } from "next/font/google";
 
 const geistSans = Geist({
   subsets: ["latin"],
@@ -14,11 +14,19 @@ const geistMono = Geist_Mono({
   display: "swap",
 });
 
+// Brand wordmark only ("PFA") — scoped to the `font-wordmark` utility, never the body.
+const keania = Keania_One({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-keania",
+  display: "swap",
+});
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html
       lang="fr"
-      className={`dark ${geistSans.variable} ${geistMono.variable}`}
+      className={`dark ${geistSans.variable} ${geistMono.variable} ${keania.variable}`}
       suppressHydrationWarning
     >
       <body className="bg-surface-base text-foreground antialiased">

--- a/front/src/components/auth/AuthHeader.tsx
+++ b/front/src/components/auth/AuthHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Logo from "@components/shared/brand/Logo";
+import Wordmark from "@components/shared/brand/Wordmark";
 import { ROUTES } from "@components/shared/config/constants";
 import { cn } from "@lib/utils";
 import login from "@text/login";
@@ -26,9 +27,9 @@ export default function AuthHeader() {
 
   return (
     <header className="relative z-[2] flex flex-wrap items-center gap-x-4 gap-y-3 px-5 py-4 sm:gap-x-6.5 sm:px-8 sm:py-4.5">
-      <div className="flex items-center gap-2.5 text-base font-semibold tracking-tight text-ink">
+      <div className="flex items-center gap-1 text-ink">
         <Logo size={26} />
-        <span>pfa</span>
+        <Wordmark />
       </div>
 
       <nav className="flex flex-wrap gap-1">

--- a/front/src/components/shared/brand/Wordmark.tsx
+++ b/front/src/components/shared/brand/Wordmark.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@lib/utils";
+
+/**
+ * pfa brand wordmark — "PFA" set in Keania One (rounded techno display face).
+ *
+ * The face is loaded once via next/font in the root layout (exposed as the
+ * `--font-keania` variable / the `font-wordmark` utility); the rest of the app
+ * stays on Geist. Kept beside Logo so the two brand marks live — and are reused
+ * — together.
+ *
+ * Colour: the primary-button (« Nouvelle dépense ») gradient, built from the
+ * same design tokens (`--accent-strong` → `--chart-2` → `--chart-3`) so the CTA
+ * and the wordmark share one accent. For a plain variant, pass
+ * `className="text-ink"` (or drop the gradient classes below).
+ */
+export default function Wordmark({ className }: { className?: string }) {
+  return (
+    <span
+      className={cn(
+        "font-wordmark text-2xl leading-none",
+        "bg-[linear-gradient(100deg,var(--accent-strong)_0%,var(--chart-2)_55%,var(--chart-3)_100%)] bg-clip-text [-webkit-background-clip:text] text-transparent",
+        className,
+      )}
+    >
+      PFA
+    </span>
+  );
+}

--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -5,6 +5,7 @@ import MonthSelector from "@components/dashboard/MonthSelector";
 import DatePickerWrapper from "@components/datePickerWrapper/DatePickerWrapper";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import Logo from "@components/shared/brand/Logo";
+import Wordmark from "@components/shared/brand/Wordmark";
 import { ROUTES } from "@components/shared/config/constants";
 import useGlobalStore from "@components/shared/globalStore";
 import { IconButton } from "@components/shared/IconButton";
@@ -160,10 +161,12 @@ const NavBar = () => {
 
   if (!user) return null;
 
-  const brand = (
-    <div className="flex items-center gap-2.5 text-base font-semibold tracking-tight text-ink">
+  // Wordmark is hidden on mobile in the top bar (icon only there); the drawer
+  // keeps it, so mobile users still see it in the open sidebar.
+  const renderBrand = (wordmarkClassName?: string) => (
+    <div className="flex items-center gap-1 text-ink">
       <Logo size={24} />
-      <span>pfa</span>
+      <Wordmark className={wordmarkClassName} />
     </div>
   );
 
@@ -184,7 +187,7 @@ const NavBar = () => {
           <Menu />
         </IconButton>
 
-        {brand}
+        {renderBrand("hidden lg:inline")}
 
         <nav className="ml-1.5 hidden gap-0.5 lg:flex">
           {NAV_ROUTES.map((route) => (
@@ -273,7 +276,7 @@ const NavBar = () => {
         aria-hidden={!drawerOpen}
       >
         <div className="mb-1.5 flex items-center justify-between border-b border-white/[0.07] px-1.5 pb-3">
-          {brand}
+          {renderBrand()}
           <IconButton
             variant="ghost"
             size={9}

--- a/front/styles/tokens/typography.css
+++ b/front/styles/tokens/typography.css
@@ -20,6 +20,8 @@
   /* Geist (UI) + Geist Mono (numbers) via next/font */
   --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
   --font-mono: var(--font-geist-mono), ui-monospace, monospace;
+  /* Keania One — brand wordmark only (`font-wordmark`), via next/font */
+  --font-wordmark: var(--font-keania), ui-sans-serif, system-ui, sans-serif;
 }
 
 /* Every meaningful number → Geist Mono, tabular */


### PR DESCRIPTION
- Load Keania One via next/font, scoped to the `font-wordmark` utility (body stays Geist)
- Reusable Wordmark component beside Logo; renders "PFA"
- Gradient reuses the primary-button accent (--accent-strong / --chart-2 / --chart-3)
- Top bar: wordmark hidden on mobile (icon only); drawer keeps it