### PR TITLE
feat(dashboard): month picker popover (COS-120)

### DIFF
--- a/front/src/components/dashboard/MonthPickerPopover.tsx
+++ b/front/src/components/dashboard/MonthPickerPopover.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { IconButton } from "@components/shared/IconButton";
+import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover";
+import { cn } from "@lib/utils";
+import dashboardText from "@text/dashboard";
+import format from "date-fns/format";
+import fr from "date-fns/locale/fr";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+const { monthSelector: text } = dashboardText;
+
+type MonthPickerPopoverProps = {
+  /** First day of the currently viewed month, or `null` before hydration. */
+  month: Date | null;
+  /** First day of the real current month (client-resolved, COS-73). */
+  currentMonthStart: Date;
+  /** Jump straight to `target`'s month (writes ?month=, clearing when current). */
+  onSelectMonth: (target: Date) => void;
+};
+
+/**
+ * Direct year + month picker behind the Dashboard month label (COS-120). The
+ * label is the popover trigger; the panel is a year stepper over a 3×4 grid of
+ * months, so any month is one jump away — no arrow-mashing burst of month-keyed
+ * requests. Bounds mirror the arrows (unbounded), adding no new reachability.
+ */
+const MonthPickerPopover = ({ month, currentMonthStart, onSelectMonth }: MonthPickerPopoverProps) => {
+  const [open, setOpen] = useState(false);
+  // Year shown in the grid header. Reset to the viewed month's year on every open
+  // so the panel always starts where the user currently is.
+  const [gridYear, setGridYear] = useState(() => (month ?? currentMonthStart).getFullYear());
+
+  const label = month ? format(month, "MMMM yyyy", { locale: fr }) : "";
+
+  const handleOpenChange = (next: boolean) => {
+    if (next) setGridYear((month ?? currentMonthStart).getFullYear());
+    setOpen(next);
+  };
+
+  const selectMonth = (target: Date) => {
+    onSelectMonth(target);
+    setOpen(false);
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={handleOpenChange}
+    >
+      {/* Trigger = the month label itself (no caret — matches the datepicker).
+          Fixed width (fits the longest month, "septembre") so the control never
+          resizes as the month changes. */}
+      <PopoverTrigger
+        aria-label={text.chooseMonth(label)}
+        className="num w-[116px] cursor-pointer rounded-sm px-1 py-0.5 text-center text-sm capitalize tracking-normal text-ink-2 transition-colors hover:text-ink"
+      >
+        {label}
+      </PopoverTrigger>
+      {/* Strip the ui/popover chrome (bg/border/padding/shadow) so the inner
+          .pfa-card owns the surface, matching every other private-screen panel. */}
+      <PopoverContent
+        align="center"
+        sideOffset={8}
+        collisionPadding={8}
+        className="w-auto border-0 bg-transparent p-0 shadow-none"
+      >
+        <div className="pfa-card w-[248px] p-3">
+          <div className="mb-2.5 flex items-center justify-between">
+            <IconButton
+              variant="ghost"
+              size={6}
+              onClick={() => setGridYear((year) => year - 1)}
+              aria-label={text.prevYear}
+            >
+              <ChevronLeft />
+            </IconButton>
+            <span className="num text-sm font-medium text-ink">{gridYear}</span>
+            <IconButton
+              variant="ghost"
+              size={6}
+              onClick={() => setGridYear((year) => year + 1)}
+              aria-label={text.nextYear}
+            >
+              <ChevronRight />
+            </IconButton>
+          </div>
+          <div className="grid grid-cols-3 gap-1.5">
+            {Array.from({ length: 12 }, (_, index) => {
+              const cellDate = new Date(gridYear, index, 1);
+              const isSelected = month != null && month.getFullYear() === gridYear && month.getMonth() === index;
+              const isCurrent = currentMonthStart.getFullYear() === gridYear && currentMonthStart.getMonth() === index;
+              return (
+                <button
+                  key={format(cellDate, "MM")}
+                  type="button"
+                  onClick={() => selectMonth(cellDate)}
+                  aria-current={isSelected ? "date" : undefined}
+                  aria-label={text.goToMonth(format(cellDate, "MMMM yyyy", { locale: fr }))}
+                  className={cn(
+                    "cursor-pointer rounded-sm py-1.5 text-sm capitalize tracking-normal transition-colors",
+                    isSelected
+                      ? "bg-primary font-semibold text-primary-foreground"
+                      : "text-ink-2 hover:bg-surface-hi hover:text-ink",
+                    !isSelected && isCurrent && "text-elec ring-1 ring-inset ring-elec/40",
+                  )}
+                >
+                  {format(cellDate, "MMM", { locale: fr })}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default MonthPickerPopover;

--- a/front/src/components/dashboard/MonthSelector.tsx
+++ b/front/src/components/dashboard/MonthSelector.tsx
@@ -1,11 +1,10 @@
 "use client";
 
+import MonthPickerPopover from "@components/dashboard/MonthPickerPopover";
 import { IconButton } from "@components/shared/IconButton";
-import { formatMonthParam, isValidMonthParam, MONTH_QUERY_PARAM, parseMonthParam } from "@helpers/dateRoute";
+import { isValidMonthParam, MONTH_QUERY_PARAM, parseMonthParam, resolveMonthParam } from "@helpers/dateRoute";
 import dashboardText from "@text/dashboard";
 import addMonths from "date-fns/addMonths";
-import format from "date-fns/format";
-import fr from "date-fns/locale/fr";
 import startOfMonth from "date-fns/startOfMonth";
 import { Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { parseAsString, useQueryState } from "nuqs";
@@ -15,7 +14,8 @@ import { useState, useSyncExternalStore } from "react";
  * Month period selector shown in the app header on the Dashboard. The month is
  * the URL's ?month= param (single source of truth, COS-118); DashboardPageClient
  * syncs the shared store from it. Landing on the current month clears the param,
- * keeping /dashboard clean.
+ * keeping /dashboard clean. The label opens a direct year+month picker (COS-120);
+ * the ‹ › arrows step one month at a time.
  */
 const MonthSelector = () => {
   const [monthParam, setMonthParam] = useQueryState(MONTH_QUERY_PARAM, parseAsString);
@@ -33,10 +33,13 @@ const MonthSelector = () => {
   // Until then the label is blank (the control keeps its fixed width).
   const month = paramMonth ?? (isClientHydrated ? currentMonthStart : null);
 
+  // Jump straight to `target`'s month; the current month clears the param. Shared
+  // by the ‹ › steppers and the picker so both land identically.
+  const goToMonth = (target: Date) => setMonthParam(resolveMonthParam(target, currentMonthStart));
+
   const stepMonth = (delta: number) => {
     if (!month) return;
-    const start = startOfMonth(addMonths(month, delta));
-    setMonthParam(start.getTime() === currentMonthStart.getTime() ? null : formatMonthParam(start));
+    goToMonth(addMonths(month, delta));
   };
 
   return (
@@ -51,11 +54,11 @@ const MonthSelector = () => {
         >
           <ChevronLeft />
         </IconButton>
-        {/* fixed width (fits the longest month, "septembre") so the control
-            never resizes as the month changes */}
-        <span className="num w-[116px] text-center capitalize tracking-normal">
-          {month ? format(month, "MMMM yyyy", { locale: fr }) : ""}
-        </span>
+        <MonthPickerPopover
+          month={month}
+          currentMonthStart={currentMonthStart}
+          onSelectMonth={goToMonth}
+        />
         <IconButton
           variant="ghost"
           size={5}

--- a/front/src/helpers/__tests__/dateRoute.test.ts
+++ b/front/src/helpers/__tests__/dateRoute.test.ts
@@ -1,0 +1,32 @@
+import { formatMonthParam, parseMonthParam, resolveMonthParam } from "@helpers/dateRoute";
+import { describe, expect, it } from "vitest";
+
+describe("formatMonthParam / parseMonthParam", () => {
+  it("formats a date as YYYY-MM on the local calendar", () => {
+    expect(formatMonthParam(new Date(2026, 6, 1))).toBe("2026-07");
+    expect(formatMonthParam(new Date(2025, 0, 15))).toBe("2025-01");
+  });
+
+  it("round-trips through parse to the first day of the month", () => {
+    const parsed = parseMonthParam("2024-03");
+    expect(parsed.getFullYear()).toBe(2024);
+    expect(parsed.getMonth()).toBe(2); // March
+    expect(parsed.getDate()).toBe(1);
+    expect(formatMonthParam(parsed)).toBe("2024-03");
+  });
+});
+
+describe("resolveMonthParam", () => {
+  const currentMonthStart = new Date(2026, 6, 1); // July 2026
+
+  it("returns null when the target resolves to the current month", () => {
+    expect(resolveMonthParam(new Date(2026, 6, 1), currentMonthStart)).toBeNull();
+    // Any day within the current month collapses to the same month → still null.
+    expect(resolveMonthParam(new Date(2026, 6, 28), currentMonthStart)).toBeNull();
+  });
+
+  it("returns the YYYY-MM of any other month", () => {
+    expect(resolveMonthParam(new Date(2025, 8, 10), currentMonthStart)).toBe("2025-09");
+    expect(resolveMonthParam(new Date(2027, 0, 1), currentMonthStart)).toBe("2027-01");
+  });
+});

--- a/front/src/helpers/dateRoute.ts
+++ b/front/src/helpers/dateRoute.ts
@@ -1,4 +1,5 @@
 import formatISO from "date-fns/formatISO";
+import startOfMonth from "date-fns/startOfMonth";
 
 export const DATE_QUERY_PARAM = "date";
 // The Dépenses (weekly) page carries the selected week as a ?date= query param.
@@ -43,3 +44,13 @@ export const parseMonthParam = (value: string): Date => {
 
 export const buildDashboardPath = (month?: string): string =>
   month ? `${DASHBOARD_PATH}?${MONTH_QUERY_PARAM}=${month}` : DASHBOARD_PATH;
+
+/**
+ * The ?month= value for viewing `target`'s month: `null` when it resolves to the
+ * current month (so /dashboard stays clean), otherwise "YYYY-MM". Shared by the
+ * MonthSelector arrow steppers and the direct month picker (COS-120).
+ */
+export const resolveMonthParam = (target: Date, currentMonthStart: Date): string | null => {
+  const start = startOfMonth(target);
+  return start.getTime() === currentMonthStart.getTime() ? null : formatMonthParam(start);
+};

--- a/front/src/text/dashboard.ts
+++ b/front/src/text/dashboard.ts
@@ -2,6 +2,10 @@ const dashboard = {
   monthSelector: {
     prevMonth: "Mois précédent",
     nextMonth: "Mois suivant",
+    chooseMonth: (month: string) => (month ? `Choisir le mois, actuellement ${month}` : "Choisir le mois"),
+    prevYear: "Année précédente",
+    nextYear: "Année suivante",
+    goToMonth: (month: string) => `Aller à ${month}`,
   },
   budgetHero: {
     remainingLabel: (month: string) => `${month} — budget restant`,


### PR DESCRIPTION
Add a direct year+month picker behind the Dashboard month label: the label opens a Radix popover with a year stepper over a 3x4 month grid, so any month is one jump away instead of arrow-mashing (which bursts the month-keyed fan-out and trips the nginx rate limiter -> 503).

The << >> arrows and the "Mois en cours" button are unchanged; both the arrows and the picker share resolveMonthParam (current month clears the param, keeping /dashboard clean).