### PR TITLE
refactor(stats): heatmap level constants (COS-125)

### DIFF
--- a/front/src/components/statistics/StatisticsHeatmap.tsx
+++ b/front/src/components/statistics/StatisticsHeatmap.tsx
@@ -3,7 +3,7 @@
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
-import { buildHeatmap, monthColumns } from "@components/statistics/helpers/heatmapData";
+import { buildHeatmap, LEVEL, monthColumns, SPEND_BANDS } from "@components/statistics/helpers/heatmapData";
 import { CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro0, pct1 } from "@lib/format";
 import { cn } from "@lib/utils";
@@ -29,24 +29,24 @@ interface StatisticsHeatmapProps {
 const DOW_LABELS = ["lun", "", "mer", "", "ven", "", "dim"];
 
 const CELL_BG: Record<FilledLevel, string> = {
-  "lvl-0": "oklch(0.20 0.006 250)",
-  "lvl-1": "oklch(0.40 0.05 148 / 0.4)",
-  "lvl-2": "oklch(0.55 0.08 148 / 0.6)",
-  "lvl-3": "oklch(0.70 0.10 148 / 0.8)",
-  "lvl-4": "var(--accent-strong)",
-  "lvl-neg": "var(--exc)",
+  [LEVEL.ZERO]: "oklch(0.20 0.006 250)",
+  [LEVEL.ONE]: "oklch(0.40 0.05 148 / 0.4)",
+  [LEVEL.TWO]: "oklch(0.55 0.08 148 / 0.6)",
+  [LEVEL.THREE]: "oklch(0.70 0.10 148 / 0.8)",
+  [LEVEL.FOUR]: "var(--accent-strong)",
+  [LEVEL.NEG]: "var(--exc)",
 };
 
 const DIST_BG: Record<FilledLevel, string> = {
-  "lvl-0": "oklch(0.20 0.006 250)",
-  "lvl-1": "oklch(0.40 0.05 148 / 0.45)",
-  "lvl-2": "oklch(0.55 0.08 148 / 0.7)",
-  "lvl-3": "oklch(0.70 0.10 148 / 0.85)",
-  "lvl-4": "var(--accent-strong)",
-  "lvl-neg": "var(--exc)",
+  [LEVEL.ZERO]: "oklch(0.20 0.006 250)",
+  [LEVEL.ONE]: "oklch(0.40 0.05 148 / 0.45)",
+  [LEVEL.TWO]: "oklch(0.55 0.08 148 / 0.7)",
+  [LEVEL.THREE]: "oklch(0.70 0.10 148 / 0.85)",
+  [LEVEL.FOUR]: "var(--accent-strong)",
+  [LEVEL.NEG]: "var(--exc)",
 };
 
-const FILLED_ORDER: FilledLevel[] = ["lvl-0", "lvl-1", "lvl-2", "lvl-3", "lvl-4", "lvl-neg"];
+const FILLED_ORDER: FilledLevel[] = [...SPEND_BANDS, LEVEL.NEG];
 
 // The hover tooltip wears the hovered cell/segment colour. CELL_BG/DIST_BG use
 // alpha for the mid greens, so composite over the base surface to stay opaque;
@@ -56,12 +56,12 @@ const tipBg = (color: string) => `linear-gradient(${color}, ${color}), var(--sur
 // from the page, subtle enough not to read as a bright ring on dark cells.
 const tipBorder = (color: string) => `color-mix(in oklch, ${color} 82%, var(--ink) 18%)`;
 const TIP_FG: Record<FilledLevel, string> = {
-  "lvl-0": "var(--ink)",
-  "lvl-1": "var(--ink)",
-  "lvl-2": "var(--ink)",
-  "lvl-3": "var(--surface-base)",
-  "lvl-4": "var(--surface-base)",
-  "lvl-neg": "var(--surface-base)",
+  [LEVEL.ZERO]: "var(--ink)",
+  [LEVEL.ONE]: "var(--ink)",
+  [LEVEL.TWO]: "var(--ink)",
+  [LEVEL.THREE]: "var(--surface-base)",
+  [LEVEL.FOUR]: "var(--surface-base)",
+  [LEVEL.NEG]: "var(--surface-base)",
 };
 
 /** "Carte de chaleur — quotidienne" — daily-spend intensity calendar (COS-45). */
@@ -95,23 +95,23 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
   );
 
   const gridColumns = `16px repeat(${weeks}, minmax(0, 1fr))`;
-  const soberDays = counts["lvl-0"] + counts["lvl-1"];
-  const commonDays = counts["lvl-2"] + counts["lvl-3"];
+  const soberDays = counts[LEVEL.ZERO] + counts[LEVEL.ONE];
+  const commonDays = counts[LEVEL.TWO] + counts[LEVEL.THREE];
   const distGroups = [
     { label: t.dist.sober, n: soberDays, color: "oklch(0.45 0.06 148 / 0.7)" },
     { label: t.dist.common, n: commonDays, color: "oklch(0.70 0.10 148 / 0.85)" },
-    { label: t.dist.intense, n: counts["lvl-4"], color: "var(--accent-strong)" },
-    { label: t.dist.exceptional, n: counts["lvl-neg"], color: "var(--exc)" },
+    { label: t.dist.intense, n: counts[LEVEL.FOUR], color: "var(--accent-strong)" },
+    { label: t.dist.exceptional, n: counts[LEVEL.NEG], color: "var(--exc)" },
   ];
   // Each colour band maps to its distribution group, so a hovered bar segment
   // (two bands share a group) explains itself.
   const groupForLevel: Record<FilledLevel, (typeof distGroups)[number]> = {
-    "lvl-0": distGroups[0],
-    "lvl-1": distGroups[0],
-    "lvl-2": distGroups[1],
-    "lvl-3": distGroups[1],
-    "lvl-4": distGroups[2],
-    "lvl-neg": distGroups[3],
+    [LEVEL.ZERO]: distGroups[0],
+    [LEVEL.ONE]: distGroups[0],
+    [LEVEL.TWO]: distGroups[1],
+    [LEVEL.THREE]: distGroups[1],
+    [LEVEL.FOUR]: distGroups[2],
+    [LEVEL.NEG]: distGroups[3],
   };
   const peakLabels = exceptionalLabels.slice(0, 3).join(" · ");
   const distShare = (n: number) => pct1(realizedDays > 0 ? (n / realizedDays) * 100 : 0);
@@ -171,11 +171,11 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
             >
               <span className="num self-center pr-1 text-right text-3xs leading-3 text-ink-4">{DOW_LABELS[dow]}</span>
               {weekArr.map((lvl, week) => {
-                const filled = lvl !== "future" && lvl !== "empty";
+                const filled = lvl !== LEVEL.FUTURE && lvl !== LEVEL.EMPTY;
                 const style =
-                  lvl === "future"
+                  lvl === LEVEL.FUTURE
                     ? { background: "transparent", border: "1px dashed var(--line)" }
-                    : lvl === "empty"
+                    : lvl === LEVEL.EMPTY
                       ? { background: "transparent" }
                       : { background: CELL_BG[lvl] };
                 return (
@@ -197,7 +197,7 @@ const StatisticsHeatmap = ({ year, now, days, exceptionals }: StatisticsHeatmapP
         <div className="num mt-4 flex items-center gap-2 text-2xs text-ink-4">
           <span>0 €</span>
           <span className="flex gap-0.5">
-            {(["lvl-0", "lvl-1", "lvl-2", "lvl-3", "lvl-4"] as FilledLevel[]).map((lvl) => (
+            {SPEND_BANDS.map((lvl) => (
               <span
                 key={lvl}
                 className="size-2.5 rounded-xs"

--- a/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/heatmapData.test.ts
@@ -1,4 +1,4 @@
-import { bandFor, buildHeatmap } from "@components/statistics/helpers/heatmapData";
+import { bandFor, buildHeatmap, LEVEL } from "@components/statistics/helpers/heatmapData";
 
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
 import type { DailyStat } from "@src/schemas/stats";
@@ -9,18 +9,18 @@ const exc = (date: string, amount: number, label: string): ExceptionalItem =>
 
 describe("bandFor", () => {
   it("is lvl-0 at or below zero, or when there is no scale", () => {
-    expect(bandFor(0, 100)).toBe("lvl-0");
-    expect(bandFor(-5, 100)).toBe("lvl-0");
-    expect(bandFor(50, 0)).toBe("lvl-0");
+    expect(bandFor(0, 100)).toBe(LEVEL.ZERO);
+    expect(bandFor(-5, 100)).toBe(LEVEL.ZERO);
+    expect(bandFor(50, 0)).toBe(LEVEL.ZERO);
   });
 
   it("spreads positive amounts over four bands up to the max", () => {
-    expect(bandFor(1, 100)).toBe("lvl-1");
-    expect(bandFor(25, 100)).toBe("lvl-1");
-    expect(bandFor(26, 100)).toBe("lvl-2");
-    expect(bandFor(50, 100)).toBe("lvl-2");
-    expect(bandFor(75, 100)).toBe("lvl-3");
-    expect(bandFor(100, 100)).toBe("lvl-4");
+    expect(bandFor(1, 100)).toBe(LEVEL.ONE);
+    expect(bandFor(25, 100)).toBe(LEVEL.ONE);
+    expect(bandFor(26, 100)).toBe(LEVEL.TWO);
+    expect(bandFor(50, 100)).toBe(LEVEL.TWO);
+    expect(bandFor(75, 100)).toBe(LEVEL.THREE);
+    expect(bandFor(100, 100)).toBe(LEVEL.FOUR);
   });
 });
 
@@ -39,7 +39,14 @@ describe("buildHeatmap", () => {
 
   it("counts realized days by level, exceptional days overriding the spend band", () => {
     const { counts } = buildHeatmap(2023, now, days, exceptionals);
-    expect(counts).toEqual({ "lvl-0": 6, "lvl-1": 1, "lvl-2": 0, "lvl-3": 0, "lvl-4": 1, "lvl-neg": 2 });
+    expect(counts).toEqual({
+      [LEVEL.ZERO]: 6,
+      [LEVEL.ONE]: 1,
+      [LEVEL.TWO]: 0,
+      [LEVEL.THREE]: 0,
+      [LEVEL.FOUR]: 1,
+      [LEVEL.NEG]: 2,
+    });
   });
 
   it("measures the longest run of consecutive sober (lvl-0/lvl-1) days", () => {
@@ -55,19 +62,19 @@ describe("buildHeatmap", () => {
 
   it("places days on the calendar grid (Jan 1 2023 = Sunday) and pads/futures the rest", () => {
     const { rows } = buildHeatmap(2023, now, days, exceptionals);
-    expect(rows[6][0]).toBe("lvl-0"); // Sun 01-01
-    expect(rows[0][1]).toBe("lvl-4"); // Mon 01-02 (heaviest day)
-    expect(rows[0][0]).toBe("empty"); // Mon of week 0 = 2022-12-26, out of year
-    expect(rows[2][2]).toBe("future"); // Wed 01-11, past the realized window
+    expect(rows[6][0]).toBe(LEVEL.ZERO); // Sun 01-01
+    expect(rows[0][1]).toBe(LEVEL.FOUR); // Mon 01-02 (heaviest day)
+    expect(rows[0][0]).toBe(LEVEL.EMPTY); // Mon of week 0 = 2022-12-26, out of year
+    expect(rows[2][2]).toBe(LEVEL.FUTURE); // Wed 01-11, past the realized window
   });
 
   it("carries per-cell tooltip metadata; future and out-of-year slots stay null", () => {
     const { cells } = buildHeatmap(2023, now, days, exceptionals);
-    expect(cells[0][1]).toEqual({ date: "2023-01-02", amount: 100, level: "lvl-4", exceptionals: [] });
+    expect(cells[0][1]).toEqual({ date: "2023-01-02", amount: 100, level: LEVEL.FOUR, exceptionals: [] });
     expect(cells[3][1]).toEqual({
       date: "2023-01-05",
       amount: 0,
-      level: "lvl-neg",
+      level: LEVEL.NEG,
       exceptionals: [{ label: "ordinateur", amount: 800 }],
     });
     expect(cells[2][2]).toBeNull(); // 01-11, future
@@ -78,8 +85,8 @@ describe("buildHeatmap", () => {
     const { scaleMax, busiest, counts, streak, realizedDays } = buildHeatmap(2023, new Date(2023, 5, 1), [], []);
     expect(scaleMax).toBe(0);
     expect(busiest).toBeNull();
-    expect(counts["lvl-0"]).toBe(realizedDays);
-    expect(counts["lvl-neg"]).toBe(0);
+    expect(counts[LEVEL.ZERO]).toBe(realizedDays);
+    expect(counts[LEVEL.NEG]).toBe(0);
     expect(streak).toBe(realizedDays);
   });
 });

--- a/front/src/components/statistics/helpers/heatmapData.ts
+++ b/front/src/components/statistics/helpers/heatmapData.ts
@@ -4,8 +4,27 @@ import getDayOfYear from "date-fns/getDayOfYear";
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
 import type { DailyStat } from "@src/schemas/stats";
 
-export type HeatmapLevel = "empty" | "future" | "lvl-0" | "lvl-1" | "lvl-2" | "lvl-3" | "lvl-4" | "lvl-neg";
-export type FilledLevel = Exclude<HeatmapLevel, "future" | "empty">;
+/**
+ * The single source of truth for heat-map intensity levels: the `empty`/`future`
+ * grid states, the spend bands `lvl-0`…`lvl-4`, and the `lvl-neg` exceptional day.
+ * Keys drive counts and styling maps; values are the CSS band identifiers.
+ */
+export const LEVEL = {
+  EMPTY: "empty",
+  FUTURE: "future",
+  ZERO: "lvl-0",
+  ONE: "lvl-1",
+  TWO: "lvl-2",
+  THREE: "lvl-3",
+  FOUR: "lvl-4",
+  NEG: "lvl-neg",
+} as const;
+
+export type HeatmapLevel = (typeof LEVEL)[keyof typeof LEVEL];
+export type FilledLevel = Exclude<HeatmapLevel, typeof LEVEL.EMPTY | typeof LEVEL.FUTURE>;
+
+/** Spend bands in ascending order, indexed by the 0–4 band number (`lvl-neg` excluded). */
+export const SPEND_BANDS = [LEVEL.ZERO, LEVEL.ONE, LEVEL.TWO, LEVEL.THREE, LEVEL.FOUR] as const;
 
 export interface HeatmapCellExceptional {
   label: string;
@@ -45,12 +64,12 @@ export interface HeatmapModel {
 }
 
 const emptyCounts = (): Record<FilledLevel, number> => ({
-  "lvl-0": 0,
-  "lvl-1": 0,
-  "lvl-2": 0,
-  "lvl-3": 0,
-  "lvl-4": 0,
-  "lvl-neg": 0,
+  [LEVEL.ZERO]: 0,
+  [LEVEL.ONE]: 0,
+  [LEVEL.TWO]: 0,
+  [LEVEL.THREE]: 0,
+  [LEVEL.FOUR]: 0,
+  [LEVEL.NEG]: 0,
 });
 
 /** Monday-based day of week: 0 = Monday … 6 = Sunday (date-fns getDay is 0=Sunday). */
@@ -69,10 +88,10 @@ const isoOf = (date: Date): string => {
  */
 export const bandFor = (amount: number, max: number): FilledLevel => {
   if (amount <= 0 || max <= 0) {
-    return "lvl-0";
+    return LEVEL.ZERO;
   }
   const band = Math.min(4, Math.max(1, Math.ceil((amount / max) * 4)));
-  return `lvl-${band}` as FilledLevel;
+  return SPEND_BANDS[band];
 };
 
 /**
@@ -128,7 +147,7 @@ export const buildHeatmap = (
   // sized to the exact number of columns this year spans (52–54).
   const firstOffset = mondayDow(new Date(year, 0, 1));
   const weeks = Math.floor((daysInYear - 1 + firstOffset) / 7) + 1;
-  const rows: HeatmapLevel[][] = Array.from({ length: 7 }, () => Array<HeatmapLevel>(weeks).fill("empty"));
+  const rows: HeatmapLevel[][] = Array.from({ length: 7 }, () => Array<HeatmapLevel>(weeks).fill(LEVEL.EMPTY));
   const cells: (HeatmapCell | null)[][] = Array.from({ length: 7 }, () => Array<HeatmapCell | null>(weeks).fill(null));
   const realizedLevels: FilledLevel[] = []; // chronological, for counts + streak
 
@@ -138,14 +157,14 @@ export const buildHeatmap = (
     const row = mondayDow(date);
 
     if (doy > realizedDays) {
-      rows[row][col] = "future";
+      rows[row][col] = LEVEL.FUTURE;
       continue;
     }
 
     const iso = isoOf(date);
     const dayExceptionals = exceptionalsByDate.get(iso) ?? [];
     const amount = totalByDate.get(iso) ?? 0;
-    const level: FilledLevel = dayExceptionals.length > 0 ? "lvl-neg" : bandFor(amount, scaleMax);
+    const level: FilledLevel = dayExceptionals.length > 0 ? LEVEL.NEG : bandFor(amount, scaleMax);
     realizedLevels.push(level);
     rows[row][col] = level;
     cells[row][col] = { date: iso, amount, level, exceptionals: dayExceptionals };
@@ -156,7 +175,7 @@ export const buildHeatmap = (
   let best = 0;
   for (const level of realizedLevels) {
     counts[level] += 1;
-    if (level === "lvl-0" || level === "lvl-1") {
+    if (level === LEVEL.ZERO || level === LEVEL.ONE) {
       run += 1;
       best = Math.max(best, run);
     } else {


### PR DESCRIPTION
Replace the magic "lvl-0".."lvl-4" / "lvl-neg" / "empty" / "future" strings — scattered across the heatmap helper, component and tests — with a single LEVEL object (as const) plus derived HeatmapLevel/FilledLevel types. A typo is now a compile error, not a silent bad key.

bandFor indexes an ordered SPEND_BANDS array instead of interpolating `lvl-${band}`; the component reuses SPEND_BANDS for the scale legend and FILLED_ORDER, so the 0-4 order lives in one place.

No behaviour change: rendering identical, helper tests green.