### PR TITLE
fix(dashboard): donut ring shows used % (COS-134)

### DIFF
--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -160,6 +160,7 @@ const BudgetHero = () => {
           <Donut
             key={monthKey}
             segments={segments}
+            capacity={initialAmount}
             size={168}
             thickness={7}
             animate
@@ -175,10 +176,10 @@ const BudgetHero = () => {
           </Donut>
           <div className="flex gap-4 text-2xs text-ink-3">
             <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-d" />}>
-              {t.fixed} <span className="num text-ink-2">{euro0(fixed)}</span>
+              {t.fixed} <span className="num text-ink-2">{euro0(fixed)} €</span>
             </LegendItem>
             <LegendItem swatch={<span className="size-2 rounded-xs bg-accent-strong" />}>
-              {t.variables} <span className="num text-ink-2">{euro0(variable)}</span>
+              {t.variables} <span className="num text-ink-2">{euro0(variable)} €</span>
             </LegendItem>
           </div>
         </div>

--- a/front/src/lib/dataviz/Donut.tsx
+++ b/front/src/lib/dataviz/Donut.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { wedgePath } from "@lib/dataviz/arcPaths";
+import { annularSectorPath, wedgePath } from "@lib/dataviz/arcPaths";
 import { cn } from "@lib/utils";
+import { useId } from "react";
 
 import type { DonutSegment } from "@lib/dataviz/dataVizTypes";
 import type { CSSProperties, ReactNode } from "react";
@@ -21,6 +22,13 @@ interface DonutProps {
    *  `key`) to replay — e.g. on a month change. */
   animate?: boolean;
   trackColor?: string;
+  /** Ring gauge full-scale. When it exceeds the sum of segment values, the
+   *  leftover (capacity − sum) renders as an empty dotted "available" band that
+   *  completes the ring. Omit to let the segments fill the whole ring. */
+  capacity?: number;
+  /** Stroke color of the dotted "available" band (ring gauge, when `capacity`
+   *  is set). */
+  availableColor?: string;
   /** Center overlay (e.g. a big % for a gauge). */
   children?: ReactNode;
   className?: string;
@@ -29,6 +37,18 @@ interface DonutProps {
 
 const CX = 50;
 const CY = 50;
+/** Empty "remaining / available" arc: a hollow band the same width as the solid
+ *  arcs, traced by a fine dotted outline (the projection curve's rhythm — "3 4"
+ *  dash, ~1.5px non-scaling stroke, round caps) with a see-through interior. */
+const REMAINING_DASHARRAY = "3 4";
+const REMAINING_STROKE = 1.5;
+/** Inset the dotted outline just inside the band so its stroke stays within the
+ *  dark track and clear of the viewBox edge (the outer band edge sits at r=50). */
+const REMAINING_INSET = 0.75;
+/** Reveal-mask padding — a touch wider than the band, radially and at each
+ *  angular end, so the growing mask never clips the dotted outline. */
+const REMAINING_MASK_PAD = 3;
+const REMAINING_MASK_ARC = 1.5;
 
 /**
  * Donut / gauge / camembert. `ring` (default) draws stroked arcs — ideal for a
@@ -43,16 +63,21 @@ const Donut = ({
   rounded = false,
   animate = false,
   trackColor = "var(--surface-hi)",
+  capacity,
+  availableColor = "var(--accent-strong)",
   children,
   className,
   ariaLabel,
 }: DonutProps) => {
-  const total = segments.reduce((sum, seg) => sum + Math.max(0, seg.value), 0) || 1;
+  const segmentsTotal = segments.reduce((sum, seg) => sum + Math.max(0, seg.value), 0);
+  // Stable prefix for the reveal-mask id (unique across mounted Donuts).
+  const uid = useId();
 
   // cumulative geometry computed imperatively (no reassignment inside JSX)
   let body: ReactNode;
   if (variant === "pie") {
     const r = 50;
+    const total = segmentsTotal || 1;
     const wedges: { d: string; color: string }[] = [];
     let angle = 0;
     for (const seg of segments) {
@@ -75,49 +100,135 @@ const Donut = ({
   } else {
     const r = 50 - thickness / 2;
     const circumference = 2 * Math.PI * r;
-    const arcs: { dash: number; offset: number; color: string }[] = [];
+    // Optional gauge leftover: capacity beyond the summed segments renders as the
+    // empty dotted "available" band that completes the ring.
+    const leftover = capacity != null ? Math.max(0, capacity - segmentsTotal) : 0;
+    const total = segmentsTotal + leftover || 1;
+    const growStyle = (dash: number) =>
+      ({ "--pfa-circ": circumference, "--pfa-dash": dash, "--pfa-gap": circumference - dash }) as CSSProperties;
+
+    const solidArcs: { dash: number; offset: number; color: string }[] = [];
     let offset = 0;
     for (const seg of segments) {
       const dash = (Math.max(0, seg.value) / total) * circumference;
-      arcs.push({ dash, offset, color: seg.color });
+      if (dash > 0) {
+        solidArcs.push({ dash, offset, color: seg.color });
+      }
       offset += dash;
     }
+
+    // The empty "available" band — a hollow band, same width as the solid arcs but
+    // only traced by a fine dotted outline (annularSectorPath), interior see-through.
+    // Its own dash array carries the dot pattern, so it can't grow via that; instead
+    // it's revealed through a mask whose band grows with the same pfa-donut-grow
+    // keyframe — the empty band fills in lockstep with the solid arcs.
+    const emptyDash = (leftover / total) * circumference;
+    const emptyFull = emptyDash >= circumference - 0.01;
+    const rInner = 50 - thickness + REMAINING_INSET;
+    const rOuter = 50 - REMAINING_INSET;
+    const maskId = `${uid}-available`;
+    // Mask arc runs a touch longer than the band so its butt ends never clip the
+    // outline's end caps; the mask stroke is a touch wider for the radial edges.
+    const maskDash = Math.min(circumference, emptyDash + 2 * REMAINING_MASK_ARC);
+    const maskProps = animate ? { mask: `url(#${maskId})` } : {};
+    const dotProps = {
+      fill: "none",
+      stroke: availableColor,
+      strokeWidth: REMAINING_STROKE,
+      strokeDasharray: REMAINING_DASHARRAY,
+      strokeLinecap: "round" as const,
+      vectorEffect: "non-scaling-stroke" as const,
+    };
+
     body = (
-      <g transform={`rotate(-90 ${CX} ${CY})`}>
-        <circle
-          cx={CX}
-          cy={CY}
-          r={r}
-          fill="none"
-          stroke={trackColor}
-          strokeWidth={thickness}
-        />
-        {arcs.map((a, i) => (
+      <>
+        <g transform={`rotate(-90 ${CX} ${CY})`}>
           <circle
-            // biome-ignore lint/suspicious/noArrayIndexKey: fixed positional ring arcs with no stable unique field
-            key={i}
             cx={CX}
             cy={CY}
             r={r}
             fill="none"
-            stroke={a.color}
+            stroke={trackColor}
             strokeWidth={thickness}
-            strokeDasharray={`${a.dash} ${circumference - a.dash}`}
-            strokeDashoffset={-a.offset}
-            strokeLinecap={rounded ? "round" : "butt"}
-            className={animate ? "pfa-anim-donut" : undefined}
-            style={
-              animate
-                ? ({
-                    "--pfa-circ": circumference,
-                    "--pfa-dash": a.dash,
-                    "--pfa-gap": circumference - a.dash,
-                  } as CSSProperties)
-                : undefined
-            }
           />
-        ))}
-      </g>
+          {solidArcs.map((a, i) => (
+            <circle
+              // biome-ignore lint/suspicious/noArrayIndexKey: fixed positional ring arcs with no stable unique field
+              key={i}
+              cx={CX}
+              cy={CY}
+              r={r}
+              fill="none"
+              stroke={a.color}
+              strokeWidth={thickness}
+              strokeDasharray={`${a.dash} ${circumference - a.dash}`}
+              strokeDashoffset={-a.offset}
+              strokeLinecap={rounded ? "round" : "butt"}
+              className={animate ? "pfa-anim-donut" : undefined}
+              style={animate ? growStyle(a.dash) : undefined}
+            />
+          ))}
+        </g>
+        {emptyDash > 0 && (
+          <g>
+            {animate && (
+              <mask
+                id={maskId}
+                maskUnits="userSpaceOnUse"
+                x="0"
+                y="0"
+                width="100"
+                height="100"
+              >
+                <g transform={`rotate(-90 ${CX} ${CY})`}>
+                  <circle
+                    cx={CX}
+                    cy={CY}
+                    r={r}
+                    fill="none"
+                    stroke="#fff"
+                    strokeWidth={thickness + REMAINING_MASK_PAD}
+                    strokeDasharray={`${maskDash} ${circumference - maskDash}`}
+                    strokeDashoffset={-(offset - REMAINING_MASK_ARC)}
+                    className="pfa-anim-donut"
+                    style={growStyle(maskDash)}
+                  />
+                </g>
+              </mask>
+            )}
+            {emptyFull ? (
+              // Whole ring empty (nothing spent yet): two concentric dotted circles.
+              <g {...maskProps}>
+                <circle
+                  cx={CX}
+                  cy={CY}
+                  r={rOuter}
+                  {...dotProps}
+                />
+                <circle
+                  cx={CX}
+                  cy={CY}
+                  r={rInner}
+                  {...dotProps}
+                />
+              </g>
+            ) : (
+              <path
+                d={annularSectorPath(
+                  CX,
+                  CY,
+                  rInner,
+                  rOuter,
+                  (offset / circumference) * 360,
+                  ((offset + emptyDash) / circumference) * 360,
+                )}
+                {...dotProps}
+                {...maskProps}
+              />
+            )}
+          </g>
+        )}
+      </>
     );
   }
 

--- a/front/src/lib/dataviz/__tests__/arcPaths.test.ts
+++ b/front/src/lib/dataviz/__tests__/arcPaths.test.ts
@@ -1,0 +1,51 @@
+import { annularSectorPath, polarToCartesian } from "@lib/dataviz/arcPaths";
+import { describe, expect, it } from "vitest";
+
+// All numbers a path string lands on, in order (handles decimals + sci notation).
+const numsOf = (d: string): number[] => (d.match(/-?\d+(?:\.\d+)?(?:e-?\d+)?/g) ?? []).map(Number);
+
+describe("polarToCartesian", () => {
+  it("measures clockwise from 12 o'clock (0° = top, 90° = right, 180° = bottom)", () => {
+    const top = polarToCartesian(50, 50, 40, 0);
+    expect(top.x).toBeCloseTo(50);
+    expect(top.y).toBeCloseTo(10);
+
+    const right = polarToCartesian(50, 50, 40, 90);
+    expect(right.x).toBeCloseTo(90);
+    expect(right.y).toBeCloseTo(50);
+
+    const bottom = polarToCartesian(50, 50, 40, 180);
+    expect(bottom.x).toBeCloseTo(50);
+    expect(bottom.y).toBeCloseTo(90);
+  });
+});
+
+describe("annularSectorPath", () => {
+  it("traces a closed band: two arcs, one cap line, closed with Z", () => {
+    const d = annularSectorPath(50, 50, 40, 46, 0, 90);
+    expect(d.startsWith("M ")).toBe(true);
+    expect(d.trim().endsWith("Z")).toBe(true);
+    expect(d.match(/A/g)).toHaveLength(2);
+    expect(d.match(/L/g)).toHaveLength(1);
+  });
+
+  it("starts at the outer radius on the start angle", () => {
+    const d = annularSectorPath(50, 50, 40, 46, 0, 90);
+    const start = polarToCartesian(50, 50, 46, 0);
+    const nums = numsOf(d);
+    expect(nums[0]).toBeCloseTo(start.x);
+    expect(nums[1]).toBeCloseTo(start.y);
+  });
+
+  it("runs the outer arc clockwise (sweep 1) and the inner arc back (sweep 0)", () => {
+    const d = annularSectorPath(50, 50, 40, 46, 0, 90);
+    expect(d).toMatch(/A 46 46 0 0 1 /); // outer, rOuter = 46
+    expect(d).toMatch(/A 40 40 0 0 0 /); // inner, rInner = 40
+  });
+
+  it("picks the small-arc flag up to 180° and the large-arc flag beyond", () => {
+    expect(annularSectorPath(50, 50, 40, 46, 0, 90)).toMatch(/A 46 46 0 0 1 /); // 90° → small
+    expect(annularSectorPath(50, 50, 40, 46, 0, 270)).toMatch(/A 46 46 0 1 1 /); // 270° → large (outer)
+    expect(annularSectorPath(50, 50, 40, 46, 0, 270)).toMatch(/A 40 40 0 1 0 /); // 270° → large (inner)
+  });
+});

--- a/front/src/lib/dataviz/arcPaths.ts
+++ b/front/src/lib/dataviz/arcPaths.ts
@@ -22,3 +22,34 @@ export const wedgePath = (cx: number, cy: number, r: number, startAngle: number,
   const largeArc = endAngle - startAngle <= 180 ? "0" : "1";
   return `M ${cx} ${cy} L ${start.x} ${start.y} A ${r} ${r} 0 ${largeArc} 0 ${end.x} ${end.y} Z`;
 };
+
+/**
+ * Closed annular-sector ("ring segment") outline from `startAngle` to `endAngle`
+ * (degrees, clockwise from 12 o'clock), between `rInner` and `rOuter`. Traces the
+ * band's whole perimeter — outer arc, end cap, inner arc, start cap — so a
+ * `fill="none"` stroke draws it as a hollow, see-through band: the Donut's empty
+ * "remaining" arc, the same width as the solid arcs but only outlined (dotted).
+ * The path length lives in its geometry, leaving `stroke-dasharray` free for the
+ * dot pattern.
+ */
+export const annularSectorPath = (
+  cx: number,
+  cy: number,
+  rInner: number,
+  rOuter: number,
+  startAngle: number,
+  endAngle: number,
+): string => {
+  const oStart = polarToCartesian(cx, cy, rOuter, startAngle);
+  const oEnd = polarToCartesian(cx, cy, rOuter, endAngle);
+  const iEnd = polarToCartesian(cx, cy, rInner, endAngle);
+  const iStart = polarToCartesian(cx, cy, rInner, startAngle);
+  const largeArc = endAngle - startAngle > 180 ? "1" : "0";
+  return [
+    `M ${oStart.x} ${oStart.y}`,
+    `A ${rOuter} ${rOuter} 0 ${largeArc} 1 ${oEnd.x} ${oEnd.y}`,
+    `L ${iEnd.x} ${iEnd.y}`,
+    `A ${rInner} ${rInner} 0 ${largeArc} 0 ${iStart.x} ${iStart.y}`,
+    "Z",
+  ].join(" ");
+};


### PR DESCRIPTION
The budget donut's ring was driven only by the Fixes + Variables segments, which always summed to 360° — so the ring read as full regardless of the "% utilisé" shown in the centre.

Donut gains a `capacity` prop: the leftover (capacity − Σsegments) renders as an empty "available" band that completes the ring, so the Fixes + Variables arcs fill exactly the used fraction and the ring matches the centre percentage. The empty band is a hollow annular outline traced by a fine dotted stroke (new `annularSectorPath` helper, dash rhythm matching the projection curve), revealed in lockstep with the solid arcs via a grow mask (same pfa-donut-grow keyframe). `availableColor` sets its stroke; with no `capacity` the Donut behaves as before, so it stays generic.

BudgetHero passes `capacity={initialAmount}` (same denominator as usedPct) and drops the manual remaining segment. The legend amounts now show the € symbol, matching the convention used elsewhere.

Unit tests cover the pure geometry (annularSectorPath, polarToCartesian).