### PR TITLE
fix(stats): round bullet segment ends (COS-132)

### DIFF
--- a/front/src/components/statistics/WeekdayBulletBar.tsx
+++ b/front/src/components/statistics/WeekdayBulletBar.tsx
@@ -40,7 +40,7 @@ const WeekdayBulletBar = ({ value, dayBudget, scaleMax, height }: WeekdayBulletB
       {segments.map((seg) => (
         <span
           key={seg.level}
-          className="absolute inset-y-0"
+          className="absolute inset-y-0 rounded-sm"
           style={{
             left: `${seg.start * 100}%`,
             width: `${seg.width * 100}%`,


### PR DESCRIPTION
Give each weekday bullet-chart segment rounded-sm ends (matching the track), so the green, orange and red zones read as distinct rounded bars with a small notch at the junctions — the look of the approved mockup — instead of square butt joints.