### PR TITLE
feat(stats): weekday bullet-chart bars (COS-132)

### DIFF
--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -3,35 +3,62 @@
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MeterBar } from "@components/shared/MeterBar";
-import overspendLevel from "@components/spendings/helpers/overspendLevel";
+import { OVERSPEND_DANGER_RATIO } from "@components/spendings/helpers/overspendLevel";
+import { scaleFrac } from "@components/statistics/helpers/weekdayBullet";
 import { weekdayAverages } from "@components/statistics/helpers/weekdayStats";
-import { euro, pct1 } from "@lib/format";
+import WeekdayBulletBar from "@components/statistics/WeekdayBulletBar";
+import { euro, euro0, pct1 } from "@lib/format";
 import common from "@text/common";
 import statistics from "@text/statistics";
 
-import type { OverspendLevel } from "@components/spendings/helpers/overspendLevel";
 import type { DailyStat } from "@src/schemas/stats";
 
 const { dayOfWeek: t } = statistics;
+
+// Row layout: fixed day-name and amount columns around the elastic bar column.
+const GRID_COLS = "grid grid-cols-[90px_1fr_130px] gap-3";
+const ROW_GRID = `${GRID_COLS} items-center`;
+
+// Bar-column geometry, mirrored by the threshold guides so they span the full
+// height of the plot and line up with the bars. Must match GRID_COLS: a 90px
+// day-name column and a 130px amount column, each separated from the elastic bar
+// column by gap-3 (12px).
+const DAY_COL_PX = 90;
+const AMOUNT_COL_PX = 130;
+const COL_GAP_PX = 12;
+
+// Fixed-scale headroom so the 2×budget marker always sits inside the bar with a
+// little air past it, even when every weekday stays under it (COS-132).
+const SCALE_HEADROOM = 1.12;
 
 interface StatisticsDayOfWeekProps {
   year: number;
   now: Date;
   /** Per-day spending totals for the year (COS-45); `undefined` while the request is in flight. */
   days: DailyStat[] | undefined;
-  /** Weekly ceiling (real data) — its per-day share drives the colour ramp. */
+  /** Weekly ceiling (real data) — its per-day share drives the colour zones. */
   weeklyCeiling: number | null;
 }
 
-// Bar fill by overspend level: green under the daily budget, orange over it, red
-// well over it — same orange-before-red philosophy as COS-34 / COS-36.
-const FILL: Record<OverspendLevel, string> = {
-  normal: "var(--bar-fill)",
-  warn: "linear-gradient(90deg, oklch(0.60 0.13 70), var(--warn))",
-  danger: "linear-gradient(90deg, oklch(0.50 0.13 25), oklch(0.72 0.16 25))",
-};
+/** A dashed threshold line running the full height of the plot, over every bar. */
+const ThresholdGuide = ({ frac }: { frac: number }) => (
+  <span
+    className="absolute inset-y-0"
+    style={{ left: `${frac * 100}%`, marginLeft: -1, borderLeft: "2px dashed var(--ink)", opacity: 0.6 }}
+  />
+);
 
-/** "Dépenses par jour de la semaine" — real weekday spending rhythm (COS-48). */
+/** A dashed threshold's euro value, centred under its guide on the bar column. */
+const ThresholdLabel = ({ frac, amount }: { frac: number; amount: number }) => (
+  <span
+    className="num absolute top-0 -translate-x-1/2 whitespace-nowrap text-2xs text-ink-4"
+    style={{ left: `${frac * 100}%` }}
+  >
+    {euro0(amount)} €
+  </span>
+);
+
+/** "Dépenses par jour de la semaine" — real weekday spending rhythm (COS-48, COS-132). */
 const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOfWeekProps) => {
   if (days === undefined) {
     return (
@@ -53,6 +80,12 @@ const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOf
   // Per-weekday budget = the weekly ceiling spread over 7 days (COS-34 rule).
   const dayBudget = weeklyCeiling != null && weeklyCeiling > 0 ? weeklyCeiling / 7 : null;
 
+  // Fixed euro scale shared by all seven bars: wide enough to always show the
+  // 2×budget marker, so the two thresholds stay put across the days and only the
+  // bar lengths change. Without a ceiling there are no thresholds — fall back to
+  // the old scale-to-day-max neutral bar.
+  const scaleMax = dayBudget != null ? Math.max(maxAmount, dayBudget * OVERSPEND_DANGER_RATIO) * SCALE_HEADROOM : 1;
+
   return (
     <GlowCard
       as="section"
@@ -63,26 +96,68 @@ const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOf
         meta={t.meta(year)}
       />
 
-      <div className="mt-4.5 flex flex-col gap-2">
-        {stats.map((s, dow) => (
+      <div className="relative mt-4.5">
+        <div className="flex flex-col gap-2">
+          {stats.map((s, dow) => (
+            <div
+              key={t.days[dow]}
+              className={`${ROW_GRID} text-sm`}
+            >
+              <span className="text-ink-2">{t.days[dow]}</span>
+              {dayBudget != null ? (
+                <WeekdayBulletBar
+                  value={s.avgAmount}
+                  dayBudget={dayBudget}
+                  scaleMax={scaleMax}
+                  height={22}
+                />
+              ) : (
+                <MeterBar
+                  value={(s.avgAmount / maxAmount) * 100}
+                  height={22}
+                  opacity={0.85}
+                />
+              )}
+              <span className="num text-right font-medium text-ink">
+                {euro(s.avgAmount)} €
+                <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Continuous threshold guides: the budget and 2×budget markers are the
+            same for the seven days, so they run top-to-bottom over the whole plot
+            (across the gaps too) as one reference axis, not per-bar dashes. */}
+        {dayBudget != null && (
           <div
-            key={t.days[dow]}
-            className="grid grid-cols-[90px_1fr_130px] items-center gap-3 text-sm"
+            className="pointer-events-none absolute inset-y-0"
+            style={{ left: DAY_COL_PX + COL_GAP_PX, right: AMOUNT_COL_PX + COL_GAP_PX }}
+            aria-hidden
           >
-            <span className="text-ink-2">{t.days[dow]}</span>
-            <MeterBar
-              value={(s.avgAmount / maxAmount) * 100}
-              fill={FILL[overspendLevel(s.avgAmount, dayBudget)]}
-              height={22}
-              opacity={0.85}
-            />
-            <span className="num text-right font-medium text-ink">
-              {euro(s.avgAmount)} €
-              <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
-            </span>
+            <ThresholdGuide frac={scaleFrac(dayBudget, scaleMax)} />
+            <ThresholdGuide frac={scaleFrac(dayBudget * OVERSPEND_DANGER_RATIO, scaleMax)} />
           </div>
-        ))}
+        )}
       </div>
+
+      {/* Threshold values, labelled once beneath the bar column. */}
+      {dayBudget != null && (
+        <div className={`${ROW_GRID} mt-1.5`}>
+          <span aria-hidden />
+          <div className="relative h-3.5">
+            <ThresholdLabel
+              frac={scaleFrac(dayBudget, scaleMax)}
+              amount={dayBudget}
+            />
+            <ThresholdLabel
+              frac={scaleFrac(dayBudget * OVERSPEND_DANGER_RATIO, scaleMax)}
+              amount={dayBudget * OVERSPEND_DANGER_RATIO}
+            />
+          </div>
+          <span aria-hidden />
+        </div>
+      )}
     </GlowCard>
   );
 };

--- a/front/src/components/statistics/WeekdayBulletBar.tsx
+++ b/front/src/components/statistics/WeekdayBulletBar.tsx
@@ -1,0 +1,56 @@
+import { bulletSegments } from "@components/statistics/helpers/weekdayBullet";
+
+import type { OverspendLevel } from "@components/spendings/helpers/overspendLevel";
+
+interface WeekdayBulletBarProps {
+  /** The weekday's average spend, in euros. */
+  value: number;
+  /** Per-day budget = weekly ceiling ÷ 7, in euros (never null here). */
+  dayBudget: number;
+  /** Fixed euro scale shared by all seven bars, so the thresholds line up. */
+  scaleMax: number;
+  /** Track height in px. */
+  height: number;
+}
+
+// Fill per overspend zone: the green base keeps the accent gradient (it is
+// anchored at 0), the overspend zones are the flat warn / neg tokens — same
+// palette as the Dépenses overspend indicators (COS-34 / COS-36).
+const SEGMENT_FILL: Record<OverspendLevel, string> = {
+  normal: "var(--bar-fill)",
+  warn: "var(--warn)",
+  danger: "var(--neg)",
+};
+
+/**
+ * Bullet-chart bar for one weekday (COS-132): the green / orange / red overspend
+ * zones share a single bar on a fixed scale. `MeterBar` stays single-fill
+ * ("multi-segment bars stay bespoke"), so the segments are drawn here. The two
+ * dashed threshold markers are a single continuous guide drawn once over all
+ * seven rows by the parent, not per bar.
+ */
+const WeekdayBulletBar = ({ value, dayBudget, scaleMax, height }: WeekdayBulletBarProps) => {
+  const segments = bulletSegments(value, dayBudget, scaleMax);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-sm bg-surface-hi"
+      style={{ height }}
+    >
+      {segments.map((seg) => (
+        <span
+          key={seg.level}
+          className="absolute inset-y-0"
+          style={{
+            left: `${seg.start * 100}%`,
+            width: `${seg.width * 100}%`,
+            background: SEGMENT_FILL[seg.level],
+            opacity: 0.85,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default WeekdayBulletBar;

--- a/front/src/components/statistics/helpers/__tests__/weekdayBullet.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/weekdayBullet.test.ts
@@ -1,0 +1,55 @@
+import { OVERSPEND_DANGER_RATIO } from "@components/spendings/helpers/overspendLevel";
+import { bulletSegments, scaleFrac } from "@components/statistics/helpers/weekdayBullet";
+
+describe("scaleFrac", () => {
+  it("maps an amount to its 0–1 position on the scale", () => {
+    expect(scaleFrac(100, 400)).toBe(0.25);
+    expect(scaleFrac(0, 400)).toBe(0);
+  });
+
+  it("clamps outside 0–1 and guards a zero/negative scale", () => {
+    expect(scaleFrac(500, 400)).toBe(1);
+    expect(scaleFrac(-10, 400)).toBe(0);
+    expect(scaleFrac(100, 0)).toBe(0);
+  });
+});
+
+describe("bulletSegments", () => {
+  // budget 100 → danger 200; scale 400 keeps the fractions round.
+  const budget = 100;
+  const scaleMax = 400;
+
+  it("stays green-only under the budget", () => {
+    expect(bulletSegments(50, budget, scaleMax)).toEqual([{ level: "normal", start: 0, width: 0.125 }]);
+  });
+
+  it("stays green-only at exactly the budget (boundary is not over)", () => {
+    expect(bulletSegments(budget, budget, scaleMax)).toEqual([{ level: "normal", start: 0, width: 0.25 }]);
+  });
+
+  it("adds an orange zone above the budget, green base at full width", () => {
+    expect(bulletSegments(150, budget, scaleMax)).toEqual([
+      { level: "normal", start: 0, width: 0.25 },
+      { level: "warn", start: 0.25, width: 0.125 },
+    ]);
+  });
+
+  it("caps orange at 2×budget without a red zone at exactly the danger multiple", () => {
+    expect(bulletSegments(budget * OVERSPEND_DANGER_RATIO, budget, scaleMax)).toEqual([
+      { level: "normal", start: 0, width: 0.25 },
+      { level: "warn", start: 0.25, width: 0.25 },
+    ]);
+  });
+
+  it("adds a red zone past 2×budget, with green and orange at full width", () => {
+    expect(bulletSegments(300, budget, scaleMax)).toEqual([
+      { level: "normal", start: 0, width: 0.25 },
+      { level: "warn", start: 0.25, width: 0.25 },
+      { level: "danger", start: 0.5, width: 0.25 },
+    ]);
+  });
+
+  it("emits an empty green zone for a zero-spend weekday", () => {
+    expect(bulletSegments(0, budget, scaleMax)).toEqual([{ level: "normal", start: 0, width: 0 }]);
+  });
+});

--- a/front/src/components/statistics/helpers/weekdayBullet.ts
+++ b/front/src/components/statistics/helpers/weekdayBullet.ts
@@ -1,0 +1,40 @@
+import { OVERSPEND_DANGER_RATIO } from "@components/spendings/helpers/overspendLevel";
+
+import type { OverspendLevel } from "@components/spendings/helpers/overspendLevel";
+
+export interface BulletSegment {
+  level: OverspendLevel;
+  /** Left edge, 0–1 fraction of the bar's fixed scale. */
+  start: number;
+  /** Width, 0–1 fraction of the bar's fixed scale. */
+  width: number;
+}
+
+/** Position of a euro amount on the bar's fixed scale, clamped to 0–1. */
+export const scaleFrac = (amount: number, scaleMax: number): number =>
+  scaleMax > 0 ? Math.max(0, Math.min(1, amount / scaleMax)) : 0;
+
+/**
+ * Split a weekday's average into the green / orange / red segments of its bullet
+ * bar (COS-132). The junctions are the daily budget (green→orange) and
+ * `OVERSPEND_DANGER_RATIO`× that budget (orange→red) — the exact same seuils as
+ * the Dépenses overspend indicators (COS-34 / COS-36). Only the zones the value
+ * actually reaches are returned, each as a start/width fraction of the shared
+ * fixed scale; the strictly-greater tests mirror `overspendLevel` (at a boundary
+ * the value stays in the lower zone).
+ */
+export function bulletSegments(value: number, dayBudget: number, scaleMax: number): BulletSegment[] {
+  const dangerBudget = dayBudget * OVERSPEND_DANGER_RATIO;
+  const budgetFrac = scaleFrac(dayBudget, scaleMax);
+  const dangerFrac = scaleFrac(dangerBudget, scaleMax);
+  const valueFrac = scaleFrac(value, scaleMax);
+
+  const segments: BulletSegment[] = [{ level: "normal", start: 0, width: Math.min(valueFrac, budgetFrac) }];
+  if (value > dayBudget) {
+    segments.push({ level: "warn", start: budgetFrac, width: Math.min(valueFrac, dangerFrac) - budgetFrac });
+  }
+  if (value > dangerBudget) {
+    segments.push({ level: "danger", start: dangerFrac, width: valueFrac - dangerFrac });
+  }
+  return segments;
+}


### PR DESCRIPTION
Turn each "Dépenses par jour de la semaine" bar into a bullet chart: the green/orange/red overspend zones share one bar on a fixed scale, so the green base and the size of the overspend stay visible instead of the whole bar flipping to a single colour on a real over-budget account.

- Segments split at budget/j (plafond ÷ 7) and 2×, reusing OVERSPEND_DANGER_RATIO — same seuils as the Dépenses indicators (COS-34 / COS-36).
- Fixed scale max(day max, 2×budget) + headroom so both thresholds always stay in view (was relative to the day max).
- The two dashed thresholds are one continuous top-to-bottom guide over all seven rows, with their values labelled once beneath the bar column.
- No ceiling defined -> neutral MeterBar with no guides (unchanged fallback).
- Segment geometry extracted to a pure, unit-tested helper.