### PR TITLE
feat(dashboard): donut segment tooltips (COS-93)

### DIFF
--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -9,7 +9,7 @@ import { MoneyAmount } from "@components/shared/MoneyAmount";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useReccurings from "@components/spendings/services/useReccurings";
 import { Input } from "@components/ui/input";
-import { Donut, useCountUp } from "@lib/dataviz";
+import { CategoryBarTooltip, Donut, useCountUp } from "@lib/dataviz";
 import { euro0 } from "@lib/format";
 import { cn } from "@lib/utils";
 import dashboardText from "@text/dashboard";
@@ -18,6 +18,7 @@ import fr from "date-fns/locale/fr";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
+import type { BarHover, CategoryTooltipDatum } from "@lib/dataviz";
 import type { FocusEvent, KeyboardEvent } from "react";
 
 interface SalaryForm {
@@ -36,6 +37,7 @@ const BudgetHero = () => {
   } = useDashboard();
   const { recurrings } = useReccurings();
   const [editing, setEditing] = useState(false);
+  const [hover, setHover] = useState<BarHover<number> | null>(null);
   const { register, handleSubmit, setFocus } = useForm<SalaryForm>();
   const { budgetHero: t } = dashboardText;
 
@@ -57,13 +59,35 @@ const BudgetHero = () => {
   // remount key → replays the donut grow-from-zero on month change
   const monthKey = format(from ?? new Date(), "yyyy-MM");
 
-  const segments =
+  // One source of truth for the two budget segments → the donut arcs AND the
+  // hover tooltip render identical values (same order → hover index maps back).
+  const budgetSegments =
     initialAmount > 0
       ? [
-          { label: t.fixed, value: fixed, color: "var(--accent-d)" },
-          { label: t.variables, value: variable, color: "var(--accent-strong)" },
+          { name: t.fixed, value: fixed, color: "var(--accent-d)" },
+          { name: t.variables, value: variable, color: "var(--accent-strong)" },
         ]
       : [];
+  const segments = budgetSegments.map((s) => ({ label: s.name, value: s.value, color: s.color }));
+  // `pct` = share of the whole budget (value / initialAmount), i.e. the fraction
+  // of the ring the arc actually occupies post-COS-134 — so the tooltip % matches
+  // the hovered arc, not the "% utilisé" of the center.
+  const tooltipData: CategoryTooltipDatum[] = budgetSegments.map((s) => ({
+    color: s.color,
+    name: s.name,
+    pct: (s.value / initialAmount) * 100,
+    total: s.value,
+  }));
+  // The empty "available" band (donut reports it as index === segments.length) →
+  // the remaining amount and its share of the budget (100 − % utilisé).
+  if (initialAmount > 0 && remaining > 0) {
+    tooltipData.push({
+      color: "var(--accent-strong)",
+      name: t.available,
+      pct: (remaining / initialAmount) * 100,
+      total: remaining,
+    });
+  }
 
   const onSubmit = (v: SalaryForm) => {
     setEditing(false);
@@ -165,6 +189,8 @@ const BudgetHero = () => {
             thickness={7}
             animate
             ariaLabel={t.donutAria}
+            onSegmentHover={(index, e) => setHover({ target: index, x: e.clientX, y: e.clientY })}
+            onSegmentLeave={() => setHover(null)}
           >
             <div>
               <div className="num text-3xl font-medium leading-none tracking-tight text-ink">
@@ -184,6 +210,13 @@ const BudgetHero = () => {
           </div>
         </div>
       </div>
+
+      {hover && tooltipData[hover.target] && (
+        <CategoryBarTooltip
+          point={{ x: hover.x, y: hover.y }}
+          datum={tooltipData[hover.target]}
+        />
+      )}
 
       <DailySparkline />
     </GlowCard>

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -16,13 +16,16 @@ const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : us
 export interface CategoryTooltipDatum {
   color: string;
   name: string;
-  count: number;
+  /** Item count pill. Omit for data that has no count (e.g. the budget donut's
+   *  Fixes / Variables segments) — the pill is then hidden. */
+  count?: number;
   /** Share of the total, 0-100 (already computed — the tooltip only formats). */
   pct: number;
   /** Amount in euros. */
   total: number;
-  /** Trend data — the page computes it from its own source (weekly vs monthly). */
-  trend: CategoryTrendData;
+  /** Trend data — the page computes it from its own source (weekly vs monthly).
+   *  Omit for data with no trend — the "Tendance" row is then hidden. */
+  trend?: CategoryTrendData;
 }
 
 export interface CategoryBarTooltipProps {
@@ -110,17 +113,23 @@ const CategoryBarTooltip = ({ point, datum }: CategoryBarTooltipProps) => {
           style={{ background: datum.color }}
         />
         <span className="truncate text-sm font-medium capitalize text-ink">{datum.name}</span>
-        <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-surface-base px-2 text-2xs leading-normal text-ink-3">
-          {datum.count}
-        </span>
+        {datum.count != null && (
+          <span className="num ml-auto shrink-0 rounded-full border border-line-soft bg-surface-base px-2 text-2xs leading-normal text-ink-3">
+            {datum.count}
+          </span>
+        )}
       </div>
       <div className="grid grid-cols-[auto_1fr] items-center gap-x-5 gap-y-1 text-xs">
         <span className="text-ink-4">Part</span>
         <span className="num text-right text-ink-2">{datum.pct.toFixed(1).replace(".", ",")} %</span>
         <span className="text-ink-4">Montant</span>
         <span className="num text-right text-ink">{euro(datum.total)} €</span>
-        <span className="text-ink-4">Tendance</span>
-        <CategoryTrend {...datum.trend} />
+        {datum.trend && (
+          <>
+            <span className="text-ink-4">Tendance</span>
+            <CategoryTrend {...datum.trend} />
+          </>
+        )}
       </div>
     </div>,
     document.body,

--- a/front/src/lib/dataviz/Donut.tsx
+++ b/front/src/lib/dataviz/Donut.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { annularSectorPath, wedgePath } from "@lib/dataviz/arcPaths";
+import { angleFromCenter, annularSectorPath, wedgePath } from "@lib/dataviz/arcPaths";
 import { cn } from "@lib/utils";
 import { useId } from "react";
 
 import type { DonutSegment } from "@lib/dataviz/dataVizTypes";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties, MouseEvent, ReactNode } from "react";
 
 interface DonutProps {
   segments: DonutSegment[];
@@ -29,6 +29,13 @@ interface DonutProps {
   /** Stroke color of the dotted "available" band (ring gauge, when `capacity`
    *  is set). */
   availableColor?: string;
+  /** Fires on pointer move over a ring segment, with its index and the event —
+   *  mirrors `StackedBar` so a caller can drive a follow-cursor tooltip. The empty
+   *  "available" band reports `index === segments.length` (when `capacity` leaves a
+   *  leftover); the center hole and outside the band report a leave. */
+  onSegmentHover?: (index: number, event: MouseEvent) => void;
+  /** Fires when the pointer leaves the ring band (or lands where no segment is). */
+  onSegmentLeave?: () => void;
   /** Center overlay (e.g. a big % for a gauge). */
   children?: ReactNode;
   className?: string;
@@ -49,6 +56,9 @@ const REMAINING_INSET = 0.75;
  *  angular end, so the growing mask never clips the dotted outline. */
 const REMAINING_MASK_PAD = 3;
 const REMAINING_MASK_ARC = 1.5;
+/** Radial slack (viewBox units) around the ring band when hit-testing the cursor,
+ *  so the thin stroke stays comfortably hoverable. */
+const HIT_TOL = 4;
 
 /**
  * Donut / gauge / camembert. `ring` (default) draws stroked arcs — ideal for a
@@ -65,13 +75,57 @@ const Donut = ({
   trackColor = "var(--surface-hi)",
   capacity,
   availableColor = "var(--accent-strong)",
+  onSegmentHover,
+  onSegmentLeave,
   children,
   className,
   ariaLabel,
 }: DonutProps) => {
   const segmentsTotal = segments.reduce((sum, seg) => sum + Math.max(0, seg.value), 0);
+  // Gauge full-scale denominator (ring): segments + the leftover "available" band,
+  // so a segment's angular share = value / ringTotal — the same fraction the arc
+  // is drawn with, and what the hover hit-test maps the cursor angle against.
+  const isRing = variant !== "pie";
+  const leftover = isRing && capacity != null ? Math.max(0, capacity - segmentsTotal) : 0;
+  const ringTotal = segmentsTotal + leftover || 1;
   // Stable prefix for the reveal-mask id (unique across mounted Donuts).
   const uid = useId();
+
+  // Hit-test the cursor against the ring band: resolve its angle to a segment
+  // (clockwise from 12 o'clock, same as the arcs), reporting the segment with the
+  // event so the caller can drive a follow-cursor tooltip — no per-arc handlers,
+  // so the SVG stays a single labelled image. The center hole, the empty
+  // "available" band, and outside the band all report a leave (no tooltip).
+  const handleMove = (event: MouseEvent<SVGSVGElement>) => {
+    if (!onSegmentHover || !isRing) {
+      return;
+    }
+    const rect = event.currentTarget.getBoundingClientRect();
+    const scale = (rect.width || 1) / 100; // viewBox spans 100 units
+    const dx = (event.clientX - (rect.left + CX * scale)) / scale;
+    const dy = (event.clientY - (rect.top + CY * scale)) / scale;
+    const radius = Math.hypot(dx, dy);
+    if (radius < 50 - thickness - HIT_TOL || radius > 50 + HIT_TOL) {
+      onSegmentLeave?.();
+      return;
+    }
+    const fraction = angleFromCenter(dx, dy) / 360;
+    let acc = 0;
+    for (let i = 0; i < segments.length; i++) {
+      acc += Math.max(0, segments[i].value) / ringTotal;
+      if (fraction <= acc) {
+        onSegmentHover(i, event);
+        return;
+      }
+    }
+    // Past the solid segments: the empty "available" band (index === segments.length)
+    // when there is a leftover, else no target.
+    if (leftover > 0) {
+      onSegmentHover(segments.length, event);
+    } else {
+      onSegmentLeave?.();
+    }
+  };
 
   // cumulative geometry computed imperatively (no reassignment inside JSX)
   let body: ReactNode;
@@ -100,17 +154,13 @@ const Donut = ({
   } else {
     const r = 50 - thickness / 2;
     const circumference = 2 * Math.PI * r;
-    // Optional gauge leftover: capacity beyond the summed segments renders as the
-    // empty dotted "available" band that completes the ring.
-    const leftover = capacity != null ? Math.max(0, capacity - segmentsTotal) : 0;
-    const total = segmentsTotal + leftover || 1;
     const growStyle = (dash: number) =>
       ({ "--pfa-circ": circumference, "--pfa-dash": dash, "--pfa-gap": circumference - dash }) as CSSProperties;
 
     const solidArcs: { dash: number; offset: number; color: string }[] = [];
     let offset = 0;
     for (const seg of segments) {
-      const dash = (Math.max(0, seg.value) / total) * circumference;
+      const dash = (Math.max(0, seg.value) / ringTotal) * circumference;
       if (dash > 0) {
         solidArcs.push({ dash, offset, color: seg.color });
       }
@@ -122,7 +172,7 @@ const Donut = ({
     // Its own dash array carries the dot pattern, so it can't grow via that; instead
     // it's revealed through a mask whose band grows with the same pfa-donut-grow
     // keyframe — the empty band fills in lockstep with the solid arcs.
-    const emptyDash = (leftover / total) * circumference;
+    const emptyDash = (leftover / ringTotal) * circumference;
     const emptyFull = emptyDash >= circumference - 0.01;
     const rInner = 50 - thickness + REMAINING_INSET;
     const rOuter = 50 - REMAINING_INSET;
@@ -237,16 +287,23 @@ const Donut = ({
       className={cn("relative inline-grid place-items-center", className)}
       style={{ width: size, height: size }}
     >
+      {/* Hover lives on the <svg> (the labelled graphic) so it stays a single
+          role="img" for assistive tech; the center overlay is pointer-transparent
+          so the cursor reaches the ring underneath it. */}
       <svg
         viewBox="0 0 100 100"
         width={size}
         height={size}
         role="img"
         aria-label={ariaLabel}
+        onMouseMove={onSegmentHover ? handleMove : undefined}
+        onMouseLeave={onSegmentHover ? onSegmentLeave : undefined}
       >
         {body}
       </svg>
-      {children && <div className="absolute inset-0 grid place-content-center text-center">{children}</div>}
+      {children && (
+        <div className="pointer-events-none absolute inset-0 grid place-content-center text-center">{children}</div>
+      )}
     </div>
   );
 };

--- a/front/src/lib/dataviz/__tests__/arcPaths.test.ts
+++ b/front/src/lib/dataviz/__tests__/arcPaths.test.ts
@@ -1,4 +1,4 @@
-import { annularSectorPath, polarToCartesian } from "@lib/dataviz/arcPaths";
+import { angleFromCenter, annularSectorPath, polarToCartesian } from "@lib/dataviz/arcPaths";
 import { describe, expect, it } from "vitest";
 
 // All numbers a path string lands on, in order (handles decimals + sci notation).
@@ -17,6 +17,20 @@ describe("polarToCartesian", () => {
     const bottom = polarToCartesian(50, 50, 40, 180);
     expect(bottom.x).toBeCloseTo(50);
     expect(bottom.y).toBeCloseTo(90);
+  });
+});
+
+describe("angleFromCenter", () => {
+  it("inverts polarToCartesian: clockwise from 12 o'clock, normalized to [0, 360)", () => {
+    expect(angleFromCenter(0, -1)).toBeCloseTo(0); // up
+    expect(angleFromCenter(1, 0)).toBeCloseTo(90); // right
+    expect(angleFromCenter(0, 1)).toBeCloseTo(180); // down
+    expect(angleFromCenter(-1, 0)).toBeCloseTo(270); // left (normalized, not -90)
+  });
+
+  it("round-trips a point produced by polarToCartesian", () => {
+    const p = polarToCartesian(50, 50, 40, 123);
+    expect(angleFromCenter(p.x - 50, p.y - 50)).toBeCloseTo(123);
   });
 });
 

--- a/front/src/lib/dataviz/arcPaths.ts
+++ b/front/src/lib/dataviz/arcPaths.ts
@@ -10,6 +10,17 @@ export const polarToCartesian = (cx: number, cy: number, r: number, angleDeg: nu
 };
 
 /**
+ * Inverse of {@link polarToCartesian}'s angle: an offset from the center
+ * (`dx` right, `dy` down) → its angle in degrees, measured clockwise from
+ * 12 o'clock and normalized to [0, 360). Used to hit-test a cursor against
+ * the ring's segments (which run clockwise from the top).
+ */
+export const angleFromCenter = (dx: number, dy: number): number => {
+  const deg = (Math.atan2(dx, -dy) * 180) / Math.PI;
+  return deg < 0 ? deg + 360 : deg;
+};
+
+/**
  * Filled pie-wedge path from `startAngle` to `endAngle` (degrees, clockwise).
  * NOTE: this is the canonical `describeArc` pattern — the arc endpoints are
  * intentionally computed from the *opposite* angles and drawn with sweep-flag 0.

--- a/front/src/text/dashboard.ts
+++ b/front/src/text/dashboard.ts
@@ -18,6 +18,7 @@ const dashboard = {
     donutAria: "Répartition du budget consommé",
     fixed: "Fixes",
     variables: "Variables",
+    available: "Restant",
   },
   categoryBreakdown: {
     title: "Répartition par catégorie",


### PR DESCRIPTION
Hovering a Fixes / Variables arc — or the empty "available" band — of the budget donut now shows the shared CategoryBarTooltip (name, share of budget, amount €), matching the category-breakdown tooltip.

- Donut: onSegmentHover(index, e) / onSegmentLeave (StackedBar-style), angle hit-test on the <svg> (center overlay made pointer-transparent). The empty band reports index === segments.length; center hole and outside the band report a leave.
- arcPaths: pure angleFromCenter helper (inverse of polarToCartesian) + tests.
- CategoryBarTooltip: count and trend made optional (pill / "Tendance" row hidden when absent); category breakdown unchanged.
- BudgetHero: hover state + tooltip data derived from one source shared with the arcs. pct = value / initialAmount (the arc's real ring share post-COS-134); the "Restant" band shows the remaining %.