### PR TITLE
feat(stats): de-mock biggest expense row (COS-46)

### DIFF
--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -12,6 +12,7 @@ export const QUERY_KEYS = {
   CHARTS: "charts",
   WEEKLY_STATS: "weeklyStats",
   DAILY_STATS: "dailyStats",
+  BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",
   CATEGORIES: "categories",
   CATEGORY_STATS: "categoryStats",
   EXCEPTIONALS: "exceptionals",

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -13,7 +13,6 @@ import {
   MONTHS_FR,
   maxIndex,
   monthlyTotals,
-  perCategoryTotals,
   yearTotal,
 } from "@components/statistics/helpers/statisticsData";
 import StatMiniChart from "@components/statistics/StatMiniChart";
@@ -27,7 +26,7 @@ import parseISO from "date-fns/parseISO";
 import { useState } from "react";
 
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
-import type { StatisticsResponse } from "@src/schemas/stats";
+import type { BiggestRegularExpense, StatisticsResponse } from "@src/schemas/stats";
 
 interface StatisticsKpisProps {
   statistics: StatisticsResponse | undefined;
@@ -35,6 +34,7 @@ interface StatisticsKpisProps {
   compareYear: number;
   exceptionals: ExceptionalItem[];
   compareExceptionals: ExceptionalItem[];
+  biggestRegular: BiggestRegularExpense | null;
   showExceptionals: boolean;
 }
 
@@ -132,15 +132,16 @@ const CmpRow = ({
   );
 };
 
-/** The four Statistiques KPI cards. Totals / averages / biggest month are real
- *  (from /statistics + /exceptionals); the "courante" biggest single expense in
- *  card 4 is MOCK — there is no per-transaction yearly endpoint. */
+/** The four Statistiques KPI cards, all real: totals / averages / biggest month
+ *  from /statistics + /exceptionals, and card 4's biggest single expenses from
+ *  /exceptionals (exceptional) + /biggest-regular-expense (courante). */
 const StatisticsKpis = ({
   statistics,
   year,
   compareYear,
   exceptionals,
   compareExceptionals,
+  biggestRegular,
   showExceptionals,
 }: StatisticsKpisProps) => {
   const [now] = useState(() => new Date());
@@ -174,12 +175,10 @@ const StatisticsKpis = ({
 
   // biggest single expense
   const topExc = biggestExceptional(exceptionals);
-  const topCategory = perCategoryTotals(data, statistics?.colors ?? {}, year)[0];
-  // MOCK — no per-transaction yearly endpoint; approximated from the top category
-  const mockRegularBiggest = topCategory
-    ? { label: cap(topCategory.name), amount: Math.round(topCategory.value / months) }
-    : { label: t.regularExpenseFallback, amount: 0 };
-  const expenseScale = Math.max(Number(topExc?.amount ?? 0), mockRegularBiggest.amount, 1);
+  const regularBiggest = biggestRegular
+    ? { label: cap(biggestRegular.label), amount: Number(biggestRegular.amount), date: biggestRegular.date }
+    : { label: t.regularExpenseFallback, amount: 0, date: null as string | null };
+  const expenseScale = Math.max(Number(topExc?.amount ?? 0), regularBiggest.amount, 1);
 
   return (
     <section className="grid grid-cols-1 gap-4 min-[520px]:grid-cols-2 min-[768px]:grid-cols-4">
@@ -266,11 +265,19 @@ const StatisticsKpis = ({
           <CmpRow
             tag={t.tag.regular}
             kind="reg"
-            title={mockRegularBiggest.label}
+            title={regularBiggest.label}
             titleVariant="expense"
-            amount={mockRegularBiggest.amount}
-            regWidth={mockRegularBiggest.amount / expenseScale}
+            amount={regularBiggest.amount}
+            regWidth={regularBiggest.amount / expenseScale}
             excWidth={0}
+            titleTooltip={
+              regularBiggest.date
+                ? t.tooltip.expenseInfo(
+                    regularBiggest.label,
+                    format(parseISO(regularBiggest.date), "d MMM yyyy", { locale: fr }),
+                  )
+                : undefined
+            }
           />
         </div>
       </Card>

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -19,6 +19,7 @@ import StatisticsHeatmap from "@components/statistics/StatisticsHeatmap";
 import StatisticsKpis from "@components/statistics/StatisticsKpis";
 import StatisticsMonthlyChart from "@components/statistics/StatisticsMonthlyChart";
 import StatisticsTopCategories from "@components/statistics/StatisticsTopCategories";
+import useBiggestRegularExpense from "@components/statistics/services/useBiggestRegularExpense";
 import useDailyStats from "@components/statistics/services/useDailyStats";
 import useStatistics from "@components/statistics/services/useStatistics";
 import { useMemo, useState } from "react";
@@ -46,6 +47,7 @@ const StatisticsView = () => {
 
   const { statistics, categories } = useStatistics({ years });
   const { dailyStats } = useDailyStats({ year: selectedYear });
+  const { biggestRegular } = useBiggestRegularExpense({ year: selectedYear });
   const { exceptionals } = useExceptionals({ year: selectedYear });
   const { exceptionals: compareExceptionals } = useExceptionals({
     year: compareYear,
@@ -127,6 +129,7 @@ const StatisticsView = () => {
         compareYear={compareYear}
         exceptionals={exceptionals}
         compareExceptionals={compareExceptionals}
+        biggestRegular={biggestRegular}
         showExceptionals={showExceptionals}
       />
 

--- a/front/src/components/statistics/services/useBiggestRegularExpense.tsx
+++ b/front/src/components/statistics/services/useBiggestRegularExpense.tsx
@@ -1,0 +1,33 @@
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@src/helpers/useRequestHelper";
+import { BiggestRegularExpenseResponseSchema } from "@src/schemas/stats";
+import { useQuery } from "react-query";
+
+import type { BiggestRegularExpenseResponse } from "@src/schemas/stats";
+
+interface UseBiggestRegularExpenseOptions {
+  year: number;
+}
+
+/**
+ * The biggest single one-off (non-exceptional) expense of the given year
+ * (COS-46). One request per year, cached like the other stats queries. Feeds the
+ * "courante" row of the "Plus grosse dépense" KPI card.
+ */
+const useBiggestRegularExpense = ({ year }: UseBiggestRegularExpenseOptions) => {
+  const { privateRequest } = useRequestHelper();
+
+  const getBiggestRegularExpense = async (): Promise<BiggestRegularExpenseResponse> => {
+    const response = await privateRequest(`/biggest-regular-expense?year=${year}`);
+    return BiggestRegularExpenseResponseSchema.parse(response.data);
+  };
+
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.BIGGEST_REGULAR_EXPENSE, year], getBiggestRegularExpense, {
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return { biggestRegular: data?.expense ?? null, isLoading, error };
+};
+
+export default useBiggestRegularExpense;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -42,3 +42,22 @@ export const DailyStatsResponseSchema = z.object({
 });
 
 export type DailyStatsResponse = z.infer<typeof DailyStatsResponseSchema>;
+
+// Biggest single one-off (non-exceptional) expense of a year (COS-46) — GET
+// /biggest-regular-expense. `expense` is null when the user has no spending that
+// year. Backs the "courante" row of the "Plus grosse dépense" KPI card.
+export const BiggestRegularExpenseSchema = z.object({
+  label: z.string(),
+  amount: numberLikeSchema,
+  date: z.string(),
+  categoryName: z.string().nullable(),
+  categoryColor: z.string().nullable(),
+});
+
+export type BiggestRegularExpense = z.infer<typeof BiggestRegularExpenseSchema>;
+
+export const BiggestRegularExpenseResponseSchema = z.object({
+  expense: BiggestRegularExpenseSchema.nullable(),
+});
+
+export type BiggestRegularExpenseResponse = z.infer<typeof BiggestRegularExpenseResponseSchema>;

--- a/nest-api/src/stats/dto/biggest-regular-expense-query.dto.ts
+++ b/nest-api/src/stats/dto/biggest-regular-expense-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class BiggestRegularExpenseQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  year: string;
+}

--- a/nest-api/src/stats/dto/biggest-regular-expense-response.interface.ts
+++ b/nest-api/src/stats/dto/biggest-regular-expense-response.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * The single biggest one-off (non-exceptional) expense of a year
+ * (GET /biggest-regular-expense?year=YYYY).
+ *
+ * Read from the one-off `Spendings` table only — recurrings and exceptionals
+ * live in their own tables — so the row is a real "hors récurrent / hors
+ * exceptionnel" spending; no itemType filter is needed. Backs the "courante" row
+ * of the Statistiques "Plus grosse dépense" KPI card (COS-46).
+ */
+export interface BiggestRegularExpense {
+  /** The spending's label. */
+  label: string;
+  /** Its amount, rounded to the cent. */
+  amount: number;
+  /** ISO date (YYYY-MM-DD, UTC) of the spending. */
+  date: string;
+  /** Category name, or null for an uncategorized spending. */
+  categoryName: string | null;
+  /** Category color, or null for an uncategorized spending. */
+  categoryColor: string | null;
+}
+
+export interface BiggestRegularExpenseResponse {
+  /** The biggest regular expense of the year, or null when there is none. */
+  expense: BiggestRegularExpense | null;
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -5,6 +5,7 @@ import { MonthlyStatsQueryDto } from "@stats/dto/monthly-stats-query.dto";
 import { StatisticsQueryDto } from "@stats/dto/statistics-query.dto";
 import { RegularMonthlyAverageQueryDto } from "@stats/dto/regular-monthly-average-query.dto";
 import { DailyStatsQueryDto } from "@stats/dto/daily-stats-query.dto";
+import { BiggestRegularExpenseQueryDto } from "@stats/dto/biggest-regular-expense-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 
@@ -79,5 +80,16 @@ export class DailyStatsController {
   @Get()
   async getDailyStats(@Query() query: DailyStatsQueryDto, @GetUserId() userID: string) {
     return this.statsService.getDailyStats(query.year, userID);
+  }
+}
+
+@Controller("biggest-regular-expense")
+@UseGuards(SessionAuthGuard)
+export class BiggestRegularExpenseController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getBiggestRegularExpense(@Query() query: BiggestRegularExpenseQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getBiggestRegularExpense(query.year, userID);
   }
 }

--- a/nest-api/src/stats/stats.module.ts
+++ b/nest-api/src/stats/stats.module.ts
@@ -7,6 +7,7 @@ import {
   RegularMonthlyAverageController,
   CategoryStatsController,
   DailyStatsController,
+  BiggestRegularExpenseController,
 } from "@stats/stats.controller";
 import { PrismaModule } from "../prisma/prisma.module";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
@@ -20,6 +21,7 @@ import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
     RegularMonthlyAverageController,
     CategoryStatsController,
     DailyStatsController,
+    BiggestRegularExpenseController,
   ],
   providers: [StatsService, SessionAuthGuard],
 })

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -163,3 +163,96 @@ describe("StatsService.getDailyStats", () => {
     expect(result.days).toEqual([{ date: "2023-02-01", total: 10.01, count: 2 }]);
   });
 });
+
+/**
+ * Unit tests for StatsService.getBiggestRegularExpense — the single biggest
+ * one-off (non-exceptional) expense of a year, backing the "courante" row of the
+ * Statistiques "Plus grosse dépense" KPI card (COS-46). Prisma is mocked; these
+ * assert the query shape (max-amount row in the Spendings table only) and the
+ * mapping to the response envelope.
+ */
+describe("StatsService.getBiggestRegularExpense", () => {
+  const makeService = (findFirstResult: unknown) => {
+    const findFirst = jest.fn().mockResolvedValue(findFirstResult);
+    const prisma = { spendings: { findFirst } } as unknown as never;
+    return { service: new StatsService(prisma), findFirst };
+  };
+
+  it("returns a null expense and skips the query for a non-numeric year", async () => {
+    const { service, findFirst } = makeService(null);
+
+    await expect(service.getBiggestRegularExpense("not-a-year", "user-1")).resolves.toEqual({ expense: null });
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("queries the year's max-amount spending as a half-open UTC range, scoped to the user", async () => {
+    const { service, findFirst } = makeService(null);
+
+    await service.getBiggestRegularExpense("2023", "user-1");
+
+    // Spendings table only (exceptionals/recurrings live elsewhere), biggest
+    // amount first, with the category joined for the label/color.
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        userID: "user-1",
+        date: { gte: new Date(Date.UTC(2023, 0, 1)), lt: new Date(Date.UTC(2024, 0, 1)) },
+      },
+      orderBy: { amount: "desc" },
+      include: { category: true },
+    });
+  });
+
+  it("returns a null expense when the user has no spending that year", async () => {
+    const { service } = makeService(null);
+
+    await expect(service.getBiggestRegularExpense("2023", "user-1")).resolves.toEqual({ expense: null });
+  });
+
+  it("maps the biggest row to label / amount / UTC date / category", async () => {
+    const { service } = makeService({
+      label: "Canapé",
+      amount: 899.9,
+      date: new Date("2023-06-15T00:00:00.000Z"),
+      category: { name: "Maison", color: "#abcdef" },
+    });
+
+    await expect(service.getBiggestRegularExpense("2023", "user-1")).resolves.toEqual({
+      expense: {
+        label: "Canapé",
+        amount: 899.9,
+        date: "2023-06-15",
+        categoryName: "Maison",
+        categoryColor: "#abcdef",
+      },
+    });
+  });
+
+  it("returns null category fields for an uncategorized spending", async () => {
+    const { service } = makeService({
+      label: "Divers",
+      amount: 300,
+      date: new Date("2023-02-01T00:00:00.000Z"),
+      category: null,
+    });
+
+    const result = await service.getBiggestRegularExpense("2023", "user-1");
+
+    expect(result).toEqual({
+      expense: { label: "Divers", amount: 300, date: "2023-02-01", categoryName: null, categoryColor: null },
+    });
+  });
+
+  it("coerces a Prisma Decimal amount (object with toString) to a number", async () => {
+    const decimal = { toString: () => "1499.99" };
+    const { service } = makeService({
+      label: "Frigo",
+      amount: decimal,
+      date: new Date("2023-11-20T00:00:00.000Z"),
+      category: { name: "Maison", color: "#000000" },
+    });
+
+    const result = await service.getBiggestRegularExpense("2023", "user-1");
+
+    expect(result.expense?.amount).toBeCloseTo(1499.99, 2);
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -6,6 +6,7 @@ import { PrismaService } from "../prisma/prisma.service";
 import type { StatisticsResponse } from "@stats/dto/statistics-response.interface";
 import type { CategoryStat, CategoryStatsResponse } from "@stats/dto/category-stats-response.interface";
 import type { DailyStat, DailyStatsResponse } from "@stats/dto/daily-stats-response.interface";
+import type { BiggestRegularExpenseResponse } from "@stats/dto/biggest-regular-expense-response.interface";
 
 /** Rounds to 2 decimal places to avoid JS float precision issues. */
 const roundCurrency = (n: number): number => Math.round(n);
@@ -210,6 +211,44 @@ export class StatsService {
       .sort((a, b) => a.date.localeCompare(b.date));
 
     return { days };
+  }
+
+  /**
+   * The single biggest one-off (non-exceptional) expense of a year (COS-46).
+   * Reads the `Spendings` table only, so recurrings and exceptionals — which live
+   * in their own tables — are excluded by construction; no itemType filter needed.
+   * Amounts are stored positive, so the max-amount row is the biggest expense.
+   * Uses the same half-open UTC range as the daily stats. Returns a null expense
+   * when the user has no spending that year. Backs the "courante" row of the
+   * "Plus grosse dépense" KPI card.
+   */
+  async getBiggestRegularExpense(yearStr: string, userID: string): Promise<BiggestRegularExpenseResponse> {
+    const year = parseInt(yearStr, 10);
+    if (Number.isNaN(year)) {
+      return { expense: null };
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const nextYearStart = new Date(Date.UTC(year + 1, 0, 1));
+
+    const row = await this.prisma.spendings.findFirst({
+      where: { userID, date: { gte: yearStart, lt: nextYearStart } },
+      orderBy: { amount: "desc" },
+      include: { category: true },
+    });
+    if (!row) {
+      return { expense: null };
+    }
+
+    return {
+      expense: {
+        label: row.label,
+        amount: round2(Number(row.amount)),
+        date: row.date.toISOString().slice(0, 10),
+        categoryName: row.category?.name ?? null,
+        categoryColor: row.category?.color ?? null,
+      },
+    };
   }
 
   async getStatistics(categoryIDs: string[], years: string[], userID: string): Promise<StatisticsResponse> {


### PR DESCRIPTION
Add GET /biggest-regular-expense?year=YYYY returning the single biggest row of the Spendings table for the user/year. Exceptionals live in their own table, so querying Spendings excludes them by construction — no itemType filter needed.

Front: new useBiggestRegularExpense hook + Zod schema feed the real label/amount (and a date tooltip) into the "courante" row of the "Plus grosse dépense" KPI card, replacing the topCategory/months mock. The exceptional row is unchanged.