### PR TITLE
feat(stats): de-mock day-of-week averages (COS-48)

### DIFF
--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -1,80 +1,90 @@
 "use client";
 
-// MOCK — there is no per-transaction / day-of-week aggregation endpoint, so
-// these weekly averages are illustrative sample values.
-
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MeterBar } from "@components/shared/MeterBar";
+import overspendLevel from "@components/spendings/helpers/overspendLevel";
+import { weekdayAverages } from "@components/statistics/helpers/weekdayStats";
+import { euro, pct1 } from "@lib/format";
+import common from "@text/common";
 import statistics from "@text/statistics";
+
+import type { OverspendLevel } from "@components/spendings/helpers/overspendLevel";
+import type { DailyStat } from "@src/schemas/stats";
 
 const { dayOfWeek: t } = statistics;
 
-interface DayRow {
-  day: string;
-  width: number;
-  amount: string;
-  transactions: string;
-  weekend?: boolean;
+interface StatisticsDayOfWeekProps {
+  year: number;
+  now: Date;
+  /** Per-day spending totals for the year (COS-45); `undefined` while the request is in flight. */
+  days: DailyStat[] | undefined;
+  /** Weekly ceiling (real data) — its per-day share drives the colour ramp. */
+  weeklyCeiling: number | null;
 }
 
-const ROWS: DayRow[] = [
-  { day: "Lundi", width: 42, amount: "38,20 €", transactions: t.transactionsPerDay("3,2") },
-  { day: "Mardi", width: 48, amount: "44,10 €", transactions: t.transactionsPerDay("3,5") },
-  { day: "Mercredi", width: 55, amount: "50,80 €", transactions: t.transactionsPerDay("4,1") },
-  { day: "Jeudi", width: 51, amount: "46,90 €", transactions: t.transactionsPerDay("3,7") },
-  { day: "Vendredi", width: 64, amount: "58,60 €", transactions: t.transactionsPerDay("4,5") },
-  {
-    day: "Samedi",
-    width: 96,
-    amount: "88,40 €",
-    transactions: t.transactionsPerDay("5,2"),
-    weekend: true,
-  },
-  {
-    day: "Dimanche",
-    width: 78,
-    amount: "71,20 €",
-    transactions: t.transactionsPerDay("4,4"),
-    weekend: true,
-  },
-];
+// Bar fill by overspend level: green under the daily budget, orange over it, red
+// well over it — same orange-before-red philosophy as COS-34 / COS-36.
+const FILL: Record<OverspendLevel, string> = {
+  normal: "var(--bar-fill)",
+  warn: "linear-gradient(90deg, oklch(0.60 0.13 70), var(--warn))",
+  danger: "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.16 25))",
+};
 
-const WEEKDAY_FILL = "var(--bar-fill)";
-const WEEKEND_FILL = "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.16 25))";
+/** "Dépenses par jour de la semaine" — real weekday spending rhythm (COS-48). */
+const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOfWeekProps) => {
+  if (days === undefined) {
+    return (
+      <GlowCard
+        as="section"
+        className="px-6 py-5.5"
+      >
+        <CardSectionHeader
+          title={t.title}
+          meta={t.meta(year)}
+        />
+        <div className="grid place-items-center py-10 text-sm text-ink-4">{common.loading}</div>
+      </GlowCard>
+    );
+  }
 
-/** "Dépenses par jour de la semaine" — weekly spending rhythm (MOCK). */
-const StatisticsDayOfWeek = () => (
-  <GlowCard
-    as="section"
-    className="px-6 py-5.5"
-  >
-    <CardSectionHeader
-      title={t.title}
-      meta={t.meta}
-    />
+  const stats = weekdayAverages(days, year, now);
+  const maxAmount = Math.max(...stats.map((s) => s.avgAmount), 1);
+  // Per-weekday budget = the weekly ceiling spread over 7 days (COS-34 rule).
+  const dayBudget = weeklyCeiling != null && weeklyCeiling > 0 ? weeklyCeiling / 7 : null;
 
-    <div className="mt-4.5 flex flex-col gap-2">
-      {ROWS.map((row) => (
-        <div
-          key={row.day}
-          className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-sm"
-        >
-          <span className={row.weekend ? "text-ink" : "text-ink-2"}>{row.day}</span>
-          <MeterBar
-            value={row.width}
-            fill={row.weekend ? WEEKEND_FILL : WEEKDAY_FILL}
-            height={22}
-            opacity={0.85}
-          />
-          <span className="num text-right font-medium text-ink">
-            {row.amount}
-            <small className="block text-2xs font-normal text-ink-4">{row.transactions}</small>
-          </span>
-        </div>
-      ))}
-    </div>
-  </GlowCard>
-);
+  return (
+    <GlowCard
+      as="section"
+      className="px-6 py-5.5"
+    >
+      <CardSectionHeader
+        title={t.title}
+        meta={t.meta(year)}
+      />
+
+      <div className="mt-4.5 flex flex-col gap-2">
+        {stats.map((s, dow) => (
+          <div
+            key={t.days[dow]}
+            className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-sm"
+          >
+            <span className="text-ink-2">{t.days[dow]}</span>
+            <MeterBar
+              value={(s.avgAmount / maxAmount) * 100}
+              fill={FILL[overspendLevel(s.avgAmount, dayBudget)]}
+              height={22}
+              opacity={0.85}
+            />
+            <span className="num text-right font-medium text-ink">
+              {euro(s.avgAmount)} €
+              <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
+            </span>
+          </div>
+        ))}
+      </div>
+    </GlowCard>
+  );
+};
 
 export default StatisticsDayOfWeek;

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -170,7 +170,12 @@ const StatisticsView = () => {
         now={now}
       />
 
-      <StatisticsDayOfWeek />
+      <StatisticsDayOfWeek
+        year={selectedYear}
+        now={now}
+        days={dailyStats?.days}
+        weeklyCeiling={dashboard.get.data?.initialCeiling ?? null}
+      />
     </div>
   );
 };

--- a/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
@@ -1,0 +1,36 @@
+import { weekdayAverages } from "@components/statistics/helpers/weekdayStats";
+
+import type { DailyStat } from "@src/schemas/stats";
+
+const day = (date: string, total: number, count: number): DailyStat => ({ date, total, count });
+
+describe("weekdayAverages", () => {
+  // Current year, only Jan 1–8 realized. Jan 1 2023 is a Sunday, so the window
+  // covers each weekday once and Sunday twice — a small, deterministic base.
+  const now = new Date(2023, 0, 8);
+  const days = [
+    day("2023-01-02", 100, 2), // Monday
+    day("2023-01-01", 10, 1), // Sunday
+    day("2023-01-08", 30, 1), // Sunday
+    day("2023-06-01", 999, 9), // future (excluded)
+  ];
+
+  it("averages amount and tx per weekday over the weekday's real occurrences", () => {
+    const result = weekdayAverages(days, 2023, now);
+    expect(result[0]).toEqual({ avgAmount: 100, avgTx: 2 }); // Monday: 100 over 1 occurrence
+    expect(result[6]).toEqual({ avgAmount: 20, avgTx: 1 }); // Sunday: (10+30)/2, (1+1)/2
+    expect(result[1]).toEqual({ avgAmount: 0, avgTx: 0 }); // Tuesday: no spending
+  });
+
+  it("excludes future-dated spendings from the averages", () => {
+    const result = weekdayAverages(days, 2023, now);
+    // 2023-06-01 (Thursday, index 3) is in the future → must not inflate Thursday.
+    expect(result[3]).toEqual({ avgAmount: 0, avgTx: 0 });
+  });
+
+  it("returns zeros for every weekday when there is no spending", () => {
+    const result = weekdayAverages([], 2023, new Date(2023, 5, 1));
+    expect(result).toHaveLength(7);
+    expect(result.every((s) => s.avgAmount === 0 && s.avgTx === 0)).toBe(true);
+  });
+});

--- a/front/src/components/statistics/helpers/weekdayStats.ts
+++ b/front/src/components/statistics/helpers/weekdayStats.ts
@@ -1,0 +1,56 @@
+import getDay from "date-fns/getDay";
+import getDayOfYear from "date-fns/getDayOfYear";
+import parseISO from "date-fns/parseISO";
+
+import type { DailyStat } from "@src/schemas/stats";
+
+export interface WeekdayStat {
+  /** Average spend on that weekday over the year (0 when the weekday never occurred). */
+  avgAmount: number;
+  /** Average number of transactions on that weekday. */
+  avgTx: number;
+}
+
+/** Monday-based day of week: 0 = Monday … 6 = Sunday (date-fns getDay is 0=Sunday). */
+const mondayDow = (date: Date): number => (getDay(date) + 6) % 7;
+
+/** Local calendar date as YYYY-MM-DD, built from Y/M/D parts (no timezone shift). */
+const isoOf = (date: Date): string => {
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${date.getFullYear()}-${month}-${day}`;
+};
+
+/**
+ * Average spend + transaction count per weekday (Mon..Sun) over the realized part
+ * of `year`, from the shared /daily-stats series (COS-45, COS-48). Zero-spend
+ * days count toward the average: the sparse `days` only carries spending days, so
+ * the denominator is each weekday's real occurrence count (not `days.length`).
+ * Future-dated spendings (current year) are excluded, matching the heatmap.
+ */
+export function weekdayAverages(days: DailyStat[], year: number, now: Date): WeekdayStat[] {
+  const isCurrentYear = year === now.getFullYear();
+  const realizedDays = isCurrentYear ? getDayOfYear(now) : getDayOfYear(new Date(year, 11, 31));
+  const lastRealizedIso = isoOf(new Date(year, 0, realizedDays));
+
+  const occurrences = new Array<number>(7).fill(0);
+  for (let doy = 1; doy <= realizedDays; doy++) {
+    occurrences[mondayDow(new Date(year, 0, doy))] += 1;
+  }
+
+  const sumAmount = new Array<number>(7).fill(0);
+  const sumTx = new Array<number>(7).fill(0);
+  for (const day of days) {
+    if (day.date.slice(0, 10) > lastRealizedIso) {
+      continue; // future-dated spending
+    }
+    const w = mondayDow(parseISO(day.date));
+    sumAmount[w] += day.total;
+    sumTx[w] += day.count;
+  }
+
+  return occurrences.map((occ, w) => ({
+    avgAmount: occ > 0 ? sumAmount[w] / occ : 0,
+    avgTx: occ > 0 ? sumTx[w] / occ : 0,
+  }));
+}

--- a/front/src/text/statistics.ts
+++ b/front/src/text/statistics.ts
@@ -74,8 +74,9 @@ const statistics = {
     },
   },
   dayOfWeek: {
-    title: "Dépenses par jour de la semaine",
-    meta: "moyenne sur 12 mois",
+    title: "Dépenses par jour de la semaine (moyenne sur l'année)",
+    meta: (year: number) => `${year}`,
+    days: ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
     transactionsPerDay: (value: string) => `${value} transactions/j`,
   },
   fixedExpenses: {


### PR DESCRIPTION
Replace the hard-coded ROWS mock with real per-weekday averages, aggregated client-side from the shared /daily-stats series (COS-45): average amount + tx count per weekday over the realized part of the year.

Colour ramp green -> orange -> red via overspendLevel (daily budget = weekly ceiling / 7), consistent with COS-34/36; weekend is no longer a colour criterion. Adds the weekdayAverages helper and its tests.