### PR TITLE
feat(stats): cursor-following tooltips (COS-121)

### DIFF
--- a/front/src/components/statistics/StatisticsFixedExpenses.tsx
+++ b/front/src/components/statistics/StatisticsFixedExpenses.tsx
@@ -9,6 +9,7 @@ import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MeterBar } from "@components/shared/MeterBar";
 import { Overline } from "@components/shared/Overline";
+import { CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro, splitAmount } from "@lib/format";
 import statistics from "@text/statistics";
 import format from "date-fns/format";
@@ -61,6 +62,7 @@ const Stat = ({
 /** "Dépenses fixes" — recurrings annualised, with per-line share and the
  *  year-to-date drawn amount. */
 const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesProps) => {
+  const rowTip = useCursorHover<{ monthly: string; day: number }>();
   if (recurrings.length === 0) return null;
 
   const { fixedExpenses: t } = statistics;
@@ -114,7 +116,15 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
               className="flex flex-col gap-2"
             >
               <div className="flex items-baseline gap-2.5 text-sm">
-                <span className="text-ink">{r.label}</span>
+                <span
+                  className="text-ink"
+                  role="img"
+                  aria-label={r.label}
+                  onMouseMove={rowTip.move({ monthly: euro(Number(r.amount)), day: chargeDay(r) })}
+                  onMouseLeave={rowTip.clear}
+                >
+                  {r.label}
+                </span>
                 <span className="num ml-auto font-medium text-ink">
                   {euro(annual)} €<small className="ml-1.5 text-2xs font-normal text-ink-4">{share}%</small>
                 </span>
@@ -130,6 +140,10 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
       </div>
 
       <p className="mt-5 border-t border-line-soft pt-4.5 text-xs text-ink-4">{t.note(list[0].label, topShare)}</p>
+
+      <CursorTooltip point={rowTip.hover}>
+        {rowTip.hover ? t.tooltip.row(rowTip.hover.data.monthly, rowTip.hover.data.day) : null}
+      </CursorTooltip>
     </GlowCard>
   );
 };

--- a/front/src/components/statistics/StatisticsForecast.tsx
+++ b/front/src/components/statistics/StatisticsForecast.tsx
@@ -7,7 +7,7 @@ import GlowCard from "@components/shared/GlowCard";
 import { Overline } from "@components/shared/Overline";
 import { exceptionalTotal } from "@components/statistics/helpers/exceptionalsData";
 import { yearTotal } from "@components/statistics/helpers/statisticsData";
-import { AnimatedNumber, ProgressTrack } from "@lib/dataviz";
+import { AnimatedNumber, CursorTooltip, ProgressTrack, useCursorHover } from "@lib/dataviz";
 import { euro, euro0 } from "@lib/format";
 import statisticsText from "@text/statistics";
 import format from "date-fns/format";
@@ -36,6 +36,7 @@ const StatisticsForecast = ({
   showExceptionals,
 }: StatisticsForecastProps) => {
   const [now] = useState(() => new Date());
+  const projectionTip = useCursorHover();
   const { forecast: t } = statisticsText;
   const data = statistics?.data;
 
@@ -86,7 +87,13 @@ const StatisticsForecast = ({
         </div>
       </div>
 
-      <div className="flex flex-col items-start gap-1 sm:items-end sm:text-right">
+      <div
+        className="flex flex-col items-start gap-1 sm:items-end sm:text-right"
+        role="img"
+        aria-label={t.projectionTitle}
+        onMouseMove={projectionTip.move()}
+        onMouseLeave={projectionTip.clear}
+      >
         <Overline>{t.projectionTitle}</Overline>
         <AnimatedNumber
           value={projection}
@@ -101,6 +108,13 @@ const StatisticsForecast = ({
           </span>{" "}
           {t.vsCompare(compareYear, euro0(compareTotal))}
         </span>
+        <CursorTooltip point={projectionTip.hover}>
+          {projectionTip.hover
+            ? isCurrent
+              ? t.tooltip.projectionModel(euro(perDay), daysInYear)
+              : t.tooltip.projectionActual
+            : null}
+        </CursorTooltip>
       </div>
     </GlowCard>
   );

--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -4,11 +4,16 @@ import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
 import { buildHeatmap, monthColumns } from "@components/statistics/helpers/heatmapData";
-import { euro0 } from "@lib/format";
+import { CursorTooltip, useCursorHover } from "@lib/dataviz";
+import { euro0, pct1 } from "@lib/format";
+import { cn } from "@lib/utils";
 import common from "@text/common";
 import statistics from "@text/statistics";
+import format from "date-fns/format";
+import fr from "date-fns/locale/fr";
+import parseISO from "date-fns/parseISO";
 
-import type { FilledLevel } from "@components/statistics/helpers/heatmapData";
+import type { FilledLevel, HeatmapCell } from "@components/statistics/helpers/heatmapData";
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
 import type { DailyStat } from "@src/schemas/stats";
 
@@ -43,9 +48,27 @@ const DIST_BG: Record<FilledLevel, string> = {
 
 const FILLED_ORDER: FilledLevel[] = ["lvl-0", "lvl-1", "lvl-2", "lvl-3", "lvl-4", "lvl-neg"];
 
+// The hover tooltip wears the hovered cell/segment colour. CELL_BG/DIST_BG use
+// alpha for the mid greens, so composite over the base surface to stay opaque;
+// TIP_FG keeps the text readable on each level (dark on the light bands).
+const tipBg = (color: string) => `linear-gradient(${color}, ${color}), var(--surface-base)`;
+// A slightly lifted tint of the cell colour: enough to separate the tooltip
+// from the page, subtle enough not to read as a bright ring on dark cells.
+const tipBorder = (color: string) => `color-mix(in oklch, ${color} 82%, var(--ink) 18%)`;
+const TIP_FG: Record<FilledLevel, string> = {
+  "lvl-0": "var(--ink)",
+  "lvl-1": "var(--ink)",
+  "lvl-2": "var(--ink)",
+  "lvl-3": "var(--surface-base)",
+  "lvl-4": "var(--surface-base)",
+  "lvl-neg": "var(--surface-base)",
+};
+
 /** "Carte de chaleur — quotidienne" — daily-spend intensity calendar (COS-45). */
 const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapProps) => {
   const { heatmap: t } = statistics;
+  const cellTip = useCursorHover<HeatmapCell>();
+  const distributionTip = useCursorHover<FilledLevel>();
 
   // Not yet loaded (or the request failed): show a placeholder rather than an
   // all-zero grid, which would read as a real, confident "sober all year".
@@ -64,7 +87,7 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
     );
   }
 
-  const { rows, weeks, counts, streak, scaleMax, busiest, exceptionalLabels, realizedDays } = buildHeatmap(
+  const { rows, cells, weeks, counts, streak, scaleMax, busiest, exceptionalLabels, realizedDays } = buildHeatmap(
     year,
     now,
     days,
@@ -80,7 +103,18 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
     { label: t.dist.intense, n: counts["lvl-4"], color: "var(--accent-strong)" },
     { label: t.dist.exceptional, n: counts["lvl-neg"], color: "var(--exc)" },
   ];
+  // Each colour band maps to its distribution group, so a hovered bar segment
+  // (two bands share a group) explains itself.
+  const groupForLevel: Record<FilledLevel, (typeof distGroups)[number]> = {
+    "lvl-0": distGroups[0],
+    "lvl-1": distGroups[0],
+    "lvl-2": distGroups[1],
+    "lvl-3": distGroups[1],
+    "lvl-4": distGroups[2],
+    "lvl-neg": distGroups[3],
+  };
   const peakLabels = exceptionalLabels.slice(0, 3).join(" · ");
+  const distShare = (n: number) => pct1(realizedDays > 0 ? (n / realizedDays) * 100 : 0);
 
   return (
     <GlowCard
@@ -108,10 +142,26 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
           ))}
         </div>
 
-        {/* grid */}
+        {/* grid — one hover handler on the container resolves the cell by position
+            (like StackedBar), so the tooltip follows the cursor across the grid. */}
         <div
           className="grid gap-0.5"
           style={{ gridTemplateColumns: gridColumns }}
+          role="img"
+          aria-label={t.title}
+          onMouseMove={(e) => {
+            const el = (e.target as HTMLElement).closest<HTMLElement>("[data-week]");
+            if (!el) {
+              return; // over a gap or the day-of-week label — keep the current tooltip
+            }
+            const cell = cells[Number(el.dataset.dow)]?.[Number(el.dataset.week)];
+            if (cell) {
+              cellTip.show(e.clientX, e.clientY, cell);
+            } else {
+              cellTip.clear(); // future / out-of-year cell
+            }
+          }}
+          onMouseLeave={cellTip.clear}
         >
           {rows.map((weekArr, dow) => (
             <div
@@ -120,20 +170,25 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
               className="contents"
             >
               <span className="num self-center pr-1 text-right text-3xs leading-3 text-ink-4">{DOW_LABELS[dow]}</span>
-              {weekArr.map((lvl, week) => (
-                <span
-                  // biome-ignore lint/suspicious/noArrayIndexKey: fixed 53-week grid, positional cell never reorders
-                  key={week}
-                  className="aspect-square min-h-[9px] rounded-xs"
-                  style={
-                    lvl === "future"
-                      ? { background: "transparent", border: "1px dashed var(--line)" }
-                      : lvl === "empty"
-                        ? { background: "transparent" }
-                        : { background: CELL_BG[lvl] }
-                  }
-                />
-              ))}
+              {weekArr.map((lvl, week) => {
+                const filled = lvl !== "future" && lvl !== "empty";
+                const style =
+                  lvl === "future"
+                    ? { background: "transparent", border: "1px dashed var(--line)" }
+                    : lvl === "empty"
+                      ? { background: "transparent" }
+                      : { background: CELL_BG[lvl] };
+                return (
+                  <span
+                    // biome-ignore lint/suspicious/noArrayIndexKey: fixed week grid, positional cell never reorders
+                    key={week}
+                    className={cn("aspect-square min-h-[9px] rounded-xs", filled && "transition hover:brightness-150")}
+                    style={style}
+                    data-dow={dow}
+                    data-week={week}
+                  />
+                );
+              })}
             </div>
           ))}
         </div>
@@ -169,12 +224,25 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
       <div className="mt-auto flex flex-col gap-5.5 border-t border-line-soft pt-5.5">
         <div>
           <div className="num mb-2.5 text-2xs uppercase tracking-caps text-ink-4">{t.distributionTitle}</div>
-          <div className="flex h-4 gap-0.5 overflow-hidden rounded-sm">
+          <div
+            className="flex h-4 gap-0.5 overflow-hidden rounded-sm"
+            role="img"
+            aria-label={t.distributionTitle}
+            onMouseMove={(e) => {
+              const el = (e.target as HTMLElement).closest<HTMLElement>("[data-level]");
+              if (el) {
+                distributionTip.show(e.clientX, e.clientY, el.dataset.level as FilledLevel);
+              }
+              // over a gap — keep the current tooltip; onMouseLeave clears
+            }}
+            onMouseLeave={distributionTip.clear}
+          >
             {FILLED_ORDER.filter((lvl) => counts[lvl] > 0).map((lvl) => (
               <span
                 key={lvl}
                 className="block h-full rounded-xs"
                 style={{ background: DIST_BG[lvl], flexGrow: counts[lvl], flexBasis: 0 }}
+                data-level={lvl}
               />
             ))}
           </div>
@@ -214,6 +282,44 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
           </div>
         </div>
       </div>
+
+      <CursorTooltip
+        point={cellTip.hover}
+        background={cellTip.hover ? tipBg(CELL_BG[cellTip.hover.data.level]) : undefined}
+        color={cellTip.hover ? TIP_FG[cellTip.hover.data.level] : undefined}
+        borderColor={cellTip.hover ? tipBorder(CELL_BG[cellTip.hover.data.level]) : undefined}
+      >
+        {cellTip.hover && (
+          <>
+            <div className="font-medium capitalize">
+              {format(parseISO(cellTip.hover.data.date), "EEE d MMM", { locale: fr })}
+            </div>
+            <div>{cellTip.hover.data.amount > 0 ? `${euro0(cellTip.hover.data.amount)} €` : t.tooltip.noSpend}</div>
+            {cellTip.hover.data.exceptionals.length > 0 && (
+              <div className="mt-1">
+                <div className="font-medium">{t.tooltip.exceptionalLead}</div>
+                {cellTip.hover.data.exceptionals.map((e) => (
+                  <div key={`${e.label}-${e.amount}`}>{t.tooltip.exceptional(e.label, euro0(e.amount))}</div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </CursorTooltip>
+
+      <CursorTooltip
+        point={distributionTip.hover}
+        background={distributionTip.hover ? tipBg(DIST_BG[distributionTip.hover.data]) : undefined}
+        color={distributionTip.hover ? TIP_FG[distributionTip.hover.data] : undefined}
+        borderColor={distributionTip.hover ? tipBorder(DIST_BG[distributionTip.hover.data]) : undefined}
+      >
+        {distributionTip.hover &&
+          t.tooltip.distSegment(
+            groupForLevel[distributionTip.hover.data].n,
+            groupForLevel[distributionTip.hover.data].label,
+            distShare(groupForLevel[distributionTip.hover.data].n),
+          )}
+      </CursorTooltip>
     </GlowCard>
   );
 };

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -17,9 +17,13 @@ import {
   yearTotal,
 } from "@components/statistics/helpers/statisticsData";
 import StatMiniChart from "@components/statistics/StatMiniChart";
+import { CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro0 } from "@lib/format";
 import { cn } from "@lib/utils";
 import statisticsText from "@text/statistics";
+import format from "date-fns/format";
+import fr from "date-fns/locale/fr";
+import parseISO from "date-fns/parseISO";
 import { useState } from "react";
 
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
@@ -64,6 +68,8 @@ const CmpRow = ({
   amount,
   regWidth,
   excWidth,
+  titleTooltip,
+  barTooltip,
 }: {
   tag: string;
   kind: "exc" | "reg";
@@ -72,39 +78,59 @@ const CmpRow = ({
   amount: number;
   regWidth: number;
   excWidth: number;
-}) => (
-  <div className="flex flex-col gap-1.5">
-    <div className="flex items-baseline gap-2">
-      <span
-        className={cn(
-          "num shrink-0 rounded-xs px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider",
-          kind === "exc" ? "bg-exc-bg text-exc" : "bg-accent-bg text-accent-strong",
-        )}
+  /** Optional hover detail for the (possibly truncated) title. */
+  titleTooltip?: React.ReactNode;
+  /** Optional hover detail for the regular/exceptional split bar. */
+  barTooltip?: React.ReactNode;
+}) => {
+  const rowTip = useCursorHover<"title" | "bar">();
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline gap-2">
+        <span
+          className={cn(
+            "num shrink-0 rounded-xs px-1.5 py-0.5 text-3xs font-semibold uppercase tracking-wider",
+            kind === "exc" ? "bg-exc-bg text-exc" : "bg-accent-bg text-accent-strong",
+          )}
+        >
+          {tag}
+        </span>
+        <span
+          className={cn(
+            "truncate",
+            titleVariant === "month" ? "text-2xs uppercase tracking-caps text-ink-3" : "text-sm text-ink-2",
+          )}
+          role="img"
+          aria-label={title}
+          onMouseMove={titleTooltip ? rowTip.move("title") : undefined}
+          onMouseLeave={titleTooltip ? rowTip.clear : undefined}
+        >
+          {title}
+        </span>
+        <span className="num ml-auto text-lg font-medium text-ink">{euro0(amount)} €</span>
+      </div>
+      <div
+        className="flex h-2 overflow-hidden rounded-xs bg-surface-hi"
+        role="img"
+        aria-label={tag}
+        onMouseMove={barTooltip ? rowTip.move("bar") : undefined}
+        onMouseLeave={barTooltip ? rowTip.clear : undefined}
       >
-        {tag}
-      </span>
-      <span
-        className={cn(
-          "truncate",
-          titleVariant === "month" ? "text-2xs uppercase tracking-caps text-ink-3" : "text-sm text-ink-2",
-        )}
-      >
-        {title}
-      </span>
-      <span className="num ml-auto text-lg font-medium text-ink">{euro0(amount)} €</span>
+        <span
+          style={{
+            width: `${Math.max(0, regWidth) * 100}%`,
+            background: "var(--accent-strong)",
+            opacity: 0.9,
+          }}
+        />
+        {excWidth > 0 && <span style={{ width: `${excWidth * 100}%`, background: "var(--exc)" }} />}
+      </div>
+      <CursorTooltip point={rowTip.hover}>
+        {rowTip.hover ? (rowTip.hover.data === "title" ? titleTooltip : barTooltip) : null}
+      </CursorTooltip>
     </div>
-    <div className="flex h-2 overflow-hidden rounded-xs bg-surface-hi">
-      <span
-        style={{
-          width: `${Math.max(0, regWidth) * 100}%`,
-          background: "var(--accent-strong)",
-          opacity: 0.9,
-        }}
-      />
-      {excWidth > 0 && <span style={{ width: `${excWidth * 100}%`, background: "var(--exc)" }} />}
-    </div>
-  </div>
-);
+  );
+};
 
 /** The four Statistiques KPI cards. Totals / averages / biggest month are real
  *  (from /statistics + /exceptionals); the "courante" biggest single expense in
@@ -118,6 +144,7 @@ const StatisticsKpis = ({
   showExceptionals,
 }: StatisticsKpisProps) => {
   const [now] = useState(() => new Date());
+  const compareTotalTip = useCursorHover();
 
   const { kpis: t } = statisticsText;
   const data = statistics?.data;
@@ -136,6 +163,8 @@ const StatisticsKpis = ({
 
   const deltaPct = compareTotal > 0 ? ((total - compareTotal) / compareTotal) * 100 : 0;
   const avgDelta = avg - compareAvg;
+  const totalDiff = total - compareTotal;
+  const totalDiffStr = `${totalDiff >= 0 ? "+" : "−"}${euro0(Math.abs(totalDiff))}`;
 
   // biggest month counting exceptionals vs regular-only
   const excYearTotal = exceptionalTotal(exceptionals);
@@ -156,9 +185,18 @@ const StatisticsKpis = ({
     <section className="grid grid-cols-1 gap-4 min-[520px]:grid-cols-2 min-[768px]:grid-cols-4">
       <Card label={t.totalSpent(year)}>
         <Value amount={total} />
-        <span className="text-xs text-ink-3">
+        <span
+          className="w-fit text-xs text-ink-3"
+          role="img"
+          aria-label={t.vsMonths(compareYear, months)}
+          onMouseMove={compareTotalTip.move()}
+          onMouseLeave={compareTotalTip.clear}
+        >
           <Delta down={deltaPct <= 0}>{Math.abs(Math.round(deltaPct))}%</Delta> {t.vsMonths(compareYear, months)}
         </span>
+        <CursorTooltip point={compareTotalTip.hover}>
+          {compareTotalTip.hover ? t.tooltip.total(compareYear, euro0(compareTotal), totalDiffStr, months) : null}
+        </CursorTooltip>
         <div className="mt-4">
           <StatMiniChart
             id="kpi-total"
@@ -194,6 +232,7 @@ const StatisticsKpis = ({
               amount={totalMonthly[totalIdx]}
               regWidth={regMonthly[totalIdx] / cmpScale}
               excWidth={excMonthly[totalIdx] / cmpScale}
+              barTooltip={statisticsText.regExcSplit(euro0(regMonthly[totalIdx]), euro0(excMonthly[totalIdx]))}
             />
           )}
           <CmpRow
@@ -218,6 +257,10 @@ const StatisticsKpis = ({
               amount={Number(topExc.amount)}
               regWidth={0}
               excWidth={Number(topExc.amount) / expenseScale}
+              titleTooltip={t.tooltip.expenseInfo(
+                cap(topExc.label),
+                format(parseISO(topExc.date), "d MMM yyyy", { locale: fr }),
+              )}
             />
           )}
           <CmpRow

--- a/front/src/components/statistics/StatisticsTopCategories.tsx
+++ b/front/src/components/statistics/StatisticsTopCategories.tsx
@@ -2,6 +2,7 @@
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
+import { CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro0 } from "@lib/format";
 import statistics from "@text/statistics";
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -14,6 +15,8 @@ export interface TopCategoryRow {
   value: number;
   /** Year-over-year change in %, or null when the category is new this year. */
   deltaPct: number | null;
+  /** The compare-year total for this category (0 when absent that year). */
+  compareValue: number;
 }
 
 interface StatisticsTopCategoriesProps {
@@ -21,70 +24,124 @@ interface StatisticsTopCategoriesProps {
   compareYear: number;
 }
 
-const Trend = ({ deltaPct }: { deltaPct: number | null }) => {
+const Trend = ({
+  deltaPct,
+  value,
+  compareValue,
+  compareYear,
+}: {
+  deltaPct: number | null;
+  value: number;
+  compareValue: number;
+  compareYear: number;
+}) => {
+  const trendTip = useCursorHover();
+  let inner: React.ReactNode;
   if (deltaPct == null) {
-    return <span className="text-ink-4">{t.new}</span>;
+    inner = <span className="text-ink-4">{t.new}</span>;
+  } else {
+    const rounded = Math.round(deltaPct);
+    if (rounded === 0) {
+      inner = <span className="text-ink-4">— 0%</span>;
+    } else {
+      // spending up = worse (red), down = better (green)
+      const up = rounded > 0;
+      inner = (
+        <span className={`inline-flex items-center gap-1 ${up ? "text-neg" : "text-accent-strong"}`}>
+          {up ? (
+            <ChevronUp
+              size={9}
+              strokeWidth={3}
+            />
+          ) : (
+            <ChevronDown
+              size={9}
+              strokeWidth={3}
+            />
+          )}
+          {up ? "+" : "−"}
+          {Math.abs(rounded)}%
+        </span>
+      );
+    }
   }
-  const rounded = Math.round(deltaPct);
-  if (rounded === 0) {
-    return <span className="text-ink-4">— 0%</span>;
-  }
-  // spending up = worse (red), down = better (green)
-  const up = rounded > 0;
+
+  const diff = value - compareValue;
+  const tooltip =
+    deltaPct == null
+      ? t.tooltip.newCategory(compareYear)
+      : t.tooltip.trend(compareYear, euro0(compareValue), `${diff >= 0 ? "+" : "−"}${euro0(Math.abs(diff))}`);
+
   return (
-    <span className={`inline-flex items-center gap-1 ${up ? "text-neg" : "text-accent-strong"}`}>
-      {up ? (
-        <ChevronUp
-          size={9}
-          strokeWidth={3}
-        />
-      ) : (
-        <ChevronDown
-          size={9}
-          strokeWidth={3}
-        />
-      )}
-      {up ? "+" : "−"}
-      {Math.abs(rounded)}%
-    </span>
+    <>
+      <span
+        role="img"
+        aria-label={tooltip}
+        onMouseMove={trendTip.move()}
+        onMouseLeave={trendTip.clear}
+      >
+        {inner}
+      </span>
+      <CursorTooltip point={trendTip.hover}>{trendTip.hover ? tooltip : null}</CursorTooltip>
+    </>
   );
 };
 
 /** "Top catégories" — the year's largest categories with their real
  *  year-over-year trend (all figures from /statistics). */
-const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesProps) => (
-  <GlowCard className="flex flex-col px-6 py-5.5">
-    <CardSectionHeader
-      title={t.title}
-      meta={t.meta(compareYear)}
-    />
+const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesProps) => {
+  const nameTip = useCursorHover<string>();
+  return (
+    <GlowCard className="flex flex-col px-6 py-5.5">
+      <CardSectionHeader
+        title={t.title}
+        meta={t.meta(compareYear)}
+      />
 
-    <div className="mt-4.5 flex flex-col">
-      <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-2xs font-medium uppercase tracking-caps text-ink-4">
-        <span />
-        <span>{t.colCategory}</span>
-        <span className="text-right">{t.colTotal}</span>
-        <span className="text-right">{t.colVs(compareYear)}</span>
+      <div className="mt-4.5 flex flex-col">
+        <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-2xs font-medium uppercase tracking-caps text-ink-4">
+          <span />
+          <span>{t.colCategory}</span>
+          <span className="text-right">{t.colTotal}</span>
+          <span className="text-right">{t.colVs(compareYear)}</span>
+        </div>
+
+        {rows.map((row) => (
+          <div
+            key={row.name}
+            className="grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line-soft py-2.5 text-sm last:border-b-0"
+          >
+            <span
+              className="size-2 rounded-xs"
+              style={{ background: row.color }}
+            />
+            <span
+              className="truncate capitalize text-ink"
+              role="img"
+              aria-label={row.name}
+              onMouseMove={nameTip.move(row.name)}
+              onMouseLeave={nameTip.clear}
+            >
+              {row.name}
+            </span>
+            <span className="num text-right font-medium text-ink">{euro0(row.value)} €</span>
+            <span className="num flex justify-end text-right text-xs">
+              <Trend
+                deltaPct={row.deltaPct}
+                value={row.value}
+                compareValue={row.compareValue}
+                compareYear={compareYear}
+              />
+            </span>
+          </div>
+        ))}
       </div>
 
-      {rows.map((row) => (
-        <div
-          key={row.name}
-          className="grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line-soft py-2.5 text-sm last:border-b-0"
-        >
-          <span
-            className="size-2 rounded-xs"
-            style={{ background: row.color }}
-          />
-          <span className="truncate capitalize text-ink">{row.name}</span>
-          <span className="num text-right font-medium text-ink">{euro0(row.value)} €</span>
-          <span className="num flex justify-end text-right text-xs">
-            <Trend deltaPct={row.deltaPct} />
-          </span>
-        </div>
-      ))}
-    </div>
-  </GlowCard>
-);
+      <CursorTooltip point={nameTip.hover}>
+        {nameTip.hover ? <span className="capitalize">{nameTip.hover.data}</span> : null}
+      </CursorTooltip>
+    </GlowCard>
+  );
+};
 
 export default StatisticsTopCategories;

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -71,6 +71,7 @@ const StatisticsView = () => {
         color: c.color,
         value: c.value,
         deltaPct: prev > 0 ? ((c.value - prev) / prev) * 100 : null,
+        compareValue: prev,
       };
     });
 

--- a/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
@@ -61,6 +61,19 @@ describe("buildHeatmap", () => {
     expect(rows[2][2]).toBe("future"); // Wed 01-11, past the realized window
   });
 
+  it("carries per-cell tooltip metadata; future and out-of-year slots stay null", () => {
+    const { cells } = buildHeatmap(2023, now, days, exceptionals);
+    expect(cells[0][1]).toEqual({ date: "2023-01-02", amount: 100, level: "lvl-4", exceptionals: [] });
+    expect(cells[3][1]).toEqual({
+      date: "2023-01-05",
+      amount: 0,
+      level: "lvl-neg",
+      exceptionals: [{ label: "ordinateur", amount: 800 }],
+    });
+    expect(cells[2][2]).toBeNull(); // 01-11, future
+    expect(cells[0][0]).toBeNull(); // out-of-year padding
+  });
+
   it("handles a year with no spending: no scale, no busiest day, every day sober", () => {
     const { scaleMax, busiest, counts, streak, realizedDays } = buildHeatmap(2023, new Date(2023, 5, 1), [], []);
     expect(scaleMax).toBe(0);

--- a/front/src/components/statistics/helpers/heatmapData.ts
+++ b/front/src/components/statistics/helpers/heatmapData.ts
@@ -7,9 +7,28 @@ import type { DailyStat } from "@src/schemas/stats";
 export type HeatmapLevel = "empty" | "future" | "lvl-0" | "lvl-1" | "lvl-2" | "lvl-3" | "lvl-4" | "lvl-neg";
 export type FilledLevel = Exclude<HeatmapLevel, "future" | "empty">;
 
+export interface HeatmapCellExceptional {
+  label: string;
+  /** Exceptional purchase amount in euros. */
+  amount: number;
+}
+
+export interface HeatmapCell {
+  /** Local calendar date, YYYY-MM-DD. */
+  date: string;
+  /** The day's regular spend total in euros; 0 when the day has no spending. */
+  amount: number;
+  /** Colour band for the day (lvl-neg on an exceptional day). */
+  level: FilledLevel;
+  /** Exceptional purchases on this day, biggest first; empty when none. */
+  exceptionals: HeatmapCellExceptional[];
+}
+
 export interface HeatmapModel {
   /** [dow 0=Mon..6=Sun][week 0..weeks-1]; "empty" = out-of-year padding, "future" = not yet reached. */
   rows: HeatmapLevel[][];
+  /** Per-slot tooltip meta, same [dow][week] indexing as `rows`; null for empty/future slots. */
+  cells: (HeatmapCell | null)[][];
   /** Number of week-columns this year actually spans (52–54, so the grid matches the calendar). */
   weeks: number;
   counts: Record<FilledLevel, number>;
@@ -79,9 +98,15 @@ export const buildHeatmap = (
     totalByDate.set(day.date, (totalByDate.get(day.date) ?? 0) + day.total);
   }
 
-  const exceptionalDates = new Set<string>();
+  const exceptionalsByDate = new Map<string, HeatmapCellExceptional[]>();
   for (const item of exceptionals) {
-    exceptionalDates.add(item.date.slice(0, 10));
+    const iso = item.date.slice(0, 10);
+    const list = exceptionalsByDate.get(iso) ?? [];
+    list.push({ label: item.label, amount: Number(item.amount) });
+    exceptionalsByDate.set(iso, list);
+  }
+  for (const list of exceptionalsByDate.values()) {
+    list.sort((a, b) => b.amount - a.amount);
   }
 
   // Colour scale + busiest day: the heaviest realized, non-exceptional day.
@@ -90,7 +115,7 @@ export const buildHeatmap = (
   let scaleMax = 0;
   let busiest: { amount: number; date: string } | null = null;
   for (const [date, total] of totalByDate) {
-    if (date > lastRealizedIso || exceptionalDates.has(date)) {
+    if (date > lastRealizedIso || exceptionalsByDate.has(date)) {
       continue;
     }
     if (total > scaleMax) {
@@ -104,6 +129,7 @@ export const buildHeatmap = (
   const firstOffset = mondayDow(new Date(year, 0, 1));
   const weeks = Math.floor((daysInYear - 1 + firstOffset) / 7) + 1;
   const rows: HeatmapLevel[][] = Array.from({ length: 7 }, () => Array<HeatmapLevel>(weeks).fill("empty"));
+  const cells: (HeatmapCell | null)[][] = Array.from({ length: 7 }, () => Array<HeatmapCell | null>(weeks).fill(null));
   const realizedLevels: FilledLevel[] = []; // chronological, for counts + streak
 
   for (let doy = 1; doy <= daysInYear; doy++) {
@@ -117,9 +143,12 @@ export const buildHeatmap = (
     }
 
     const iso = isoOf(date);
-    const level: FilledLevel = exceptionalDates.has(iso) ? "lvl-neg" : bandFor(totalByDate.get(iso) ?? 0, scaleMax);
+    const dayExceptionals = exceptionalsByDate.get(iso) ?? [];
+    const amount = totalByDate.get(iso) ?? 0;
+    const level: FilledLevel = dayExceptionals.length > 0 ? "lvl-neg" : bandFor(amount, scaleMax);
     realizedLevels.push(level);
     rows[row][col] = level;
+    cells[row][col] = { date: iso, amount, level, exceptionals: dayExceptionals };
   }
 
   const counts = emptyCounts();
@@ -140,7 +169,7 @@ export const buildHeatmap = (
     .sort((a, b) => Number(b.amount) - Number(a.amount))
     .map((item) => item.label);
 
-  return { rows, weeks, counts, streak: best, scaleMax, busiest, exceptionalLabels, realizedDays };
+  return { rows, cells, weeks, counts, streak: best, scaleMax, busiest, exceptionalLabels, realizedDays };
 };
 
 /** Month labels positioned at the grid column of each month's first day. */

--- a/front/src/lib/dataviz/CursorTooltip.tsx
+++ b/front/src/lib/dataviz/CursorTooltip.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { ReactNode } from "react";
+
+// Measure-then-position must run before paint to clamp the tooltip at the
+// viewport edge without a flash; fall back to useEffect on the server.
+const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+/** Tooltip appear/disappear fade duration (ms). Tune here — applies everywhere. */
+export const TOOLTIP_FADE_MS = 150;
+
+export interface CursorPoint {
+  /** Cursor X in viewport coords (clientX). */
+  x: number;
+  /** Cursor Y in viewport coords (clientY). */
+  y: number;
+}
+
+interface CursorTooltipProps {
+  /** Cursor position, or null when hidden (triggers the fade-out). */
+  point: CursorPoint | null;
+  children: ReactNode;
+  /** Full CSS background — defaults to the elevated surface skin (matches CategoryBarTooltip). */
+  background?: string;
+  /** Text colour, for use on a coloured background. */
+  color?: string;
+  /** Border colour — defaults to the hairline token. Pass a light tint of the
+   *  background for coloured tooltips so the edge stays coherent and visible. */
+  borderColor?: string;
+}
+
+interface Snapshot {
+  point: CursorPoint;
+  children: ReactNode;
+  background?: string;
+  color?: string;
+  borderColor?: string;
+}
+
+/**
+ * Generic mouse-following tooltip: portals to <body>, follows the cursor and
+ * clamps inside the viewport. Fades in on appear and out on disappear (opacity
+ * transition + delayed unmount) so it is never abrupt. It snapshots the last
+ * shown content, so consumers can render it unconditionally and pass
+ * `point={hover}` (null to hide) with the body guarded by the same hover.
+ */
+const CursorTooltip = ({ point, children, background, color, borderColor }: CursorTooltipProps) => {
+  const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
+  const [visible, setVisible] = useState(false);
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Shown → capture the latest content and reveal on the next frame (so a fresh
+  // mount transitions from opacity 0). Hidden → fade out, then unmount.
+  useEffect(() => {
+    if (point) {
+      setSnapshot({ point, children, background, color, borderColor });
+      const raf = requestAnimationFrame(() => setVisible(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    setVisible(false);
+    const id = setTimeout(() => setSnapshot(null), TOOLTIP_FADE_MS + 40);
+    return () => clearTimeout(id);
+  }, [point, children, background, color, borderColor]);
+
+  useIsomorphicLayoutEffect(() => {
+    const el = ref.current;
+    if (!snapshot || !el) {
+      return;
+    }
+    const { width, height } = el.getBoundingClientRect();
+    const GAP = 16;
+    const EDGE = 12;
+    let left = snapshot.point.x + GAP;
+    if (left + width + EDGE > window.innerWidth) {
+      left = snapshot.point.x - GAP - width;
+    }
+    let top = snapshot.point.y + GAP;
+    if (top + height + EDGE > window.innerHeight) {
+      top = snapshot.point.y - GAP - height;
+    }
+    setPos({ left: Math.max(EDGE, left), top: Math.max(EDGE, top) });
+  }, [snapshot]);
+
+  if (!snapshot) {
+    return null;
+  }
+
+  return createPortal(
+    <div
+      ref={ref}
+      className="num"
+      style={{
+        position: "fixed",
+        zIndex: 60,
+        pointerEvents: "none",
+        left: pos ? pos.left : snapshot.point.x + 16,
+        top: pos ? pos.top : snapshot.point.y + 16,
+        opacity: visible ? 1 : 0,
+        transition: `opacity ${TOOLTIP_FADE_MS}ms ease-out`,
+        maxWidth: 240,
+        padding: "8px 10px",
+        fontSize: "12px",
+        lineHeight: 1.35,
+        background:
+          snapshot.background ?? "color-mix(in oklch, var(--surface-elev, oklch(0.185 0.006 250)) 92%, transparent)",
+        color: snapshot.color ?? "var(--ink)",
+        border: `1px solid ${snapshot.borderColor ?? "var(--line, oklch(0.27 0.008 250))"}`,
+        borderRadius: "var(--r-md, 10px)",
+        boxShadow: "0 16px 40px oklch(0 0 0 / 0.5), inset 0 1px 0 oklch(1 0 0 / 0.05)",
+      }}
+    >
+      {snapshot.children}
+    </div>,
+    document.body,
+  );
+};
+
+export default CursorTooltip;

--- a/front/src/lib/dataviz/index.ts
+++ b/front/src/lib/dataviz/index.ts
@@ -9,11 +9,13 @@ export {
 export { default as BarChart } from "@lib/dataviz/BarChart";
 export { default as CategoryBarTooltip } from "@lib/dataviz/CategoryBarTooltip";
 export { default as CategoryTrend } from "@lib/dataviz/CategoryTrend";
+export { default as CursorTooltip } from "@lib/dataviz/CursorTooltip";
 export { default as Donut } from "@lib/dataviz/Donut";
 export { default as LineChart } from "@lib/dataviz/LineChart";
 export { default as ProgressTrack } from "@lib/dataviz/ProgressTrack";
 export { default as StackedBar } from "@lib/dataviz/StackedBar";
 export { default as useCountUp } from "@lib/dataviz/useCountUp";
+export { default as useCursorHover } from "@lib/dataviz/useCursorHover";
 export { default as useElementWidth } from "@lib/dataviz/useElementWidth";
 export { default as useTween } from "@lib/dataviz/useTween";
 

--- a/front/src/lib/dataviz/useCursorHover.ts
+++ b/front/src/lib/dataviz/useCursorHover.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import { useState } from "react";
+
+import type { CursorPoint } from "@lib/dataviz/CursorTooltip";
+
+export interface CursorHover<T> extends CursorPoint {
+  data: T;
+}
+
+/**
+ * Local hover state driving a {@link CursorTooltip}: viewport coords + an
+ * optional hovered datum. `T` defaults to `void` for tooltips whose content is
+ * fixed (no per-item data) — call `move()` / `show(x, y)` with no datum. For
+ * data-driven tooltips pass the datum type, e.g. `useCursorHover<HeatmapCell>()`.
+ */
+export default function useCursorHover<T = void>() {
+  const [hover, setHover] = useState<CursorHover<T> | null>(null);
+  /** onMouseMove handler bound to a fixed datum (one interactive element). */
+  const move = (data: T) => (e: { clientX: number; clientY: number }) => setHover({ x: e.clientX, y: e.clientY, data });
+  /** Imperative setter for delegated containers that resolve the datum per event. */
+  const show = (x: number, y: number, data: T) => setHover({ x, y, data });
+  const clear = () => setHover(null);
+  return { hover, move, show, clear };
+}

--- a/front/src/text/statistics.ts
+++ b/front/src/text/statistics.ts
@@ -2,6 +2,8 @@ const statistics = {
   // Shared "year-to-date" subtitle, rendered identically by the monthly and
   // category charts ("2026 · janv. → juil.").
   ytdSubtitle: (year: number, endMonth: string) => `${year} · janv. → ${endMonth}`,
+  // Shared tooltip line splitting a total into its regular vs exceptional parts.
+  regExcSplit: (regular: string, exceptional: string) => `Régulier ${regular} € · Exceptionnel ${exceptional} €`,
   miniChart: {
     ariaLabel: "Graphique d'évolution",
     averageShort: "moy.",
@@ -26,6 +28,12 @@ const statistics = {
       exceptional: "exceptionnelle",
       regular: "courante",
     },
+    tooltip: {
+      total: (compareYear: number, total: string, diff: string, months: number) =>
+        `${compareYear} : ${total} € · ${diff} € sur ${months} mois`,
+      avg: (exact: string, total: string, months: number) => `${exact} € · ${total} € ÷ ${months} mois`,
+      expenseInfo: (label: string, date: string) => `${label} · ${date}`,
+    },
   },
   forecast: {
     spentLabel: (asOf: string) => `Dépensé · 1er janv. → ${asOf}`,
@@ -35,6 +43,10 @@ const statistics = {
     projectionAxis: "— projection —",
     projectionTitle: "Projection fin d'année",
     vsCompare: (compareYear: number, total: string) => `vs ${compareYear} (${total} €)`,
+    tooltip: {
+      projectionModel: (perDay: string, days: number) => `Au rythme actuel · ${perDay} €/jour × ${days} jours`,
+      projectionActual: "Total réalisé sur l'année",
+    },
   },
   monthlyChart: {
     title: "Dépenses mensuelles",
@@ -56,6 +68,10 @@ const statistics = {
     colTotal: "Total",
     colVs: (compareYear: number) => `vs ${compareYear}`,
     new: "nouv.",
+    tooltip: {
+      trend: (compareYear: number, value: string, diff: string) => `${compareYear} : ${value} € · ${diff} €`,
+      newCategory: (compareYear: number) => `Nouvelle catégorie — absente en ${compareYear}`,
+    },
   },
   dayOfWeek: {
     title: "Dépenses par jour de la semaine",
@@ -70,6 +86,11 @@ const statistics = {
     drawn: (date: string) => `Déjà prélevé · au ${date}`,
     note: (topName: string, topShare: number) =>
       `Les dépenses fixes ne portent pas de catégorie — elles sont totalisées par nom. Le ${topName} représente à lui seul ${topShare} % du total annuel des récurrents.`,
+    tooltip: {
+      row: (monthly: string, day: number) => `${monthly} €/mois · prélevé le ${day}`,
+      drawn:
+        "Estimation : une ligne est comptée prélevée si son jour de prélèvement (jour du mois de la date de début) est passé.",
+    },
   },
   heatmap: {
     title: "Carte de chaleur — quotidienne",
@@ -87,6 +108,12 @@ const statistics = {
       common: "courantes",
       intense: "intenses",
       exceptional: "exceptionnelles",
+    },
+    tooltip: {
+      noSpend: "Aucune dépense",
+      exceptionalLead: "Exceptionnel",
+      exceptional: (label: string, amount: string) => `${label} · ${amount} €`,
+      distSegment: (n: number, label: string, pct: string) => `${n} journées ${label} · ${pct} %`,
     },
   },
 };


### PR DESCRIPTION
Add a shared CursorTooltip + useCursorHover (@lib/dataviz): a portaled, mouse-following tooltip that fades in/out (tunable via TOOLTIP_FADE_MS) and snapshots its content so the fade-out plays after the hover ends.

Wire hover tooltips across the Statistics page: heatmap cells and the distribution-bar segments (tooltip background = the hovered colour, + hover brightness on cells), plus KPIs, Forecast, Top categories and Fixed expenses. The charts and the day-of-week widget keep their own rendering (SVG dataviz / de-mocked in COS-48).