### PR TITLE
feat(stats): de-mock daily heatmap (COS-45)

### DIFF
--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -11,6 +11,7 @@ export const QUERY_KEYS = {
   DAILY_PROJECTION: "dailyProjection",
   CHARTS: "charts",
   WEEKLY_STATS: "weeklyStats",
+  DAILY_STATS: "dailyStats",
   CATEGORIES: "categories",
   CATEGORY_STATS: "categoryStats",
   EXCEPTIONALS: "exceptionals",

--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -1,41 +1,27 @@
 "use client";
 
-// MOCK — there is no per-day spend endpoint (only per-month per-category), so
-// the daily grid is a deterministic seeded pattern. The distribution bar, the
-// sober-streak and the exceptional-pic count are all derived from that same
-// generated pattern, so the card stays internally consistent.
-
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
+import { buildHeatmap, monthColumns } from "@components/statistics/helpers/heatmapData";
+import { euro0 } from "@lib/format";
+import common from "@text/common";
 import statistics from "@text/statistics";
-import getDayOfYear from "date-fns/getDayOfYear";
+
+import type { FilledLevel } from "@components/statistics/helpers/heatmapData";
+import type { ExceptionalItem } from "@src/schemas/exceptionals";
+import type { DailyStat } from "@src/schemas/stats";
 
 interface StatisticsHeatmapProps {
   year: number;
   now: Date;
+  /** Per-day spending totals for the year (COS-45); `undefined` while the request is in flight. */
+  days: DailyStat[] | undefined;
+  /** Exceptional purchases for the year — overlaid as lvl-neg days. */
+  exceptionals: ExceptionalItem[];
 }
 
-type Level = "future" | "lvl-0" | "lvl-1" | "lvl-2" | "lvl-3" | "lvl-4" | "lvl-neg";
-type FilledLevel = Exclude<Level, "future">;
-
-const WEEKS = 53;
 const DOW_LABELS = ["lun", "", "mer", "", "ven", "", "dim"];
-
-const MONTH_COLS: { name: string; col: number }[] = [
-  { name: "jan", col: 2 },
-  { name: "fév", col: 6 },
-  { name: "mar", col: 11 },
-  { name: "avr", col: 15 },
-  { name: "mai", col: 19 },
-  { name: "jun", col: 24 },
-  { name: "jul", col: 28 },
-  { name: "aoû", col: 32 },
-  { name: "sep", col: 37 },
-  { name: "oct", col: 41 },
-  { name: "nov", col: 45 },
-  { name: "déc", col: 50 },
-];
 
 const CELL_BG: Record<FilledLevel, string> = {
   "lvl-0": "oklch(0.20 0.006 250)",
@@ -55,84 +41,46 @@ const DIST_BG: Record<FilledLevel, string> = {
   "lvl-neg": "var(--exc)",
 };
 
-interface HeatmapModel {
-  rows: Level[][]; // [dow 0..6][week 0..52]
-  counts: Record<FilledLevel, number>;
-  streak: number;
-}
-
-const emptyCounts = (): Record<FilledLevel, number> => ({
-  "lvl-0": 0,
-  "lvl-1": 0,
-  "lvl-2": 0,
-  "lvl-3": 0,
-  "lvl-4": 0,
-  "lvl-neg": 0,
-});
-
-/** Seeded LCG so the pattern is stable across renders (and SSR-safe). */
-const buildHeatmap = (todayWeek: number, cap: number): HeatmapModel => {
-  let seed = 42;
-  const rand = () => {
-    seed = (seed * 9301 + 49297) % 233280;
-    return seed / 233280;
-  };
-
-  const rows: Level[][] = Array.from({ length: 7 }, () => Array<Level>(WEEKS).fill("future"));
-  for (let dow = 0; dow < 7; dow++) {
-    for (let week = 0; week < WEEKS; week++) {
-      if (week > todayWeek) continue; // stays "future"
-      const v = rand() + (dow >= 5 ? 0.25 : 0); // weekends heavier
-      if ((week === 10 && dow === 5) || (week === 18 && dow === 6)) {
-        rows[dow][week] = "lvl-neg"; // exceptional spikes
-      } else {
-        rows[dow][week] = v < 0.25 ? "lvl-0" : v < 0.5 ? "lvl-1" : v < 0.7 ? "lvl-2" : v < 0.88 ? "lvl-3" : "lvl-4";
-      }
-    }
-  }
-
-  const counts = emptyCounts();
-  let streak = 0;
-  let best = 0;
-  let seen = 0;
-  outer: for (let week = 0; week <= todayWeek; week++) {
-    for (let dow = 0; dow < 7; dow++) {
-      const lv = rows[dow][week];
-      if (lv === "future") continue;
-      counts[lv] += 1;
-      seen += 1;
-      if (lv === "lvl-0" || lv === "lvl-1") {
-        streak += 1;
-        best = Math.max(best, streak);
-      } else {
-        streak = 0;
-      }
-      if (seen >= cap) break outer;
-    }
-  }
-
-  return { rows, counts, streak: best };
-};
-
 const FILLED_ORDER: FilledLevel[] = ["lvl-0", "lvl-1", "lvl-2", "lvl-3", "lvl-4", "lvl-neg"];
 
-/** "Carte de chaleur — quotidienne" — a daily-intensity calendar (MOCK). */
-const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
+/** "Carte de chaleur — quotidienne" — daily-spend intensity calendar (COS-45). */
+const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapProps) => {
   const { heatmap: t } = statistics;
-  const isCurrentYear = year === now.getFullYear();
-  const realizedDays = isCurrentYear ? getDayOfYear(now) : getDayOfYear(new Date(year, 11, 31));
-  const todayWeek = isCurrentYear ? Math.floor((getDayOfYear(now) - 1) / 7) : WEEKS - 1;
 
-  const { rows, counts, streak } = buildHeatmap(todayWeek, realizedDays);
+  // Not yet loaded (or the request failed): show a placeholder rather than an
+  // all-zero grid, which would read as a real, confident "sober all year".
+  if (days === undefined) {
+    return (
+      <GlowCard
+        as="div"
+        className="flex flex-col overflow-x-auto px-6 py-5.5"
+      >
+        <CardSectionHeader
+          title={t.title}
+          meta={String(year)}
+        />
+        <div className="grid flex-1 place-items-center py-16 text-sm text-ink-4">{common.loading}</div>
+      </GlowCard>
+    );
+  }
 
-  const sober = counts["lvl-0"] + counts["lvl-1"];
-  const common = counts["lvl-2"] + counts["lvl-3"];
+  const { rows, weeks, counts, streak, scaleMax, busiest, exceptionalLabels, realizedDays } = buildHeatmap(
+    year,
+    now,
+    days,
+    exceptionals,
+  );
+
+  const gridColumns = `16px repeat(${weeks}, minmax(0, 1fr))`;
+  const soberDays = counts["lvl-0"] + counts["lvl-1"];
+  const commonDays = counts["lvl-2"] + counts["lvl-3"];
   const distGroups = [
-    { label: t.dist.sober, n: sober, color: "oklch(0.45 0.06 148 / 0.7)" },
-    { label: t.dist.common, n: common, color: "oklch(0.70 0.10 148 / 0.85)" },
+    { label: t.dist.sober, n: soberDays, color: "oklch(0.45 0.06 148 / 0.7)" },
+    { label: t.dist.common, n: commonDays, color: "oklch(0.70 0.10 148 / 0.85)" },
     { label: t.dist.intense, n: counts["lvl-4"], color: "var(--accent-strong)" },
     { label: t.dist.exceptional, n: counts["lvl-neg"], color: "var(--exc)" },
   ];
+  const peakLabels = exceptionalLabels.slice(0, 3).join(" · ");
 
   return (
     <GlowCard
@@ -148,9 +96,9 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
         {/* month axis */}
         <div
           className="num mb-1 grid text-3xs text-ink-4"
-          style={{ gridTemplateColumns: "16px repeat(53, minmax(0, 1fr))" }}
+          style={{ gridTemplateColumns: gridColumns }}
         >
-          {MONTH_COLS.map((m) => (
+          {monthColumns(year).map((m) => (
             <span
               key={m.name}
               style={{ gridColumn: `${m.col} / span 4`, gridRow: 1 }}
@@ -163,7 +111,7 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
         {/* grid */}
         <div
           className="grid gap-0.5"
-          style={{ gridTemplateColumns: "16px repeat(53, minmax(0, 1fr))" }}
+          style={{ gridTemplateColumns: gridColumns }}
         >
           {rows.map((weekArr, dow) => (
             <div
@@ -180,7 +128,9 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
                   style={
                     lvl === "future"
                       ? { background: "transparent", border: "1px dashed var(--line)" }
-                      : { background: CELL_BG[lvl] }
+                      : lvl === "empty"
+                        ? { background: "transparent" }
+                        : { background: CELL_BG[lvl] }
                   }
                 />
               ))}
@@ -200,7 +150,7 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
               />
             ))}
           </span>
-          <span>210 €/j</span>
+          <span>{euro0(scaleMax)} €/j</span>
           <span className="flex-1" />
           <LegendItem
             swatch={
@@ -247,8 +197,9 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
         <div className="grid grid-cols-3 gap-4.5">
           <div>
             <div className="num text-2xs uppercase leading-snug tracking-wider text-ink-4">{t.busiestDay}</div>
-            {/* MOCK — no per-day amounts */}
-            <div className="num mt-2 text-xl tracking-snug text-ink">210 €</div>
+            <div className="num mt-2 text-xl tracking-snug text-ink">
+              {busiest ? `${euro0(busiest.amount)} €` : "—"}
+            </div>
             <div className="mt-1 text-2xs text-ink-4">{t.excludingExceptional}</div>
           </div>
           <div>
@@ -258,8 +209,8 @@ const StatisticsHeatmap = ({ year, now }: StatisticsHeatmapProps) => {
           </div>
           <div>
             <div className="num text-2xs uppercase leading-snug tracking-wider text-ink-4">{t.exceptionalPeaks}</div>
-            <div className="num mt-2 text-xl tracking-snug text-ink">{counts["lvl-neg"]}</div>
-            <div className="mt-1 text-2xs text-ink-4">ordinateur · vélo</div>
+            <div className="num mt-2 text-xl tracking-snug text-ink">{exceptionalLabels.length}</div>
+            <div className="mt-1 text-2xs text-ink-4">{peakLabels || "—"}</div>
           </div>
         </div>
       </div>

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -19,6 +19,7 @@ import StatisticsHeatmap from "@components/statistics/StatisticsHeatmap";
 import StatisticsKpis from "@components/statistics/StatisticsKpis";
 import StatisticsMonthlyChart from "@components/statistics/StatisticsMonthlyChart";
 import StatisticsTopCategories from "@components/statistics/StatisticsTopCategories";
+import useDailyStats from "@components/statistics/services/useDailyStats";
 import useStatistics from "@components/statistics/services/useStatistics";
 import { useMemo, useState } from "react";
 
@@ -44,6 +45,7 @@ const StatisticsView = () => {
   const years = useMemo(() => Array.from(new Set([selectedYear, compareYear])), [selectedYear, compareYear]);
 
   const { statistics, categories } = useStatistics({ years });
+  const { dailyStats } = useDailyStats({ year: selectedYear });
   const { exceptionals } = useExceptionals({ year: selectedYear });
   const { exceptionals: compareExceptionals } = useExceptionals({
     year: compareYear,
@@ -153,6 +155,8 @@ const StatisticsView = () => {
         <StatisticsHeatmap
           year={selectedYear}
           now={now}
+          days={dailyStats?.days}
+          exceptionals={exceptionals}
         />
         <StatisticsTopCategories
           rows={topCategoryRows}

--- a/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
@@ -1,0 +1,72 @@
+import { bandFor, buildHeatmap } from "@components/statistics/helpers/heatmapData";
+
+import type { ExceptionalItem } from "@src/schemas/exceptionals";
+import type { DailyStat } from "@src/schemas/stats";
+
+const day = (date: string, total: number, count = 1): DailyStat => ({ date, total, count });
+const exc = (date: string, amount: number, label: string): ExceptionalItem =>
+  ({ ID: date, userID: "u1", date, itemType: "exceptional", label, amount }) as ExceptionalItem;
+
+describe("bandFor", () => {
+  it("is lvl-0 at or below zero, or when there is no scale", () => {
+    expect(bandFor(0, 100)).toBe("lvl-0");
+    expect(bandFor(-5, 100)).toBe("lvl-0");
+    expect(bandFor(50, 0)).toBe("lvl-0");
+  });
+
+  it("spreads positive amounts over four bands up to the max", () => {
+    expect(bandFor(1, 100)).toBe("lvl-1");
+    expect(bandFor(25, 100)).toBe("lvl-1");
+    expect(bandFor(26, 100)).toBe("lvl-2");
+    expect(bandFor(50, 100)).toBe("lvl-2");
+    expect(bandFor(75, 100)).toBe("lvl-3");
+    expect(bandFor(100, 100)).toBe("lvl-4");
+  });
+});
+
+describe("buildHeatmap", () => {
+  // Current year, only the first 10 days realized → a small, fully deterministic
+  // window. Jan 1 2023 is a Sunday (Monday-based dow 6), which fixes the columns.
+  const now = new Date(2023, 0, 10);
+  const days = [day("2023-01-02", 100, 2), day("2023-01-03", 25)];
+  const exceptionals = [exc("2023-01-05", 800, "ordinateur"), exc("2023-01-08", 300, "vélo")];
+
+  it("derives the colour scale and busiest day from non-exceptional days only", () => {
+    const { scaleMax, busiest } = buildHeatmap(2023, now, days, exceptionals);
+    expect(scaleMax).toBe(100);
+    expect(busiest).toEqual({ amount: 100, date: "2023-01-02" });
+  });
+
+  it("counts realized days by level, exceptional days overriding the spend band", () => {
+    const { counts } = buildHeatmap(2023, now, days, exceptionals);
+    expect(counts).toEqual({ "lvl-0": 6, "lvl-1": 1, "lvl-2": 0, "lvl-3": 0, "lvl-4": 1, "lvl-neg": 2 });
+  });
+
+  it("measures the longest run of consecutive sober (lvl-0/lvl-1) days", () => {
+    const { streak } = buildHeatmap(2023, now, days, exceptionals);
+    expect(streak).toBe(2);
+  });
+
+  it("lists realized exceptional labels, biggest first, and reports realized days", () => {
+    const { exceptionalLabels, realizedDays } = buildHeatmap(2023, now, days, exceptionals);
+    expect(exceptionalLabels).toEqual(["ordinateur", "vélo"]);
+    expect(realizedDays).toBe(10);
+  });
+
+  it("places days on the calendar grid (Jan 1 2023 = Sunday) and pads/futures the rest", () => {
+    const { rows } = buildHeatmap(2023, now, days, exceptionals);
+    expect(rows[6][0]).toBe("lvl-0"); // Sun 01-01
+    expect(rows[0][1]).toBe("lvl-4"); // Mon 01-02 (heaviest day)
+    expect(rows[0][0]).toBe("empty"); // Mon of week 0 = 2022-12-26, out of year
+    expect(rows[2][2]).toBe("future"); // Wed 01-11, past the realized window
+  });
+
+  it("handles a year with no spending: no scale, no busiest day, every day sober", () => {
+    const { scaleMax, busiest, counts, streak, realizedDays } = buildHeatmap(2023, new Date(2023, 5, 1), [], []);
+    expect(scaleMax).toBe(0);
+    expect(busiest).toBeNull();
+    expect(counts["lvl-0"]).toBe(realizedDays);
+    expect(counts["lvl-neg"]).toBe(0);
+    expect(streak).toBe(realizedDays);
+  });
+});

--- a/front/src/components/statistics/helpers/heatmapData.ts
+++ b/front/src/components/statistics/helpers/heatmapData.ts
@@ -1,0 +1,156 @@
+import getDay from "date-fns/getDay";
+import getDayOfYear from "date-fns/getDayOfYear";
+
+import type { ExceptionalItem } from "@src/schemas/exceptionals";
+import type { DailyStat } from "@src/schemas/stats";
+
+export type HeatmapLevel = "empty" | "future" | "lvl-0" | "lvl-1" | "lvl-2" | "lvl-3" | "lvl-4" | "lvl-neg";
+export type FilledLevel = Exclude<HeatmapLevel, "future" | "empty">;
+
+export interface HeatmapModel {
+  /** [dow 0=Mon..6=Sun][week 0..weeks-1]; "empty" = out-of-year padding, "future" = not yet reached. */
+  rows: HeatmapLevel[][];
+  /** Number of week-columns this year actually spans (52–54, so the grid matches the calendar). */
+  weeks: number;
+  counts: Record<FilledLevel, number>;
+  /** Longest run of consecutive realized "sober" days (lvl-0 / lvl-1). */
+  streak: number;
+  /** Heaviest non-exceptional daily total in euros — colour-scale top + legend. */
+  scaleMax: number;
+  /** The single heaviest non-exceptional day, or null when there is no spending. */
+  busiest: { amount: number; date: string } | null;
+  /** Realized exceptional purchase labels, biggest first (for the "pics" subtext). */
+  exceptionalLabels: string[];
+  /** Day-of-year of the last realized day (today, or Dec 31 for a past year). */
+  realizedDays: number;
+}
+
+const emptyCounts = (): Record<FilledLevel, number> => ({
+  "lvl-0": 0,
+  "lvl-1": 0,
+  "lvl-2": 0,
+  "lvl-3": 0,
+  "lvl-4": 0,
+  "lvl-neg": 0,
+});
+
+/** Monday-based day of week: 0 = Monday … 6 = Sunday (date-fns getDay is 0=Sunday). */
+const mondayDow = (date: Date): number => (getDay(date) + 6) % 7;
+
+/** Local calendar date as YYYY-MM-DD, built from Y/M/D parts (no timezone shift). */
+const isoOf = (date: Date): string => {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+};
+
+/**
+ * Maps a day's spend to a colour band on a linear [0, max] scale (COS-45):
+ * 0 € → lvl-0, then four equal bands up to `max` (the year's heaviest day).
+ */
+export const bandFor = (amount: number, max: number): FilledLevel => {
+  if (amount <= 0 || max <= 0) {
+    return "lvl-0";
+  }
+  const band = Math.min(4, Math.max(1, Math.ceil((amount / max) * 4)));
+  return `lvl-${band}` as FilledLevel;
+};
+
+/**
+ * Builds the daily-heatmap model from the real per-day totals (COS-45). Each
+ * calendar day of `year` is placed at [Monday-based dow][weeks-since-Jan-1];
+ * exceptional days (from the separate exceptionals feed) override the spend band
+ * as `lvl-neg`. Days past today (current year) stay `future`; grid slots outside
+ * the year are `empty`.
+ */
+export const buildHeatmap = (
+  year: number,
+  now: Date,
+  days: DailyStat[],
+  exceptionals: ExceptionalItem[],
+): HeatmapModel => {
+  const isCurrentYear = year === now.getFullYear();
+  const realizedDays = isCurrentYear ? getDayOfYear(now) : getDayOfYear(new Date(year, 11, 31));
+  const daysInYear = getDayOfYear(new Date(year, 11, 31));
+  const lastRealizedIso = isoOf(new Date(year, 0, realizedDays));
+
+  const totalByDate = new Map<string, number>();
+  for (const day of days) {
+    totalByDate.set(day.date, (totalByDate.get(day.date) ?? 0) + day.total);
+  }
+
+  const exceptionalDates = new Set<string>();
+  for (const item of exceptionals) {
+    exceptionalDates.add(item.date.slice(0, 10));
+  }
+
+  // Colour scale + busiest day: the heaviest realized, non-exceptional day.
+  // Future-dated spendings are ignored (they render as "future" cells), and
+  // exceptional days are shown separately (lvl-neg) — "busiest" is hors exceptionnel.
+  let scaleMax = 0;
+  let busiest: { amount: number; date: string } | null = null;
+  for (const [date, total] of totalByDate) {
+    if (date > lastRealizedIso || exceptionalDates.has(date)) {
+      continue;
+    }
+    if (total > scaleMax) {
+      scaleMax = total;
+      busiest = { amount: total, date };
+    }
+  }
+
+  // Column = weeks since the Monday of the week containing Jan 1. The grid is
+  // sized to the exact number of columns this year spans (52–54).
+  const firstOffset = mondayDow(new Date(year, 0, 1));
+  const weeks = Math.floor((daysInYear - 1 + firstOffset) / 7) + 1;
+  const rows: HeatmapLevel[][] = Array.from({ length: 7 }, () => Array<HeatmapLevel>(weeks).fill("empty"));
+  const realizedLevels: FilledLevel[] = []; // chronological, for counts + streak
+
+  for (let doy = 1; doy <= daysInYear; doy++) {
+    const date = new Date(year, 0, doy); // day-of-year → date (JS rolls the month over)
+    const col = Math.floor((doy - 1 + firstOffset) / 7);
+    const row = mondayDow(date);
+
+    if (doy > realizedDays) {
+      rows[row][col] = "future";
+      continue;
+    }
+
+    const iso = isoOf(date);
+    const level: FilledLevel = exceptionalDates.has(iso) ? "lvl-neg" : bandFor(totalByDate.get(iso) ?? 0, scaleMax);
+    realizedLevels.push(level);
+    rows[row][col] = level;
+  }
+
+  const counts = emptyCounts();
+  let run = 0;
+  let best = 0;
+  for (const level of realizedLevels) {
+    counts[level] += 1;
+    if (level === "lvl-0" || level === "lvl-1") {
+      run += 1;
+      best = Math.max(best, run);
+    } else {
+      run = 0;
+    }
+  }
+
+  const exceptionalLabels = exceptionals
+    .filter((item) => item.date.slice(0, 10) <= lastRealizedIso)
+    .sort((a, b) => Number(b.amount) - Number(a.amount))
+    .map((item) => item.label);
+
+  return { rows, weeks, counts, streak: best, scaleMax, busiest, exceptionalLabels, realizedDays };
+};
+
+/** Month labels positioned at the grid column of each month's first day. */
+export const monthColumns = (year: number): { name: string; col: number }[] => {
+  const names = ["jan", "fév", "mar", "avr", "mai", "jun", "jul", "aoû", "sep", "oct", "nov", "déc"];
+  const firstOffset = mondayDow(new Date(year, 0, 1));
+  return names.map((name, month) => {
+    const doy = getDayOfYear(new Date(year, month, 1));
+    const col = Math.floor((doy - 1 + firstOffset) / 7);
+    // +2: grid track 1 is the 16px dow-label column, so week 0 lives in track 2.
+    return { name, col: col + 2 };
+  });
+};

--- a/front/src/components/statistics/services/useDailyStats.tsx
+++ b/front/src/components/statistics/services/useDailyStats.tsx
@@ -1,0 +1,33 @@
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@src/helpers/useRequestHelper";
+import { DailyStatsResponseSchema } from "@src/schemas/stats";
+import { useQuery } from "react-query";
+
+import type { DailyStatsResponse } from "@src/schemas/stats";
+
+interface UseDailyStatsOptions {
+  year: number;
+}
+
+/**
+ * Per-day spending totals for the given year (COS-45). One request per year,
+ * cached like the other stats queries. Feeds the daily heatmap and, later, the
+ * day-of-week averages (COS-48) — both read the same daily series.
+ */
+const useDailyStats = ({ year }: UseDailyStatsOptions) => {
+  const { privateRequest } = useRequestHelper();
+
+  const getDailyStats = async (): Promise<DailyStatsResponse> => {
+    const response = await privateRequest(`/daily-stats?year=${year}`);
+    return DailyStatsResponseSchema.parse(response.data);
+  };
+
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.DAILY_STATS, year], getDailyStats, {
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return { dailyStats: data, isLoading, error };
+};
+
+export default useDailyStats;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 
+const numberLikeSchema = z.preprocess(
+  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
+  z.coerce.number().finite(),
+);
+
 const statisticsMonthEntrySchema = z.record(z.string(), z.union([z.string(), z.number()]));
 
 export const StatisticsResponseSchema = z.object({
@@ -20,3 +25,20 @@ export const ChartsCategorySchema = z.object({
 
 export type ChartsCategory = z.infer<typeof ChartsCategorySchema>;
 export const ChartsCategoryListSchema = z.array(ChartsCategorySchema);
+
+// Per-day spending totals for a year (COS-45) — GET /daily-stats. Sparse: one
+// entry per day that has at least one spending. Feeds the daily heatmap and the
+// day-of-week averages (COS-48).
+export const DailyStatSchema = z.object({
+  date: z.string(),
+  total: numberLikeSchema,
+  count: numberLikeSchema,
+});
+
+export type DailyStat = z.infer<typeof DailyStatSchema>;
+
+export const DailyStatsResponseSchema = z.object({
+  days: z.array(DailyStatSchema),
+});
+
+export type DailyStatsResponse = z.infer<typeof DailyStatsResponseSchema>;

--- a/nest-api/src/stats/dto/daily-stats-query.dto.ts
+++ b/nest-api/src/stats/dto/daily-stats-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class DailyStatsQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  year: string;
+}

--- a/nest-api/src/stats/dto/daily-stats-response.interface.ts
+++ b/nest-api/src/stats/dto/daily-stats-response.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * Per-day spending totals for a whole year (GET /daily-stats?year=YYYY).
+ *
+ * Sparse: only days with at least one spending appear in `days`. Amounts come
+ * from the one-off `Spendings` table only — recurrings and exceptionals live in
+ * their own tables — so the totals are naturally "hors récurrent / hors
+ * exceptionnel". Shared by the Statistics daily heatmap (COS-45) and the
+ * day-of-week averages (COS-48): one daily endpoint feeds both.
+ */
+export interface DailyStat {
+  /** ISO date (YYYY-MM-DD, UTC) of the day. */
+  date: string;
+  /** Sum of that day's spending amounts, rounded to the cent. */
+  total: number;
+  /** Number of spendings on that day. */
+  count: number;
+}
+
+export interface DailyStatsResponse {
+  /** Chronological, one entry per day that has at least one spending. */
+  days: DailyStat[];
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -4,6 +4,7 @@ import { WeeklyStatsQueryDto } from "@stats/dto/weekly-stats-query.dto";
 import { MonthlyStatsQueryDto } from "@stats/dto/monthly-stats-query.dto";
 import { StatisticsQueryDto } from "@stats/dto/statistics-query.dto";
 import { RegularMonthlyAverageQueryDto } from "@stats/dto/regular-monthly-average-query.dto";
+import { DailyStatsQueryDto } from "@stats/dto/daily-stats-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 
@@ -67,5 +68,16 @@ export class CategoryStatsController {
   @Get()
   async getCategoryStats(@GetUserId() userID: string) {
     return this.statsService.getCategoryStats(userID);
+  }
+}
+
+@Controller("daily-stats")
+@UseGuards(SessionAuthGuard)
+export class DailyStatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getDailyStats(@Query() query: DailyStatsQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getDailyStats(query.year, userID);
   }
 }

--- a/nest-api/src/stats/stats.module.ts
+++ b/nest-api/src/stats/stats.module.ts
@@ -6,6 +6,7 @@ import {
   StatisticsController,
   RegularMonthlyAverageController,
   CategoryStatsController,
+  DailyStatsController,
 } from "@stats/stats.controller";
 import { PrismaModule } from "../prisma/prisma.module";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
@@ -18,6 +19,7 @@ import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
     StatisticsController,
     RegularMonthlyAverageController,
     CategoryStatsController,
+    DailyStatsController,
   ],
   providers: [StatsService, SessionAuthGuard],
 })

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -86,3 +86,80 @@ describe("StatsService.getCategoryStats", () => {
     expect(result.byCategory[0]?.total).toBeCloseTo(99.99, 2);
   });
 });
+
+/**
+ * Unit tests for StatsService.getDailyStats — the per-day spending totals for a
+ * year backing the daily heatmap (COS-45) and the day-of-week averages (COS-48).
+ * Prisma is mocked; these assert the query range/scoping and the JS bucketing.
+ */
+describe("StatsService.getDailyStats", () => {
+  const makeService = (findManyResult: { date: Date; amount: unknown }[]) => {
+    const findMany = jest.fn().mockResolvedValue(findManyResult);
+    const prisma = { spendings: { findMany } } as unknown as never;
+    return { service: new StatsService(prisma), findMany };
+  };
+
+  it("returns no days and skips the query for a non-numeric year", async () => {
+    const { service, findMany } = makeService([]);
+
+    await expect(service.getDailyStats("not-a-year", "user-1")).resolves.toEqual({ days: [] });
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("queries the whole year as a half-open UTC range, scoped to the user", async () => {
+    const { service, findMany } = makeService([]);
+
+    await service.getDailyStats("2023", "user-1");
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        userID: "user-1",
+        date: { gte: new Date(Date.UTC(2023, 0, 1)), lt: new Date(Date.UTC(2024, 0, 1)) },
+      },
+      select: { date: true, amount: true },
+    });
+  });
+
+  it("buckets rows per day (sum + count), sorted chronologically", async () => {
+    const { service } = makeService([
+      { date: new Date("2023-03-15T00:00:00.000Z"), amount: 10 },
+      { date: new Date("2023-01-02T00:00:00.000Z"), amount: 5 },
+      { date: new Date("2023-03-15T00:00:00.000Z"), amount: 2.5 },
+    ]);
+
+    const result = await service.getDailyStats("2023", "user-1");
+
+    expect(result.days).toEqual([
+      { date: "2023-01-02", total: 5, count: 1 },
+      { date: "2023-03-15", total: 12.5, count: 2 },
+    ]);
+  });
+
+  it("keys days by their UTC calendar date, including the year's first and last day", async () => {
+    // Late-in-day UTC timestamps must still key to the UTC calendar date (not the
+    // local one) so day buckets are timezone-safe on any runner.
+    const { service } = makeService([
+      { date: new Date("2023-01-01T00:00:00.000Z"), amount: 5 },
+      { date: new Date("2023-12-31T23:59:59.000Z"), amount: 8 },
+    ]);
+
+    const result = await service.getDailyStats("2023", "user-1");
+
+    expect(result.days).toEqual([
+      { date: "2023-01-01", total: 5, count: 1 },
+      { date: "2023-12-31", total: 8, count: 1 },
+    ]);
+  });
+
+  it("coerces Prisma Decimal amounts and rounds the daily total to the cent", async () => {
+    const decimal = (v: string) => ({ toString: () => v });
+    const { service } = makeService([
+      { date: new Date("2023-02-01T00:00:00.000Z"), amount: decimal("10.004") },
+      { date: new Date("2023-02-01T00:00:00.000Z"), amount: decimal("0.004") },
+    ]);
+
+    const result = await service.getDailyStats("2023", "user-1");
+
+    expect(result.days).toEqual([{ date: "2023-02-01", total: 10.01, count: 2 }]);
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -5,9 +5,13 @@ import { PrismaService } from "../prisma/prisma.service";
 
 import type { StatisticsResponse } from "@stats/dto/statistics-response.interface";
 import type { CategoryStat, CategoryStatsResponse } from "@stats/dto/category-stats-response.interface";
+import type { DailyStat, DailyStatsResponse } from "@stats/dto/daily-stats-response.interface";
 
 /** Rounds to 2 decimal places to avoid JS float precision issues. */
 const roundCurrency = (n: number): number => Math.round(n);
+
+/** Rounds to the cent, killing the float noise of summed Prisma Decimals. */
+const round2 = (n: number): number => Math.round(n * 100) / 100;
 
 @Injectable()
 export class StatsService {
@@ -169,6 +173,43 @@ export class StatsService {
     }
 
     return { totalSpent, byCategory };
+  }
+
+  /**
+   * Per-day spending totals for a whole year (COS-45). Reads the one-off
+   * `Spendings` table only, so recurrings and exceptionals — which live in their
+   * own tables — are excluded by construction. Buckets in JS from a half-open
+   * UTC range (like the dashboard projection) so day keys are timezone-safe.
+   * Feeds the daily heatmap and the day-of-week averages (COS-48).
+   */
+  async getDailyStats(yearStr: string, userID: string): Promise<DailyStatsResponse> {
+    const year = parseInt(yearStr, 10);
+    if (Number.isNaN(year)) {
+      return { days: [] };
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const nextYearStart = new Date(Date.UTC(year + 1, 0, 1));
+
+    const rows = await this.prisma.spendings.findMany({
+      where: { userID, date: { gte: yearStart, lt: nextYearStart } },
+      select: { date: true, amount: true },
+    });
+
+    const byDay = new Map<string, { total: number; count: number }>();
+    for (const row of rows) {
+      const key = row.date.toISOString().slice(0, 10);
+      const bucket = byDay.get(key) ?? { total: 0, count: 0 };
+      bucket.total += Number(row.amount);
+      bucket.count += 1;
+      byDay.set(key, bucket);
+    }
+
+    const days: DailyStat[] = Array.from(byDay.entries())
+      .map(([date, { total, count }]) => ({ date, total: round2(total), count }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+
+    return { days };
   }
 
   async getStatistics(categoryIDs: string[], years: string[], userID: string): Promise<StatisticsResponse> {


### PR DESCRIPTION
Add GET /daily-stats?year=YYYY (per-day one-off totals date/total/count, UTC-bucketed) and rewrite the Statistics heatmap to use it instead of the LCG mock: real per-day colour levels (max-based linear), dynamic legend, real busiest-day/streak/distribution, and exceptional days overlaid from the existing exceptionals feed.

The endpoint returns count too, so it can be shared by the upcoming day-of-week averages (COS-48).