### PR TITLE
feat(spendings): de-mock frequent categories (COS-22)

### DIFF
--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useAuth } from "@auth/context/AuthContext";
+import useCategoryStats from "@components/categories/services/useCategoryStats";
 import AmountField from "@components/spendings/common/spendingModal/fields/AmountField";
 import CategoryField from "@components/spendings/common/spendingModal/fields/CategoryField";
 import DateField from "@components/spendings/common/spendingModal/fields/DateField";
 import LabelField from "@components/spendings/common/spendingModal/fields/LabelField";
 import ReceiptField from "@components/spendings/common/spendingModal/fields/ReceiptField";
 import { mockLabelSuggestions } from "@components/spendings/common/spendingModal/mockSuggestions";
+import { rankFrequentCategories } from "@components/spendings/common/spendingModal/rankFrequentCategories";
 import { spendingSchema } from "@components/spendings/common/spendingModal/schema";
 import Toggle from "@components/spendings/common/spendingModal/Toggle";
 import useSpendingSubmit from "@components/spendings/common/spendingModal/useSpendingSubmit";
@@ -59,6 +61,10 @@ const SpendingModal = ({
   if (categoriesError) {
     throw categoriesError;
   }
+  // All-time per-category usage (shared source with the Categories page, COS-20)
+  // — ranks the "Fréquentes" quick-picks. Never blocks the modal: while stats
+  // load (or on error) the section is simply empty until real usage arrives.
+  const { categoryStats } = useCategoryStats();
 
   const categoryOptions: CategoryOption[] = (categories ?? []).map((c) => ({
     ID: c.ID,
@@ -66,6 +72,8 @@ const SpendingModal = ({
     name: c.name,
     color: c.color,
   }));
+
+  const frequentCategories = rankFrequentCategories(categoryOptions, categoryStats?.byCategory);
 
   const isSpendingItem = (v: SpendingListItem | null): v is SpendingItem => !!v && "date" in v;
 
@@ -214,6 +222,7 @@ const SpendingModal = ({
           {!asRecurring && (
             <CategoryField
               categoryOptions={categoryOptions}
+              frequentCategories={frequentCategories}
               selectedCategory={selectedCategory}
               setSelectedCategory={setSelectedCategory}
               comboboxOpen={comboboxOpen}

--- a/front/src/components/spendings/common/spendingModal/__tests__/rankFrequentCategories.test.ts
+++ b/front/src/components/spendings/common/spendingModal/__tests__/rankFrequentCategories.test.ts
@@ -1,0 +1,69 @@
+import { rankFrequentCategories } from "@components/spendings/common/spendingModal/rankFrequentCategories";
+
+import type { CategoryOption } from "@components/spendings/common/spendingModal/schema";
+import type { CategoryStat } from "@src/schemas/categoryStats";
+
+const cat = (id: string | null, name: string): CategoryOption => ({
+  ID: id,
+  userID: "u1",
+  name,
+  color: "#fff",
+});
+
+const stat = (categoryID: string, count: number, total: number): CategoryStat => ({
+  categoryID,
+  count,
+  total,
+});
+
+describe("rankFrequentCategories", () => {
+  it("ranks by real usage count (desc), not insertion order", () => {
+    const cats = [cat("a", "alimentation"), cat("b", "transport"), cat("c", "loisirs")];
+    const stats = [stat("a", 2, 40), stat("b", 9, 10), stat("c", 5, 30)];
+    expect(rankFrequentCategories(cats, stats).map((c) => c.name)).toEqual(["transport", "loisirs", "alimentation"]);
+  });
+
+  it("breaks count ties by total amount spent (desc)", () => {
+    const cats = [cat("a", "alpha"), cat("b", "beta")];
+    const stats = [stat("a", 3, 20), stat("b", 3, 80)];
+    expect(rankFrequentCategories(cats, stats).map((c) => c.name)).toEqual(["beta", "alpha"]);
+  });
+
+  it("breaks count+total ties by name (asc), deterministically", () => {
+    const cats = [cat("b", "zebra"), cat("a", "apple")];
+    const stats = [stat("a", 4, 50), stat("b", 4, 50)];
+    expect(rankFrequentCategories(cats, stats).map((c) => c.name)).toEqual(["apple", "zebra"]);
+  });
+
+  it("excludes never-used categories — including unsaved ones (ID null)", () => {
+    const cats = [cat(null, "brand-new"), cat("a", "used"), cat("b", "never-used")];
+    const stats = [stat("a", 1, 5)];
+    expect(rankFrequentCategories(cats, stats).map((c) => c.name)).toEqual(["used"]);
+  });
+
+  it("caps the result at the limit (default 6)", () => {
+    const cats = Array.from({ length: 10 }, (_, i) => cat(`id-${i}`, `cat-${i}`));
+    const stats = cats.map((c, i) => stat(c.ID as string, i + 1, i + 1));
+    expect(rankFrequentCategories(cats, stats)).toHaveLength(6);
+    expect(rankFrequentCategories(cats, stats, 3)).toHaveLength(3);
+  });
+
+  it("filters out categories with an empty name even when used", () => {
+    const cats = [cat("a", ""), cat("b", "kept")];
+    const stats = [stat("a", 5, 5), stat("b", 3, 3)];
+    expect(rankFrequentCategories(cats, stats).map((c) => c.name)).toEqual(["kept"]);
+  });
+
+  it("returns nothing when there is no usage data yet", () => {
+    const cats = [cat("b", "banana"), cat("a", "apple")];
+    expect(rankFrequentCategories(cats, undefined)).toEqual([]);
+    expect(rankFrequentCategories(cats, [])).toEqual([]);
+  });
+
+  it("does not mutate the input array", () => {
+    const cats = [cat("a", "alpha"), cat("b", "beta")];
+    const snapshot = [...cats];
+    rankFrequentCategories(cats, [stat("b", 5, 5)]);
+    expect(cats).toEqual(snapshot);
+  });
+});

--- a/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
@@ -13,6 +13,7 @@ import type { Dispatch, SetStateAction } from "react";
 
 interface CategoryFieldProps {
   categoryOptions: CategoryOption[];
+  frequentCategories: CategoryOption[];
   selectedCategory: CategoryOption | null;
   setSelectedCategory: Dispatch<SetStateAction<CategoryOption | null>>;
   comboboxOpen: boolean;
@@ -24,6 +25,7 @@ interface CategoryFieldProps {
 
 const CategoryField = ({
   categoryOptions,
+  frequentCategories,
   selectedCategory,
   setSelectedCategory,
   comboboxOpen,
@@ -33,11 +35,6 @@ const CategoryField = ({
   userId,
 }: CategoryFieldProps) => {
   const { modal: t } = spendings;
-
-  // MOCK — "Fréquentes" quick-picks: the SELECTION is real, but the ranking
-  // (first N categories) stands in for real per-category usage counts.
-  // De-mock tracked in COS-22.
-  const frequentCategories = categoryOptions.filter((c) => c.name).slice(0, 6);
 
   const exactMatch = categoryOptions.find((c) => c.name.toLowerCase() === comboboxQuery.trim().toLowerCase());
 

--- a/front/src/components/spendings/common/spendingModal/mockSuggestions.ts
+++ b/front/src/components/spendings/common/spendingModal/mockSuggestions.ts
@@ -1,9 +1,9 @@
-// MOCK — placeholders for data the backend does not expose yet:
-//   • "Fréquentes" category ranking → needs per-category usage counts
-//   • label autocomplete → needs the user's past spending labels
-// NOTE: the category SELECTION and the label FILL these drive are REAL — only
-// the ranking / suggestion source is fake. Deterministic and self-contained so
-// it is trivial to swap for a real endpoint later. See REFACTO_NOTES.md §6.
+// MOCK — label autocomplete: needs the user's past spending labels, which the
+// backend does not expose yet.
+// NOTE: the label FILL this drives is REAL — only the suggestion source is fake.
+// Deterministic and self-contained so it is trivial to swap for a real endpoint
+// later. See REFACTO_NOTES.md §6.
+// ("Fréquentes" category ranking is now real — see rankFrequentCategories, COS-22.)
 
 export interface LabelSuggestion {
   label: string;

--- a/front/src/components/spendings/common/spendingModal/rankFrequentCategories.ts
+++ b/front/src/components/spendings/common/spendingModal/rankFrequentCategories.ts
@@ -1,0 +1,34 @@
+import type { CategoryOption } from "@components/spendings/common/spendingModal/schema";
+import type { CategoryStat } from "@src/schemas/categoryStats";
+
+export const FREQUENT_LIMIT = 6;
+
+/**
+ * Ranks the "Fréquentes" quick-picks by real all-time usage (COS-20's
+ * per-category aggregate) and keeps only categories the user has actually
+ * used. Ordering: number of spendings attached (desc), then total amount
+ * spent (desc), then name (asc) as a deterministic tie-break. Never-used
+ * categories are excluded, so the section stays empty until there is real
+ * usage to rank. Returns at most `limit` options.
+ */
+export const rankFrequentCategories = (
+  categories: CategoryOption[],
+  byCategory: CategoryStat[] | undefined,
+  limit = FREQUENT_LIMIT,
+): CategoryOption[] => {
+  const statsByID = new Map((byCategory ?? []).map((s) => [s.categoryID, s]));
+  const statOf = (c: CategoryOption) => (c.ID ? statsByID.get(c.ID) : undefined);
+
+  return [...categories]
+    .filter((c) => c.name && (statOf(c)?.count ?? 0) > 0)
+    .sort((a, b) => {
+      const sa = statOf(a);
+      const sb = statOf(b);
+      const byCount = (sb?.count ?? 0) - (sa?.count ?? 0);
+      if (byCount !== 0) return byCount;
+      const byTotal = (sb?.total ?? 0) - (sa?.total ?? 0);
+      if (byTotal !== 0) return byTotal;
+      return a.name.localeCompare(b.name, "fr");
+    })
+    .slice(0, limit);
+};


### PR DESCRIPTION
The "Fréquentes" quick-picks in the spending modal ranked categories by insertion order (.slice(0, 6)) — a mock. Rank them by real all-time usage instead, reusing COS-20's per-category aggregate (GET /category-stats via useCategoryStats): spending count desc, then total spent, then name. Only categories actually used are shown; the section stays empty until there is real usage to rank.

Ranking extracted as a pure, unit-tested rankFrequentCategories helper.