### PR TITLE
feat(stats): sticky filter toolbar (COS-122)

### DIFF
--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -97,21 +97,29 @@ const StatisticsView = () => {
 
   return (
     <div className="flex flex-col gap-4">
-      <StatisticsFilters
-        years={yearOptions(currentYear)}
-        selectedYear={selectedYear}
-        onSelectYear={handleSelectYear}
-        compareEnabled={compareEnabled}
-        onToggleCompare={setCompareEnabled}
-        compareYear={compareYear}
-        onSelectCompareYear={setCompareYear}
-        showExceptionals={showExceptionals}
-        onToggleExceptionals={setShowExceptionals}
-        categories={categories}
-        selectedCategoryIds={selectedCategoryIds}
-        onToggleCategory={toggleCategory}
-        maxCategories={MAX_CATEGORIES}
-      />
+      {/* Filter bar as its own bordered sticky card. Dépenses keeps its full-bleed
+          .sp-sticky-zone band (it needs the gutter bleed for the timeline cards'
+          rings/glows); Stats' toolbar stands alone, so a contained card reads
+          better — the two look close but aren't pixel-identical (accepted). Shadow
+          is the shared --shadow-sticky token. `-mt-7` swallows the header's mb-7 to
+          sit tight; `before` seals the seam above, as the KPI cards scroll behind. */}
+      <div className="rounded-xl border border-line bg-surface-elev px-4 py-2.5 shadow-sticky md:sticky md:top-[76px] md:z-30 md:-mt-7 md:before:pointer-events-none md:before:absolute md:before:inset-x-0 md:before:bottom-full md:before:h-16 md:before:bg-surface-base md:before:content-['']">
+        <StatisticsFilters
+          years={yearOptions(currentYear)}
+          selectedYear={selectedYear}
+          onSelectYear={handleSelectYear}
+          compareEnabled={compareEnabled}
+          onToggleCompare={setCompareEnabled}
+          compareYear={compareYear}
+          onSelectCompareYear={setCompareYear}
+          showExceptionals={showExceptionals}
+          onToggleExceptionals={setShowExceptionals}
+          categories={categories}
+          selectedCategoryIds={selectedCategoryIds}
+          onToggleCategory={toggleCategory}
+          maxCategories={MAX_CATEGORIES}
+        />
+      </div>
 
       <StatisticsKpis
         statistics={statistics}

--- a/front/styles/components/spendings.css
+++ b/front/styles/components/spendings.css
@@ -150,12 +150,11 @@
        pane unmounts on any week with no categories (rows=[] → null), and the
        summary that then ends the band has no shadow of its own — anchoring it
        here keeps the edge drawn whatever the last widget happens to be.
-       --shadow-float (not --shadow-header, the token .pfa-hdr uses for the same
-       pinned job) because it is the inset-free drop: --shadow-header's
-       `inset 0 1px 0` highlight would paint a 1px seam across the band's top
-       edge, which lands in the open right below the header rather than behind
-       it. Its 0.35 alpha separates at least as well. */
-    box-shadow: var(--shadow-float);
+       --shadow-sticky = the DS token for pinned-bar separation (COS-122,
+       tokens/elevation.css), shared with the Statistiques toolbar. Inset-free
+       on purpose: an inset highlight (like --shadow-header's) would paint a 1px
+       seam across the band's top edge, out in the open below the header. */
+    box-shadow: var(--shadow-sticky);
     /* Header ↔ search gap, owned here rather than by the header's own mb-7:
        the negative margin swallows that 28px whole (leaving other pages
        untouched), and the padding re-adds the gap we actually want — 12px, the

--- a/front/styles/tokens/elevation.css
+++ b/front/styles/tokens/elevation.css
@@ -4,6 +4,13 @@
  * `--shadow-*` custom property (the CSS partials use `var(--shadow-*)`). */
 @theme {
   --shadow-float: 0 10px 30px oklch(0 0 0 / 0.35);
+  /* Pinned/sticky bar separation (COS-122). Two layers so it reads on the
+     near-black surfaces a bar pins over: a tight, dark near-drop that draws a
+     defined edge right under the bar, plus a soft far-drop for depth. Shared by
+     the sticky toolbar/band on Statistiques and Dépenses (reusable for any
+     pinned strip). Inset-free on purpose — an `inset 0 1px 0` highlight would
+     draw a 1px seam across the bar's top. */
+  --shadow-sticky: 0 6px 16px -3px oklch(0 0 0 / 0.6), 0 18px 36px -12px oklch(0 0 0 / 0.5);
   --shadow-card: 0 12px 32px oklch(0 0 0 / 0.26), inset 0 1px 0 oklch(1 0 0 / 0.045);
   --shadow-header: 0 14px 36px oklch(0 0 0 / 0.32), inset 0 1px 0 oklch(1 0 0 / 0.06);
   --shadow-card-hover: 0 18px 42px oklch(0 0 0 / 0.36), inset 0 1px 0 oklch(1 0 0 / 0.07);


### PR DESCRIPTION
Pin the Statistiques filter bar under the header while the page scrolls (desktop only), as a bordered sticky card sealed at the top so the KPI cards scrolling behind it don't show through.

Add a --shadow-sticky DS token for pinned-bar separation; the Depenses sticky band now uses it too so both share one shadow. Depenses stays a full-bleed band (keeps its gutter bleed for the timeline cards' rings/glows), so the two look close but aren't pixel-identical by design.