### PR TITLE
feat(spendings): warn/danger day totals (COS-34)

### DIFF
--- a/front/src/components/spendings/helpers/__tests__/overspendLevel.test.ts
+++ b/front/src/components/spendings/helpers/__tests__/overspendLevel.test.ts
@@ -1,0 +1,25 @@
+import overspendLevel, { OVERSPEND_DANGER_RATIO } from "@components/spendings/helpers/overspendLevel";
+
+describe("overspendLevel", () => {
+  it("is normal when the budget is null or non-positive (no ceiling defined)", () => {
+    expect(overspendLevel(999, null)).toBe("normal");
+    expect(overspendLevel(999, 0)).toBe("normal");
+    expect(overspendLevel(999, -50)).toBe("normal");
+  });
+
+  it("is normal at or under budget", () => {
+    expect(overspendLevel(0, 100)).toBe("normal");
+    expect(overspendLevel(99, 100)).toBe("normal");
+    expect(overspendLevel(100, 100)).toBe("normal");
+  });
+
+  it("is warn just over budget, up to the danger multiple", () => {
+    expect(overspendLevel(101, 100)).toBe("warn");
+    expect(overspendLevel(100 * OVERSPEND_DANGER_RATIO, 100)).toBe("warn");
+  });
+
+  it("is danger past the danger multiple of budget", () => {
+    expect(overspendLevel(100 * OVERSPEND_DANGER_RATIO + 1, 100)).toBe("danger");
+    expect(overspendLevel(1000, 100)).toBe("danger");
+  });
+});

--- a/front/src/components/spendings/helpers/overspendLevel.ts
+++ b/front/src/components/spendings/helpers/overspendLevel.ts
@@ -1,0 +1,28 @@
+export type OverspendLevel = "normal" | "warn" | "danger";
+
+/**
+ * The total turns red only once it exceeds its budget by this factor; between
+ * the budget and this multiple it stays orange. Single knob shared by the two
+ * Dépenses overspend indicators (COS-34 day-cards, COS-36 weekly ceiling) so
+ * they always agree — tune here.
+ */
+export const OVERSPEND_DANGER_RATIO = 2;
+
+/**
+ * Three-state overspend level shared by the Dépenses day-card totals (COS-34,
+ * day total vs the day's share of the weekly ceiling) and the weekly
+ * "vs plafond" widget (COS-36, week total vs the ceiling), so both use the exact
+ * same orange→red rule:
+ *
+ * - `normal` — at or under budget
+ * - `warn`   — over budget, up to `OVERSPEND_DANGER_RATIO`× budget (orange)
+ * - `danger` — beyond that (red)
+ *
+ * A null or non-positive budget (no ceiling defined) is always `normal`.
+ */
+export default function overspendLevel(value: number, budget: number | null): OverspendLevel {
+  if (budget == null || budget <= 0 || value <= budget) {
+    return "normal";
+  }
+  return value > budget * OVERSPEND_DANGER_RATIO ? "danger" : "warn";
+}

--- a/front/src/components/spendings/view/SpendingDayCard.tsx
+++ b/front/src/components/spendings/view/SpendingDayCard.tsx
@@ -2,6 +2,7 @@
 
 import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
 import SpendingModal from "@components/spendings/common/spendingModal/SpendingModal";
+import overspendLevel from "@components/spendings/helpers/overspendLevel";
 import useSpendingDayItem from "@components/spendings/spendingDayItem/spendingItem/helpers/useSpendingDayItem";
 import useDaySort from "@components/spendings/view/helpers/useDaySort";
 import SpendingTxRow from "@components/spendings/view/SpendingTxRow";
@@ -57,6 +58,8 @@ interface SpendingDayCardProps {
   items: SpendingItem[];
   total: number;
   dailyBudget: number | null;
+  /** The day's share of the weekly ceiling — threshold for the total colour (COS-34). */
+  ceilingPerDay: number | null;
   isToday: boolean;
   month: MonthRange | null;
   selectedCategory: string | null;
@@ -74,6 +77,7 @@ const SpendingDayCard = ({
   items,
   total,
   dailyBudget,
+  ceilingPerDay,
   isToday,
   month,
   selectedCategory,
@@ -111,7 +115,7 @@ const SpendingDayCard = ({
 
   const isFiltering = Boolean(selectedCategory) || query.length > 0;
   const displayTotal = isFiltering ? filtered.reduce((acc, s) => acc + Number(s.amount), 0) : total;
-  const over = dailyBudget != null && displayTotal > dailyBudget;
+  const level = overspendLevel(displayTotal, ceilingPerDay);
 
   const dayCategories = useMemo<DayCategory[]>(() => {
     const map = new Map<string, DayCategory>();
@@ -141,7 +145,7 @@ const SpendingDayCard = ({
             {format(date, "dd MMM", { locale: fr })}
             <span className="dow">{format(date, "EEEE", { locale: fr })}</span>
           </div>
-          <div className={cn("sp-day-total", over && "over")}>
+          <div className={cn("sp-day-total", level !== "normal" && level)}>
             <span className="tl">{dayCard.total}</span>
             {euro(displayTotal)}
             <span className="cur"> €</span>

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -140,6 +140,10 @@ const SpendingView = () => {
   // in the month (today included). Shared with the Dashboard "reste à vivre" so
   // the two always match; only rendered on today's card (see SpendingDayCard).
   const dailyBudget = dashboardQuery.data ? dailyRemainingBudget(remaining, now) : null;
+  // Threshold for each day-card total colour (COS-34): the weekly ceiling split
+  // over the number of cards actually shown (not always 7). The same ceiling the
+  // weekly "vs plafond" widget uses, so day and week colours stay consistent.
+  const ceilingPerDay = weeklyCeiling != null && groups.length > 0 ? weeklyCeiling / groups.length : null;
 
   const grand = weekTotal || 1;
   const breakdownRows: BreakdownRow[] = categoryAgg.map((c) => ({
@@ -204,6 +208,7 @@ const SpendingView = () => {
               items={group.items}
               total={group.total}
               dailyBudget={dailyBudget}
+              ceilingPerDay={ceilingPerDay}
               isToday={isSameDay(range[i], now)}
               month={month}
               selectedCategory={selectedCategory}

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -296,10 +296,17 @@
   font-weight: 400;
   font-size: 13px;
 }
-.sp-day-total.over {
+.sp-day-total.warn {
+  color: var(--warn);
+}
+.sp-day-total.warn .cur {
+  color: var(--warn);
+  opacity: 0.7;
+}
+.sp-day-total.danger {
   color: var(--neg);
 }
-.sp-day-total.over .cur {
+.sp-day-total.danger .cur {
   color: var(--neg);
   opacity: 0.7;
 }

--- a/front/styles/tokens/colors.css
+++ b/front/styles/tokens/colors.css
@@ -68,6 +68,10 @@
   --bar-fill:      linear-gradient(90deg, var(--accent-d), var(--accent-strong));
   --neg:           oklch(0.72 0.17 25);
   --neg-bg:        oklch(0.72 0.17 25 / 0.12);
+  /* Warn (amber) — the middle "over budget but not alarming" step, between the
+     accent green and --neg red (Dépenses overspend indicators, COS-34/COS-36) */
+  --warn:          oklch(0.80 0.15 70);
+  --warn-bg:       oklch(0.80 0.15 70 / 0.12);
 
   /* Danger — solid delete button + inline confirm affordance */
   --danger-solid:       oklch(0.55 0.18 25); /* solid delete-button fill */
@@ -168,6 +172,8 @@
   --color-accent-d: var(--accent-d);
   --color-accent-bg: var(--accent-bg);
   --color-neg: var(--neg);
+  --color-warn: var(--warn);
+  --color-warn-bg: var(--warn-bg);
   --color-danger-solid: var(--danger-solid);
   --color-on-danger: var(--on-danger);
   --color-danger-surface: var(--danger-surface);


### PR DESCRIPTION
Replace the binary red "over budget" day-card total with a 3-state orange->red level. The threshold is the weekly ceiling split over the number of cards actually shown (not always 7), so the day-card colours and the weekly "vs plafond" widget stay consistent.

Extract a shared overspendLevel() helper (single OVERSPEND_DANGER_RATIO knob, red at 2x budget) for COS-36 to reuse, plus a --warn amber token.