### PR TITLE
feat(stats): de-mock monthly chart projection + budget (COS-50)

### DIFF
--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -9,6 +9,7 @@ export const QUERY_KEYS = {
   INITIAL_AMOUNT: "initialAmount",
   DASHBOARD: "dashboard",
   DAILY_PROJECTION: "dailyProjection",
+  MONTHLY_INCOME: "monthlyIncome",
   CHARTS: "charts",
   WEEKLY_STATS: "weeklyStats",
   DAILY_STATS: "dailyStats",

--- a/front/src/components/statistics/StatisticsForecast.tsx
+++ b/front/src/components/statistics/StatisticsForecast.tsx
@@ -3,8 +3,8 @@
 import GlowCard from "@components/shared/GlowCard";
 import { Overline } from "@components/shared/Overline";
 import { exceptionalTotal } from "@components/statistics/helpers/exceptionalsData";
-import { projectedRemainingRegular } from "@components/statistics/helpers/projection";
-import { monthlyPresence, monthlyTotals, yearTotal } from "@components/statistics/helpers/statisticsData";
+import { projectedRemainingRegular, toYearMonthly } from "@components/statistics/helpers/projection";
+import { yearTotal } from "@components/statistics/helpers/statisticsData";
 import { AnimatedNumber, CursorTooltip, ProgressTrack, useCursorHover } from "@lib/dataviz";
 import { euro, euro0 } from "@lib/format";
 import statisticsText from "@text/statistics";
@@ -13,14 +13,8 @@ import getDayOfYear from "date-fns/getDayOfYear";
 import fr from "date-fns/locale/fr";
 import { useState } from "react";
 
-import type { YearMonthly } from "@components/statistics/helpers/projection";
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
 import type { StatisticsResponse } from "@src/schemas/stats";
-
-const yearMonthly = (data: StatisticsResponse["data"] | undefined, year: number): YearMonthly => ({
-  totals: monthlyTotals(data, year),
-  present: monthlyPresence(data, year),
-});
 
 interface StatisticsForecastProps {
   statistics: StatisticsResponse | undefined;
@@ -59,7 +53,12 @@ const StatisticsForecast = ({
   // so its projection is just its actual total. `null` remaining = the user's very
   // first month of data (no reference) → no projection shown.
   const remaining = isCurrent
-    ? projectedRemainingRegular(yearMonthly(data, year), yearMonthly(data, year - 1), yearMonthly(data, year - 2), now)
+    ? projectedRemainingRegular(
+        toYearMonthly(data, year),
+        toYearMonthly(data, year - 1),
+        toYearMonthly(data, year - 2),
+        now,
+      )
     : 0;
   const projection = remaining === null ? null : spent + remaining;
   const delta = projection === null ? 0 : projection - compareTotal;

--- a/front/src/components/statistics/StatisticsMonthlyChart.tsx
+++ b/front/src/components/statistics/StatisticsMonthlyChart.tsx
@@ -1,19 +1,12 @@
 "use client";
 
-// The exceptional caps, the 2026 bars and the compare-year line are all real
-// (from /statistics + /exceptionals). Two things are marked MOCK: the flat
-// "budget mensuel" reference (the real monthly income drawn flat across the
-// year — there is no per-month budget endpoint) and the current-month
-// end-of-month projection (an average-forward estimate).
-
 import { CardTitle } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { LegendItem } from "@components/shared/LegendItem";
-import { MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
+import { filledMonthlyIncome, MONTHS_FR, niceCeil } from "@components/statistics/helpers/statisticsData";
 import useElementWidth from "@lib/dataviz/useElementWidth";
 import { euro0 } from "@lib/format";
 import statistics from "@text/statistics";
-import getDaysInMonth from "date-fns/getDaysInMonth";
 
 interface StatisticsMonthlyChartProps {
   year: number;
@@ -24,8 +17,12 @@ interface StatisticsMonthlyChartProps {
   exceptionalMonthly: number[];
   /** 12-slot Jan→Dec total spend for `compareYear`. */
   compareMonthly: number[];
-  /** Real monthly income, drawn as a flat reference line (MOCK: flat). */
-  monthlyBudget: number | null;
+  /** 12-slot Jan→Dec monthly income (dashboard initialAmount); null where the
+   *  user has no dashboard row. Drawn as a stepped "budget mensuel" line. */
+  monthlyIncome: (number | null)[];
+  /** Projected regular remainder of the in-progress month (chain N-1 → N-2 →
+   *  M-1), or null when there's no reference. Added to the realized total. */
+  projectedRemainder: number | null;
   compareEnabled: boolean;
   showExceptionals: boolean;
   now: Date;
@@ -63,7 +60,8 @@ const StatisticsMonthlyChart = ({
   regularMonthly,
   exceptionalMonthly,
   compareMonthly,
-  monthlyBudget,
+  monthlyIncome,
+  projectedRemainder,
   compareEnabled,
   showExceptionals,
   now,
@@ -79,17 +77,20 @@ const StatisticsMonthlyChart = ({
   const exc = regularMonthly.map((_, i) => (showExceptionals ? (exceptionalMonthly[i] ?? 0) : 0));
   const total = regularMonthly.map((v, i) => v + exc[i]);
 
-  // current-month end-of-month projection (MOCK — average-forward)
-  const dayOfMonth = now.getDate();
-  const daysInMonth = getDaysInMonth(now);
+  // current-month end-of-month projection: realized so far + the regular
+  // remainder estimated from history (chain N-1 → N-2 → M-1), exceptionals not
+  // extrapolated. A null remainder = the user's first month of data → no
+  // projection.
   const realizedCM = total[cm] ?? 0;
-  const projectedCM = isCurrentYear && dayOfMonth > 0 ? (realizedCM / dayOfMonth) * daysInMonth : 0;
-  const hasProjection = isCurrentYear && realizedCount > 0 && projectedCM > realizedCM + 1;
+  const projectedCM = realizedCM + (projectedRemainder ?? 0);
+  const hasProjection = isCurrentYear && realizedCount > 0 && projectedRemainder !== null && projectedRemainder > 1;
+
+  const budgetSeries = filledMonthlyIncome(monthlyIncome);
 
   const scaleValues = [
     ...range(realizedCount).map((m) => total[m]),
     ...(compareEnabled ? compareMonthly : []),
-    ...(monthlyBudget ? [monthlyBudget] : []),
+    ...(budgetSeries ?? []),
     ...(hasProjection ? [projectedCM] : []),
     1,
   ];
@@ -106,7 +107,17 @@ const StatisticsMonthlyChart = ({
     value: (yMax * (4 - i)) / 4,
   }));
 
-  const budgetY = monthlyBudget ? yFor(monthlyBudget) : null;
+  // Stepped budget line: one horizontal segment per month at that month's income,
+  // stepping vertically where income changes (income assumed constant within a
+  // month). Spans the full plot width like the old flat line.
+  const budgetStepPath = budgetSeries
+    ? range(12)
+        .map((m) => {
+          const y = yFor(budgetSeries[m]);
+          return `${m === 0 ? "M" : "L"} ${PAD_L + slotW * m} ${y} L ${PAD_L + slotW * (m + 1)} ${y}`;
+        })
+        .join(" ")
+    : null;
   const showCompare = compareEnabled && compareMonthly.some((v) => v > 0);
   const comparePath = range(12)
     .map((m) => `${m === 0 ? "M" : "L"} ${cx(m)} ${yFor(compareMonthly[m])}`)
@@ -214,21 +225,19 @@ const StatisticsMonthlyChart = ({
               </g>
             ))}
 
-            {/* budget mensuel (flat reference) */}
-            {budgetY != null && (
+            {/* budget mensuel (per-month stepped reference) */}
+            {budgetSeries && (
               <>
-                <line
-                  x1={PAD_L}
-                  x2={width - PAD_R}
-                  y1={budgetY}
-                  y2={budgetY}
+                <path
+                  d={budgetStepPath ?? ""}
+                  fill="none"
                   stroke="var(--ink-3)"
                   strokeWidth={1}
                   strokeDasharray="3 5"
                 />
                 <text
                   x={width - PAD_R}
-                  y={budgetY - 6}
+                  y={yFor(budgetSeries[11]) - 6}
                   fontSize={10}
                   textAnchor="end"
                   fill="var(--ink-3)"
@@ -342,7 +351,7 @@ const StatisticsMonthlyChart = ({
               );
             })}
 
-            {/* current-month projection (MOCK) */}
+            {/* current-month projection (realized + history-based remainder) */}
             {hasProjection && (
               <g>
                 <rect

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -4,6 +4,7 @@ import useExceptionals from "@components/exceptionals/services/useExceptionals";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useReccurings from "@components/spendings/services/useReccurings";
 import { exceptionalMonthly } from "@components/statistics/helpers/exceptionalsData";
+import { projectedCurrentMonthRemainder, toYearMonthly } from "@components/statistics/helpers/projection";
 import {
   categoryMonthly,
   elapsedMonths,
@@ -21,6 +22,7 @@ import StatisticsMonthlyChart from "@components/statistics/StatisticsMonthlyChar
 import StatisticsTopCategories from "@components/statistics/StatisticsTopCategories";
 import useBiggestRegularExpense from "@components/statistics/services/useBiggestRegularExpense";
 import useDailyStats from "@components/statistics/services/useDailyStats";
+import useMonthlyIncome from "@components/statistics/services/useMonthlyIncome";
 import useStatistics from "@components/statistics/services/useStatistics";
 import { useMemo, useState } from "react";
 
@@ -62,13 +64,26 @@ const StatisticsView = () => {
   });
   const dashboard = useDashboard();
   const { recurrings } = useReccurings();
+  const { monthlyIncome } = useMonthlyIncome({ year: selectedYear });
 
   const data = statistics?.data;
   const colors = statistics?.colors ?? {};
   const regularMonthly = monthlyTotals(data, selectedYear);
   const excMonthly = exceptionalMonthly(exceptionals);
   const compareMonthly = monthlyTotals(data, compareYear);
-  const monthlyBudget = dashboard.get.data ? Number(dashboard.get.data.initialAmount) || null : null;
+  // Real end-of-month projection for the in-progress month (COS-50): its regular
+  // remainder estimated from history (chain N-1 → N-2 → M-1), null at the very
+  // first month of data. Only the current year is projected — past years are
+  // complete. The chart adds the realized total (exceptionals not extrapolated).
+  const projectedRemainder =
+    selectedYear === currentYear
+      ? projectedCurrentMonthRemainder(
+          toYearMonthly(data, selectedYear),
+          toYearMonthly(data, selectedYear - 1),
+          toYearMonthly(data, selectedYear - 2),
+          now,
+        )
+      : null;
 
   const prevTotals = perCategoryTotals(data, colors, compareYear);
   const prevByName = new Map(prevTotals.map((c) => [c.name, c.value]));
@@ -156,7 +171,8 @@ const StatisticsView = () => {
         regularMonthly={regularMonthly}
         exceptionalMonthly={excMonthly}
         compareMonthly={compareMonthly}
-        monthlyBudget={monthlyBudget}
+        monthlyIncome={monthlyIncome ?? []}
+        projectedRemainder={projectedRemainder}
         compareEnabled={compareEnabled}
         showExceptionals={showExceptionals}
         now={now}

--- a/front/src/components/statistics/helpers/__tests__/projection.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/projection.test.ts
@@ -1,4 +1,4 @@
-import { projectedRemainingRegular } from "@components/statistics/helpers/projection";
+import { projectedCurrentMonthRemainder, projectedRemainingRegular } from "@components/statistics/helpers/projection";
 
 import type { YearMonthly } from "@components/statistics/helpers/projection";
 
@@ -75,5 +75,42 @@ describe("projectedRemainingRegular", () => {
     const result = projectedRemainingRegular(empty, lastYear, twoAgo, midDecember);
     // N-1's real 0 wins over N-2's 999 → the December remainder is 0, not null.
     expect(result).toBe(0);
+  });
+});
+
+describe("projectedCurrentMonthRemainder", () => {
+  const midJuly = new Date(2026, 6, 19); // 12 of July's 31 days remain
+  const julyShare = 12 / 31;
+
+  it("prorates the current month's same month last year (N-1)", () => {
+    const result = projectedCurrentMonthRemainder(empty, ym(rising, allTrue), empty, midJuly);
+    expect(result).toBeCloseTo(70 * julyShare, 6); // July N-1 = 70
+  });
+
+  it("falls back N-2 then M-1, and returns null with no reference", () => {
+    // N-2 fallback: N-1 missing July, N-2 has it.
+    const n1NoJuly = ym(
+      rising,
+      allTrue.map((_, i) => i !== 6),
+    );
+    const n2July = ym(
+      [...zeros].map((_, i) => (i === 6 ? 900 : 0)),
+      allTrue.map((_, i) => i === 6),
+    );
+    expect(projectedCurrentMonthRemainder(empty, n1NoJuly, n2July, midJuly)).toBeCloseTo(900 * julyShare, 6);
+
+    // M-1 fallback: no prior years, June (previous month) present.
+    const june = ym(
+      [...zeros].map((_, i) => (i === 5 ? 600 : 0)),
+      allTrue.map((_, i) => i === 5),
+    );
+    expect(projectedCurrentMonthRemainder(june, empty, empty, midJuly)).toBeCloseTo(600 * julyShare, 6);
+
+    // No reference anywhere (first month of data) → null.
+    const julyOnly = ym(
+      zeros,
+      allTrue.map((_, i) => i === 6),
+    );
+    expect(projectedCurrentMonthRemainder(julyOnly, empty, empty, midJuly)).toBeNull();
   });
 });

--- a/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
@@ -1,4 +1,4 @@
-import { monthlyPresence, monthlyTotals } from "@components/statistics/helpers/statisticsData";
+import { filledMonthlyIncome, monthlyPresence, monthlyTotals } from "@components/statistics/helpers/statisticsData";
 
 import type { StatisticsResponse } from "@src/schemas/stats";
 
@@ -28,5 +28,31 @@ describe("monthlyPresence", () => {
 
   it("returns an all-false mask for a year with no data", () => {
     expect(monthlyPresence(data, 2020)).toEqual(Array(12).fill(false));
+  });
+});
+
+describe("filledMonthlyIncome", () => {
+  const sparse = (entries: Record<number, number>): (number | null)[] =>
+    Array.from({ length: 12 }, (_, i) => entries[i] ?? null);
+
+  it("carries the last known income forward over the gaps", () => {
+    const result = filledMonthlyIncome(sparse({ 0: 3000, 3: 3200, 10: 3500 }));
+    expect(result).toEqual([3000, 3000, 3000, 3200, 3200, 3200, 3200, 3200, 3200, 3200, 3500, 3500]);
+  });
+
+  it("back-fills the leading months before the first known value", () => {
+    const result = filledMonthlyIncome(sparse({ 5: 2000 }));
+    expect(result).toEqual(Array(12).fill(2000));
+  });
+
+  it("preserves a real zero income", () => {
+    const result = filledMonthlyIncome(sparse({ 0: 3000, 6: 0 }));
+    expect(result?.[6]).toBe(0);
+    expect(result?.[11]).toBe(0); // carried forward from the zero
+  });
+
+  it("returns null when there is no income at all", () => {
+    expect(filledMonthlyIncome(Array(12).fill(null))).toBeNull();
+    expect(filledMonthlyIncome([])).toBeNull();
   });
 });

--- a/front/src/components/statistics/helpers/projection.ts
+++ b/front/src/components/statistics/helpers/projection.ts
@@ -1,11 +1,15 @@
+import { monthlyPresence, monthlyTotals } from "@components/statistics/helpers/statisticsData";
 import getDaysInMonth from "date-fns/getDaysInMonth";
+
+import type { StatisticsResponse } from "@src/schemas/stats";
 
 /**
  * Per-month projection helper, following the GLOBAL projection chain shared with
- * the dashboard sparkline (COS-27) and the monthly chart (COS-50): to estimate a
- * month, prefer the same month last year (N-1), then two years ago (N-2), then
- * fall back to the previous calendar month (M-1). The chain resolves per month,
- * so a partial year still projects month by month.
+ * the dashboard sparkline (COS-27), the year-end forecast (COS-47) and the
+ * monthly chart (COS-50): to estimate a month, prefer the same month last year
+ * (N-1), then two years ago (N-2), then fall back to the previous calendar month
+ * (M-1). The chain resolves per month, so a partial year still projects month by
+ * month.
  */
 export interface YearMonthly {
   /** 12-slot (Jan→Dec) regular monthly totals. */
@@ -14,29 +18,20 @@ export interface YearMonthly {
   present: boolean[];
 }
 
-/**
- * Projected *additional* regular spend for the rest of the current year: the
- * remainder of the in-progress month plus full estimates for every later month,
- * each estimated via the chain (N-1 → N-2 → M-1). Exceptionals are never
- * extrapolated — they are one-offs, so only the year's known ones count (added by
- * the caller). Returns null when no historical reference exists at all (the
- * user's very first month of data → no projection is shown).
- *
- * The in-progress month is split: its actual spend so far is already in the
- * caller's cumulative total, so only its remainder is projected here, prorated by
- * the share of the month still ahead (assumes an even daily pace over the
- * reference month).
- */
-export const projectedRemainingRegular = (
-  current: YearMonthly,
-  lastYear: YearMonthly,
-  twoYearsAgo: YearMonthly,
-  now: Date,
-): number | null => {
-  const curMonth = now.getMonth();
+/** Builds a {@link YearMonthly} for `year` from a `/statistics` response. */
+export const toYearMonthly = (data: StatisticsResponse["data"] | undefined, year: number): YearMonthly => ({
+  totals: monthlyTotals(data, year),
+  present: monthlyPresence(data, year),
+});
 
-  // Single M-1 anchor: the previous calendar month's total (wrapping January back
-  // to last December), used for any month the two prior years do not cover.
+/**
+ * The per-month chain estimator (N-1[m] → N-2[m] → M-1), or null when none of
+ * the three has data. M-1 is a single anchor — the previous calendar month of
+ * `now` (wrapping January back to last December) — used for any month the two
+ * prior years do not cover.
+ */
+const makeEstimator = (current: YearMonthly, lastYear: YearMonthly, twoYearsAgo: YearMonthly, now: Date) => {
+  const curMonth = now.getMonth();
   const prevIdx = (curMonth + 11) % 12;
   const mMinus1 =
     curMonth === 0
@@ -47,11 +42,52 @@ export const projectedRemainingRegular = (
         ? current.totals[prevIdx]
         : null;
 
-  const estimate = (m: number): number | null => {
+  return (m: number): number | null => {
     if (lastYear.present[m]) return lastYear.totals[m];
     if (twoYearsAgo.present[m]) return twoYearsAgo.totals[m];
     return mMinus1;
   };
+};
+
+/** Remaining (not-yet-elapsed) share of the current month, assuming an even
+ *  daily pace. */
+const remainingMonthShare = (now: Date): number => {
+  const daysInMonth = getDaysInMonth(now);
+  return (daysInMonth - now.getDate()) / daysInMonth;
+};
+
+/**
+ * Projected end-of-month remainder of the *current* month's regular spend (its
+ * chain estimate × the share of the month still ahead), or null when there is no
+ * reference (the user's very first month of data → no projection). Exceptionals
+ * are never extrapolated; the caller adds the realized total. Backs the monthly
+ * chart's projected current-month bar (COS-50).
+ */
+export const projectedCurrentMonthRemainder = (
+  current: YearMonthly,
+  lastYear: YearMonthly,
+  twoYearsAgo: YearMonthly,
+  now: Date,
+): number | null => {
+  const monthEstimate = makeEstimator(current, lastYear, twoYearsAgo, now)(now.getMonth());
+  return monthEstimate === null ? null : monthEstimate * remainingMonthShare(now);
+};
+
+/**
+ * Projected *additional* regular spend for the rest of the current year: the
+ * remainder of the in-progress month plus full estimates for every later month,
+ * each estimated via the chain. Exceptionals are never extrapolated — they are
+ * one-offs, so only the year's known ones count (added by the caller). Returns
+ * null when no historical reference exists at all (COS-47).
+ */
+export const projectedRemainingRegular = (
+  current: YearMonthly,
+  lastYear: YearMonthly,
+  twoYearsAgo: YearMonthly,
+  now: Date,
+): number | null => {
+  const curMonth = now.getMonth();
+  const estimate = makeEstimator(current, lastYear, twoYearsAgo, now);
 
   let remaining = 0;
   let hasEstimate = false;
@@ -59,9 +95,7 @@ export const projectedRemainingRegular = (
   // In-progress month: only the not-yet-elapsed share is projected.
   const currentEstimate = estimate(curMonth);
   if (currentEstimate !== null) {
-    const daysInMonth = getDaysInMonth(now);
-    const remainingShare = (daysInMonth - now.getDate()) / daysInMonth;
-    remaining += currentEstimate * remainingShare;
+    remaining += currentEstimate * remainingMonthShare(now);
     hasEstimate = true;
   }
 

--- a/front/src/components/statistics/helpers/statisticsData.ts
+++ b/front/src/components/statistics/helpers/statisticsData.ts
@@ -60,6 +60,32 @@ export const monthlyPresence = (data: StatData | undefined, year: number): boole
   return present;
 };
 
+/**
+ * Turns a sparse 12-slot monthly income series (null where the user has no
+ * dashboard row) into a continuous one by carrying the last known value forward
+ * and back-filling the leading gap — income is assumed to persist until changed.
+ * Returns null when there is no income at all, so the caller draws no line
+ * (COS-50 budget line).
+ */
+export const filledMonthlyIncome = (income: (number | null)[]): number[] | null => {
+  if (!income.some((v) => v !== null)) return null;
+  const out: (number | null)[] = income.slice(0, 12);
+  while (out.length < 12) out.push(null);
+
+  let carry: number | null = null;
+  for (let i = 0; i < 12; i += 1) {
+    if (out[i] !== null) carry = out[i];
+    else out[i] = carry;
+  }
+  // Back-fill any leading months before the first known value.
+  carry = null;
+  for (let i = 11; i >= 0; i -= 1) {
+    if (out[i] !== null) carry = out[i];
+    else out[i] = carry;
+  }
+  return out as number[];
+};
+
 /** Round up to a "nice" axis ceiling (1, 1.5, 2, 3, 4, 5, 7.5, 10 × 10ⁿ). */
 export const niceCeil = (value: number): number => {
   if (value <= 0) return 1;

--- a/front/src/components/statistics/services/useMonthlyIncome.tsx
+++ b/front/src/components/statistics/services/useMonthlyIncome.tsx
@@ -1,0 +1,33 @@
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@src/helpers/useRequestHelper";
+import { MonthlyIncomeResponseSchema } from "@src/schemas/dashboard";
+import { useQuery } from "react-query";
+
+import type { MonthlyIncomeResponse } from "@src/schemas/dashboard";
+
+interface UseMonthlyIncomeOptions {
+  year: number;
+}
+
+/**
+ * Per-month income (dashboard `initialAmount`) for the given year (COS-50),
+ * backing the monthly chart's stepped budget line. Months with no dashboard row
+ * come back null; the chart carries the last known value forward.
+ */
+const useMonthlyIncome = ({ year }: UseMonthlyIncomeOptions) => {
+  const { privateRequest } = useRequestHelper();
+
+  const getMonthlyIncome = async (): Promise<MonthlyIncomeResponse> => {
+    const response = await privateRequest(`/dashboard/monthly-income?year=${year}`);
+    return MonthlyIncomeResponseSchema.parse(response.data);
+  };
+
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.MONTHLY_INCOME, year], getMonthlyIncome, {
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return { monthlyIncome: data?.income, isLoading, error };
+};
+
+export default useMonthlyIncome;

--- a/front/src/schemas/dashboard.ts
+++ b/front/src/schemas/dashboard.ts
@@ -46,6 +46,15 @@ export const DailyProjectionSchema = z.object({
 
 export type DailyProjection = z.infer<typeof DailyProjectionSchema>;
 
+// Per-month income (dashboard initialAmount) for a year (COS-50) — GET
+// /dashboard/monthly-income. 12-slot Jan→Dec; null where the user has no
+// dashboard row for that month. Backs the monthly chart's stepped budget line.
+export const MonthlyIncomeResponseSchema = z.object({
+  income: z.array(z.number().finite().nullable()),
+});
+
+export type MonthlyIncomeResponse = z.infer<typeof MonthlyIncomeResponseSchema>;
+
 export const MonthlyStatsSchema = z.object({
   spendingsSum: z.object({
     amount: numberLikeSchema,

--- a/nest-api/src/dashboard/dashboard.controller.ts
+++ b/nest-api/src/dashboard/dashboard.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Get, Param, Post, Put, Query, Res, UseGuards } from "
 import type { Response } from "express";
 import { DashboardService } from "@dashboard/dashboard.service";
 import { DashboardQueryDto } from "@dashboard/dto/dashboard-query.dto";
+import { MonthlyIncomeQueryDto } from "@dashboard/dto/monthly-income-query.dto";
 import { CreateDashboardDto } from "@dashboard/dto/create-dashboard.dto";
 import { UpdateDashboardDto } from "@dashboard/dto/update-dashboard.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
@@ -25,6 +26,13 @@ export class DashboardController {
   @Get("projection")
   async getDailyProjection(@Query() query: DashboardQueryDto, @GetUserId() userID: string) {
     return this.dashboardService.getDailyProjection(query.start, userID);
+  }
+
+  // Per-month income (dashboard initialAmount) for a year (COS-50), backing the
+  // monthly chart's stepped budget line.
+  @Get("monthly-income")
+  async getMonthlyIncome(@Query() query: MonthlyIncomeQueryDto, @GetUserId() userID: string) {
+    return this.dashboardService.getMonthlyIncome(query.year, userID);
   }
 
   @Post()

--- a/nest-api/src/dashboard/dashboard.service.spec.ts
+++ b/nest-api/src/dashboard/dashboard.service.spec.ts
@@ -102,3 +102,50 @@ describe("DashboardService.getDailyProjection", () => {
     expect(result.dailyTotals[30]).toBe(9); // day 31
   });
 });
+
+/**
+ * Unit tests for DashboardService.getMonthlyIncome — the per-month income series
+ * backing the monthly chart's stepped budget line (COS-50). Prisma is mocked, so
+ * these assert the query window and the month-of-year bucketing.
+ */
+describe("DashboardService.getMonthlyIncome", () => {
+  const makeService = (findMany: jest.Mock) => {
+    const prisma = { dashboards: { findMany } } as unknown as never;
+    return new DashboardService(prisma);
+  };
+
+  const row = (dateFrom: string, initialAmount: number | string) => ({ dateFrom: new Date(dateFrom), initialAmount });
+
+  it("returns a 12-slot array keyed by the dashboard month, null where absent", async () => {
+    const findMany = jest.fn().mockResolvedValue([row("2026-01-01", 3000), row("2026-03-01", 3200), row("2026-12-01", 3500)]);
+    const service = makeService(findMany);
+
+    const result = await service.getMonthlyIncome("2026", "user-1");
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userID: "user-1", dateFrom: { gte: new Date(Date.UTC(2026, 0, 1)), lt: new Date(Date.UTC(2027, 0, 1)) } },
+      select: { dateFrom: true, initialAmount: true },
+    });
+    expect(result.income).toEqual([3000, null, 3200, null, null, null, null, null, null, null, null, 3500]);
+  });
+
+  it("returns all nulls for an invalid year without querying", async () => {
+    const findMany = jest.fn();
+    const service = makeService(findMany);
+
+    const result = await service.getMonthlyIncome("nope", "user-1");
+
+    expect(findMany).not.toHaveBeenCalled();
+    expect(result.income).toEqual(Array(12).fill(null));
+  });
+
+  it("coerces Prisma Decimal amounts (and keeps a real zero)", async () => {
+    const findMany = jest.fn().mockResolvedValue([row("2026-06-01", 0), row("2026-07-01", "2750.50")]);
+    const service = makeService(findMany);
+
+    const result = await service.getMonthlyIncome("2026", "user-1");
+
+    expect(result.income[5]).toBe(0);
+    expect(result.income[6]).toBe(2750.5);
+  });
+});

--- a/nest-api/src/dashboard/dashboard.service.ts
+++ b/nest-api/src/dashboard/dashboard.service.ts
@@ -2,6 +2,8 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import { PrismaService } from "../prisma/prisma.service";
 
+import type { MonthlyIncomeResponse } from "@dashboard/dto/monthly-income-response.interface";
+
 // Which historical period the sparkline projection is based on (COS-27). Follows
 // the GLOBAL projection chain; "none" is the very-first-month case (no reference
 // exists yet — the front shows no projection tail, never an average fallback).
@@ -77,6 +79,37 @@ export class DashboardService {
     }
 
     return { source: "none", referenceMonth: null, dailyTotals: [] };
+  }
+
+  /**
+   * Per-month income (dashboard initialAmount) for a year (COS-50). Reads the
+   * per-month `Dashboards` rows and returns a 12-slot array (Jan→Dec); a month
+   * with no dashboard row comes back null. Uses a half-open UTC range like the
+   * daily stats so the month bucketing is timezone-safe. Backs the monthly
+   * chart's stepped budget line — the front carries the last known value forward
+   * over the null gaps.
+   */
+  async getMonthlyIncome(yearStr: string, userID: string): Promise<MonthlyIncomeResponse> {
+    const year = parseInt(yearStr, 10);
+    if (Number.isNaN(year)) {
+      return { income: Array<number | null>(12).fill(null) };
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const nextYearStart = new Date(Date.UTC(year + 1, 0, 1));
+
+    const rows = await this.prisma.dashboards.findMany({
+      where: { userID, dateFrom: { gte: yearStart, lt: nextYearStart } },
+      select: { dateFrom: true, initialAmount: true },
+    });
+
+    const income = Array<number | null>(12).fill(null);
+    for (const row of rows) {
+      const month = row.dateFrom.getUTCMonth();
+      if (month >= 0 && month < 12) income[month] = Number(row.initialAmount);
+    }
+
+    return { income };
   }
 
   async getDashboard(start: string, userID: string) {

--- a/nest-api/src/dashboard/dto/monthly-income-query.dto.ts
+++ b/nest-api/src/dashboard/dto/monthly-income-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class MonthlyIncomeQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  year: string;
+}

--- a/nest-api/src/dashboard/dto/monthly-income-response.interface.ts
+++ b/nest-api/src/dashboard/dto/monthly-income-response.interface.ts
@@ -1,0 +1,5 @@
+export interface MonthlyIncomeResponse {
+  /** 12-slot Jan→Dec monthly income (dashboard initialAmount); null where the
+   *  user has no dashboard row for that month. */
+  income: (number | null)[];
+}


### PR DESCRIPTION
Current-month projection: replace the average-forward mock with the history-based chain (same month N-1 -> N-2 -> previous month), reusing the COS-47 estimator via a shared projectedCurrentMonthRemainder helper. Exceptionals are not extrapolated; the first month of data shows no projection.

Budget line: real per-month income instead of one value drawn flat. New GET /dashboard/monthly-income?year= returns the 12 monthly initialAmounts (null where unset); the chart draws a stepped dashed line, carrying the last known income forward over gaps (filledMonthlyIncome).

- projection.ts: shared estimator + projectedCurrentMonthRemainder (+tests)
- dashboard.service: getMonthlyIncome + endpoint/DTO (+tests)
- useMonthlyIncome hook, MonthlyIncomeResponse schema
- remove the two MOCK blocks; bars, caps, N-1 line, placeholders untouched