### PR TITLE
feat(stats): de-mock year-end projection (COS-47)

### DIFF
--- a/front/src/components/statistics/StatisticsForecast.tsx
+++ b/front/src/components/statistics/StatisticsForecast.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-// MOCK — the end-of-year projection is a synthetic average-forward model
-// (spent / days-elapsed × days-in-year). Spent + the year-over-year figure are real.
-
 import GlowCard from "@components/shared/GlowCard";
 import { Overline } from "@components/shared/Overline";
 import { exceptionalTotal } from "@components/statistics/helpers/exceptionalsData";
-import { yearTotal } from "@components/statistics/helpers/statisticsData";
+import { projectedRemainingRegular } from "@components/statistics/helpers/projection";
+import { monthlyPresence, monthlyTotals, yearTotal } from "@components/statistics/helpers/statisticsData";
 import { AnimatedNumber, CursorTooltip, ProgressTrack, useCursorHover } from "@lib/dataviz";
 import { euro, euro0 } from "@lib/format";
 import statisticsText from "@text/statistics";
@@ -15,8 +13,14 @@ import getDayOfYear from "date-fns/getDayOfYear";
 import fr from "date-fns/locale/fr";
 import { useState } from "react";
 
+import type { YearMonthly } from "@components/statistics/helpers/projection";
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
 import type { StatisticsResponse } from "@src/schemas/stats";
+
+const yearMonthly = (data: StatisticsResponse["data"] | undefined, year: number): YearMonthly => ({
+  totals: monthlyTotals(data, year),
+  present: monthlyPresence(data, year),
+});
 
 interface StatisticsForecastProps {
   statistics: StatisticsResponse | undefined;
@@ -46,10 +50,22 @@ const StatisticsForecast = ({
   const isCurrent = year === now.getFullYear();
   const daysInYear = getDayOfYear(new Date(year, 11, 31));
   const daysElapsed = isCurrent ? getDayOfYear(now) : daysInYear;
-  const projection = isCurrent && daysElapsed > 0 ? (spent / daysElapsed) * daysInYear : spent; // MOCK
   const perDay = daysElapsed > 0 ? spent / daysElapsed : 0;
-  const delta = projection - compareTotal;
   const asOfLabel = isCurrent ? format(now, "d MMM", { locale: fr }) : t.endOfYear;
+
+  // Real end-of-year projection: cumulative-to-date + the rest of the year
+  // estimated month by month from history (same month N-1 → N-2 → previous
+  // month), exceptionals left as known one-offs. A past year is already complete,
+  // so its projection is just its actual total. `null` remaining = the user's very
+  // first month of data (no reference) → no projection shown.
+  const remaining = isCurrent
+    ? projectedRemainingRegular(yearMonthly(data, year), yearMonthly(data, year - 1), yearMonthly(data, year - 2), now)
+    : 0;
+  const projection = remaining === null ? null : spent + remaining;
+  const delta = projection === null ? 0 : projection - compareTotal;
+  // Tell "loaded, no history" (show the reason) apart from "still loading" (stay
+  // silent) — the empty-reference path resolves to null in both cases.
+  const noHistory = projection === null && data !== undefined;
 
   return (
     <GlowCard
@@ -95,24 +111,37 @@ const StatisticsForecast = ({
         onMouseLeave={projectionTip.clear}
       >
         <Overline>{t.projectionTitle}</Overline>
-        <AnimatedNumber
-          value={projection}
-          decimals={0}
-          suffix=" €"
-          color="var(--accent-strong)"
-          className="num text-2xl font-medium tracking-tight"
-        />
-        <span className="text-xs text-ink-3">
-          <span className={delta > 0 ? "text-neg" : "text-accent-strong"}>
-            {delta > 0 ? `+${euro0(delta)}` : euro0(delta)} €
-          </span>{" "}
-          {t.vsCompare(compareYear, euro0(compareTotal))}
-        </span>
+        {projection === null ? (
+          <>
+            <span className="num text-2xl font-medium tracking-tight text-ink-3">—</span>
+            {noHistory && <span className="text-xs text-ink-3">{t.noProjection}</span>}
+          </>
+        ) : (
+          <>
+            <AnimatedNumber
+              value={projection}
+              decimals={0}
+              suffix=" €"
+              color="var(--accent-strong)"
+              className="num text-2xl font-medium tracking-tight"
+            />
+            <span className="text-xs text-ink-3">
+              <span className={delta > 0 ? "text-neg" : "text-accent-strong"}>
+                {delta > 0 ? `+${euro0(delta)}` : euro0(delta)} €
+              </span>{" "}
+              {t.vsCompare(compareYear, euro0(compareTotal))}
+            </span>
+          </>
+        )}
         <CursorTooltip point={projectionTip.hover}>
           {projectionTip.hover
-            ? isCurrent
-              ? t.tooltip.projectionModel(euro(perDay), daysInYear)
-              : t.tooltip.projectionActual
+            ? projection === null
+              ? noHistory
+                ? t.tooltip.noProjection
+                : null
+              : isCurrent
+                ? t.tooltip.projectionModel
+                : t.tooltip.projectionActual
             : null}
         </CursorTooltip>
       </div>

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -43,7 +43,15 @@ const StatisticsView = () => {
   const [showExceptionals, setShowExceptionals] = useState(true);
   const [selectedCategoryIds, setSelectedCategoryIds] = useState<string[]>([]);
 
-  const years = useMemo(() => Array.from(new Set([selectedYear, compareYear])), [selectedYear, compareYear]);
+  // The current-year forecast projects the rest of the year from history, so it
+  // needs N-1 and N-2 alongside the selected + compare years (COS-47). N-1 is
+  // usually already the compare year; N-2 is the extra fetch. Only added when the
+  // current year is in view — past years are complete and never projected.
+  const years = useMemo(() => {
+    const requested = [selectedYear, compareYear];
+    if (selectedYear === currentYear) requested.push(selectedYear - 1, selectedYear - 2);
+    return Array.from(new Set(requested));
+  }, [selectedYear, compareYear, currentYear]);
 
   const { statistics, categories } = useStatistics({ years });
   const { dailyStats } = useDailyStats({ year: selectedYear });

--- a/front/src/components/statistics/helpers/__tests__/projection.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/projection.test.ts
@@ -1,0 +1,79 @@
+import { projectedRemainingRegular } from "@components/statistics/helpers/projection";
+
+import type { YearMonthly } from "@components/statistics/helpers/projection";
+
+const ym = (totals: number[], present: boolean[]): YearMonthly => ({ totals, present });
+const zeros = Array<number>(12).fill(0);
+const allFalse = Array<boolean>(12).fill(false);
+const allTrue = Array<boolean>(12).fill(true);
+const empty = ym(zeros, allFalse);
+
+// Distinct per-month values so an index bug can't hide: Jan=10 … Dec=120.
+const rising = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120];
+
+describe("projectedRemainingRegular", () => {
+  // 19 July 2026: 12 of the month's 31 days remain → the in-progress month is
+  // prorated at 12/31.
+  const midJuly = new Date(2026, 6, 19);
+  const julyShare = 12 / 31;
+
+  it("estimates the rest of the year from the same months last year (N-1)", () => {
+    const result = projectedRemainingRegular(empty, ym(rising, allTrue), empty, midJuly);
+    // July remainder (70 × 12/31) + Aug…Dec in full (80+90+100+110+120).
+    expect(result).toBeCloseTo(500 + 70 * julyShare, 6);
+  });
+
+  it("falls back to two years ago (N-2) for a month N-1 is missing", () => {
+    const lastYear = ym(
+      rising,
+      allTrue.map((_, i) => i !== 8),
+    ); // September absent in N-1
+    const twoAgo = ym(
+      [...zeros].map((_, i) => (i === 8 ? 999 : 0)),
+      allTrue.map((_, i) => i === 8),
+    );
+    const result = projectedRemainingRegular(empty, lastYear, twoAgo, midJuly);
+    // Aug 80 + Sep 999 (from N-2) + Oct 100 + Nov 110 + Dec 120 = 1409.
+    expect(result).toBeCloseTo(1409 + 70 * julyShare, 6);
+  });
+
+  it("falls back to the previous month (M-1) when there is no prior year", () => {
+    const current = ym(
+      [...zeros].map((_, i) => (i === 5 ? 600 : 0)),
+      allTrue.map((_, i) => i === 5),
+    ); // June only
+    const result = projectedRemainingRegular(current, empty, empty, midJuly);
+    // Every remaining month uses June's 600: Aug…Dec (×5) + July remainder.
+    expect(result).toBeCloseTo(3000 + 600 * julyShare, 6);
+  });
+
+  it("returns null at the very first month of data (no reference at all)", () => {
+    const current = ym(
+      zeros,
+      allTrue.map((_, i) => i === 6),
+    ); // July only, no earlier month
+    const result = projectedRemainingRegular(current, empty, empty, midJuly);
+    expect(result).toBeNull();
+  });
+
+  it("only prorates the in-progress month when it is the last of the year", () => {
+    const midDecember = new Date(2026, 11, 15); // 16 of 31 days remain
+    const result = projectedRemainingRegular(empty, ym(rising, allTrue), empty, midDecember);
+    expect(result).toBeCloseTo(120 * (16 / 31), 6);
+  });
+
+  it("uses presence, not value: a real zero-spend reference month counts", () => {
+    const midDecember = new Date(2026, 11, 15);
+    const lastYear = ym(
+      zeros,
+      allTrue.map((_, i) => i === 11),
+    ); // Dec present but 0
+    const twoAgo = ym(
+      [...zeros].map((_, i) => (i === 11 ? 999 : 0)),
+      allTrue.map((_, i) => i === 11),
+    );
+    const result = projectedRemainingRegular(empty, lastYear, twoAgo, midDecember);
+    // N-1's real 0 wins over N-2's 999 → the December remainder is 0, not null.
+    expect(result).toBe(0);
+  });
+});

--- a/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
@@ -1,0 +1,32 @@
+import { monthlyPresence, monthlyTotals } from "@components/statistics/helpers/statisticsData";
+
+import type { StatisticsResponse } from "@src/schemas/stats";
+
+const data: StatisticsResponse["data"] = {
+  "2026": [
+    { month: "janv.", food: 10, rent: 5 },
+    { month: "mars", food: 0 }, // present, but a genuine zero total
+  ],
+};
+
+describe("monthlyPresence", () => {
+  it("flags only the months the year actually has a row for", () => {
+    const present = monthlyPresence(data, 2026);
+    expect(present[0]).toBe(true); // janv.
+    expect(present[2]).toBe(true); // mars — present even though its total is 0
+    expect(present[1]).toBe(false); // févr. — no row
+    expect(present.filter(Boolean)).toHaveLength(2);
+  });
+
+  it("tells a real zero-spend month apart from a no-data month", () => {
+    const totals = monthlyPresence(data, 2026);
+    // March totals to 0 but is present; February is simply absent.
+    expect(monthlyTotals(data, 2026)[2]).toBe(0);
+    expect(totals[2]).toBe(true);
+    expect(totals[1]).toBe(false);
+  });
+
+  it("returns an all-false mask for a year with no data", () => {
+    expect(monthlyPresence(data, 2020)).toEqual(Array(12).fill(false));
+  });
+});

--- a/front/src/components/statistics/helpers/projection.ts
+++ b/front/src/components/statistics/helpers/projection.ts
@@ -1,0 +1,78 @@
+import getDaysInMonth from "date-fns/getDaysInMonth";
+
+/**
+ * Per-month projection helper, following the GLOBAL projection chain shared with
+ * the dashboard sparkline (COS-27) and the monthly chart (COS-50): to estimate a
+ * month, prefer the same month last year (N-1), then two years ago (N-2), then
+ * fall back to the previous calendar month (M-1). The chain resolves per month,
+ * so a partial year still projects month by month.
+ */
+export interface YearMonthly {
+  /** 12-slot (Jan→Dec) regular monthly totals. */
+  totals: number[];
+  /** 12-slot presence mask: true where the year has ≥1 spending that month. */
+  present: boolean[];
+}
+
+/**
+ * Projected *additional* regular spend for the rest of the current year: the
+ * remainder of the in-progress month plus full estimates for every later month,
+ * each estimated via the chain (N-1 → N-2 → M-1). Exceptionals are never
+ * extrapolated — they are one-offs, so only the year's known ones count (added by
+ * the caller). Returns null when no historical reference exists at all (the
+ * user's very first month of data → no projection is shown).
+ *
+ * The in-progress month is split: its actual spend so far is already in the
+ * caller's cumulative total, so only its remainder is projected here, prorated by
+ * the share of the month still ahead (assumes an even daily pace over the
+ * reference month).
+ */
+export const projectedRemainingRegular = (
+  current: YearMonthly,
+  lastYear: YearMonthly,
+  twoYearsAgo: YearMonthly,
+  now: Date,
+): number | null => {
+  const curMonth = now.getMonth();
+
+  // Single M-1 anchor: the previous calendar month's total (wrapping January back
+  // to last December), used for any month the two prior years do not cover.
+  const prevIdx = (curMonth + 11) % 12;
+  const mMinus1 =
+    curMonth === 0
+      ? lastYear.present[prevIdx]
+        ? lastYear.totals[prevIdx]
+        : null
+      : current.present[prevIdx]
+        ? current.totals[prevIdx]
+        : null;
+
+  const estimate = (m: number): number | null => {
+    if (lastYear.present[m]) return lastYear.totals[m];
+    if (twoYearsAgo.present[m]) return twoYearsAgo.totals[m];
+    return mMinus1;
+  };
+
+  let remaining = 0;
+  let hasEstimate = false;
+
+  // In-progress month: only the not-yet-elapsed share is projected.
+  const currentEstimate = estimate(curMonth);
+  if (currentEstimate !== null) {
+    const daysInMonth = getDaysInMonth(now);
+    const remainingShare = (daysInMonth - now.getDate()) / daysInMonth;
+    remaining += currentEstimate * remainingShare;
+    hasEstimate = true;
+  }
+
+  // Whole future months.
+  for (let m = curMonth + 1; m < 12; m += 1) {
+    const monthEstimate = estimate(m);
+    if (monthEstimate !== null) {
+      remaining += monthEstimate;
+      hasEstimate = true;
+    }
+  }
+
+  return hasEstimate ? remaining : null;
+};

--- a/front/src/components/statistics/helpers/statisticsData.ts
+++ b/front/src/components/statistics/helpers/statisticsData.ts
@@ -45,6 +45,21 @@ export const monthlyTotals = (data: StatData | undefined, year: number): number[
 export const yearTotal = (data: StatData | undefined, year: number): number =>
   monthlyTotals(data, year).reduce((a, b) => a + b, 0);
 
+/**
+ * 12-slot mask (Jan→Dec) of which months `year` has any data for. `/statistics`
+ * only emits a row for a month once it has a spending, so this tells a real
+ * zero-spend month apart from a no-data one — the projection chain needs the
+ * distinction to know whether a reference month actually exists.
+ */
+export const monthlyPresence = (data: StatData | undefined, year: number): boolean[] => {
+  const present = Array<boolean>(12).fill(false);
+  rowsForYear(data, year).forEach((row, i) => {
+    const idx = MONTHS_FR.indexOf(String(row.month));
+    present[idx >= 0 ? idx : i] = true;
+  });
+  return present;
+};
+
 /** Round up to a "nice" axis ceiling (1, 1.5, 2, 3, 4, 5, 7.5, 10 × 10ⁿ). */
 export const niceCeil = (value: number): number => {
   if (value <= 0) return 1;

--- a/front/src/text/statistics.ts
+++ b/front/src/text/statistics.ts
@@ -42,10 +42,12 @@ const statistics = {
     endOfYear: "31 déc.",
     projectionAxis: "— projection —",
     projectionTitle: "Projection fin d'année",
+    noProjection: "Historique insuffisant",
     vsCompare: (compareYear: number, total: string) => `vs ${compareYear} (${total} €)`,
     tooltip: {
-      projectionModel: (perDay: string, days: number) => `Au rythme actuel · ${perDay} €/jour × ${days} jours`,
+      projectionModel: "Reste de l'année estimé d'après l'historique (même mois N-1) · exceptionnels non extrapolés",
       projectionActual: "Total réalisé sur l'année",
+      noProjection: "Aucun historique pour projeter — première période de données",
     },
   },
   monthlyChart: {


### PR DESCRIPTION
Replace the linear average-forward mock with a history-based model: cumulative-to-date + the rest of the year estimated month by month via the global projection chain (same month N-1 -> N-2 -> previous month). Exceptionals are no longer extrapolated — they count once as known one-offs, so a big trip stops inflating the projection. The very first month of data (no reference) shows no projection.

- projection.ts: projectedRemainingRegular helper (+ tests)
- statisticsData.ts: monthlyPresence, to tell a real zero-spend month apart from a no-data one (+ tests)
- StatisticsView: request N-2 for the current-year chain (/statistics already accepts an arbitrary years array, so no backend change)
- delta vs compare recomputed from the real projection