### PR TITLE
feat(spendings): frequent categories by current-year usage (COS-137)

### DIFF
--- a/front/src/components/categories/services/useCategoryStats.ts
+++ b/front/src/components/categories/services/useCategoryStats.ts
@@ -4,15 +4,28 @@ import useRequestHelper from "@helpers/useRequestHelper";
 import { CategoryStatsResponseSchema } from "@src/schemas/categoryStats";
 import { useQuery } from "react-query";
 
-/** All-time usage aggregate per category (count of spendings + total spent). */
-const useCategoryStats = () => {
+/** Inclusive calendar-date window (yyyy-MM-dd) to scope the aggregate. */
+interface CategoryStatsRange {
+  from: string;
+  to: string;
+}
+
+/**
+ * Usage aggregate per category (count of spendings + total spent). Without a
+ * range it covers the whole history (Categories page); with one it scopes to
+ * that window — the spending modal passes the current year to date so its
+ * "Fréquentes" quick-picks rank on recent usage (COS-137). Each window is a
+ * separate cache entry.
+ */
+const useCategoryStats = (range?: CategoryStatsRange) => {
   const { privateRequest } = useRequestHelper();
   const { user } = useAuth();
   const userID = user?.id;
 
   const getCategoryStatsService = async () => {
     try {
-      const response = await privateRequest("/category-stats");
+      const query = range ? `?from=${range.from}&to=${range.to}` : "";
+      const response = await privateRequest(`/category-stats${query}`);
       return CategoryStatsResponseSchema.parse(response.data);
     } catch (e) {
       console.log("get category stats error : ", e);
@@ -20,11 +33,15 @@ const useCategoryStats = () => {
     }
   };
 
-  const { data: categoryStats, error } = useQuery([QUERY_KEYS.CATEGORY_STATS, userID], getCategoryStatsService, {
-    retry: 2,
-    enabled: !!userID,
-    ...QUERY_OPTIONS,
-  });
+  const { data: categoryStats, error } = useQuery(
+    [QUERY_KEYS.CATEGORY_STATS, userID, range?.from ?? null, range?.to ?? null],
+    getCategoryStatsService,
+    {
+      retry: 2,
+      enabled: !!userID,
+      ...QUERY_OPTIONS,
+    },
+  );
 
   return { categoryStats, error };
 };

--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -23,6 +23,7 @@ import spendings from "@text/spendings";
 import endOfMonth from "date-fns/endOfMonth";
 import format from "date-fns/format";
 import startOfMonth from "date-fns/startOfMonth";
+import startOfYear from "date-fns/startOfYear";
 import subMonths from "date-fns/subMonths";
 import { Copy } from "lucide-react";
 import { useState } from "react";
@@ -61,10 +62,13 @@ const SpendingModal = ({
   if (categoriesError) {
     throw categoriesError;
   }
-  // All-time per-category usage (shared source with the Categories page, COS-20)
-  // — ranks the "Fréquentes" quick-picks. Never blocks the modal: while stats
-  // load (or on error) the section is simply empty until real usage arrives.
-  const { categoryStats } = useCategoryStats();
+  // Per-category usage scoped to the current year to date (client-side "today",
+  // cf COS-73) — ranks the "Fréquentes" quick-picks on recent habits, not
+  // all-time cumulative usage (COS-137). Never blocks the modal: while stats load
+  // (or on error) the section is simply empty until real usage arrives.
+  const now = new Date();
+  const frequentRange = { from: format(startOfYear(now), "yyyy-MM-dd"), to: format(now, "yyyy-MM-dd") };
+  const { categoryStats } = useCategoryStats(frequentRange);
 
   const categoryOptions: CategoryOption[] = (categories ?? []).map((c) => ({
     ID: c.ID,

--- a/nest-api/src/stats/dto/category-stats-query.dto.ts
+++ b/nest-api/src/stats/dto/category-stats-query.dto.ts
@@ -1,0 +1,19 @@
+import { IsOptional, Matches } from "class-validator";
+
+const YMD = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Optional date window for the per-category usage aggregate. Both bounds are
+ * inclusive calendar dates (yyyy-MM-dd); omit both for the all-time aggregate
+ * (Categories page). The spending-modal quick-picks pass the current year to
+ * date so "Fréquentes" reflects recent usage (COS-137).
+ */
+export class CategoryStatsQueryDto {
+  @IsOptional()
+  @Matches(YMD, { message: "from must be a yyyy-MM-dd date" })
+  from?: string;
+
+  @IsOptional()
+  @Matches(YMD, { message: "to must be a yyyy-MM-dd date" })
+  to?: string;
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -5,6 +5,7 @@ import { MonthlyStatsQueryDto } from "@stats/dto/monthly-stats-query.dto";
 import { StatisticsQueryDto } from "@stats/dto/statistics-query.dto";
 import { RegularMonthlyAverageQueryDto } from "@stats/dto/regular-monthly-average-query.dto";
 import { DailyStatsQueryDto } from "@stats/dto/daily-stats-query.dto";
+import { CategoryStatsQueryDto } from "@stats/dto/category-stats-query.dto";
 import { BiggestRegularExpenseQueryDto } from "@stats/dto/biggest-regular-expense-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
@@ -67,8 +68,8 @@ export class CategoryStatsController {
   constructor(private readonly statsService: StatsService) {}
 
   @Get()
-  async getCategoryStats(@GetUserId() userID: string) {
-    return this.statsService.getCategoryStats(userID);
+  async getCategoryStats(@Query() query: CategoryStatsQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getCategoryStats(userID, query.from, query.to);
   }
 }
 

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -28,6 +28,37 @@ describe("StatsService.getCategoryStats", () => {
     });
   });
 
+  it("scopes to a half-open UTC window when from/to are given, with `to` inclusive", async () => {
+    const { service, groupBy } = makeService([]);
+
+    await service.getCategoryStats("user-1", "2026-01-01", "2026-07-19");
+
+    // `to` is made inclusive by pushing the exclusive upper bound to the next UTC day.
+    expect(groupBy).toHaveBeenCalledWith({
+      by: ["categoryID"],
+      where: {
+        userID: "user-1",
+        date: { gte: new Date(Date.UTC(2026, 0, 1)), lt: new Date(Date.UTC(2026, 6, 20)) },
+      },
+      _sum: { amount: true },
+      _count: true,
+    });
+  });
+
+  it("supports an open-ended window (only `from`, or only `to`)", async () => {
+    const { service, groupBy } = makeService([]);
+
+    await service.getCategoryStats("user-1", "2026-01-01");
+    expect(groupBy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ where: { userID: "user-1", date: { gte: new Date(Date.UTC(2026, 0, 1)) } } }),
+    );
+
+    await service.getCategoryStats("user-1", undefined, "2026-07-19");
+    expect(groupBy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ where: { userID: "user-1", date: { lt: new Date(Date.UTC(2026, 6, 20)) } } }),
+    );
+  });
+
   it("returns zeros when the user has no spendings", async () => {
     const { service } = makeService([]);
 

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -149,15 +149,36 @@ export class StatsService {
   }
 
   /**
-   * All-time usage aggregate per category: number of spendings and total amount
-   * spent, grouped by category over the user's whole history (no date filter).
-   * `totalSpent` sums every spending (incl. uncategorized) so the front can derive
-   * each category's share of total spending.
+   * Turns inclusive calendar-date bounds (yyyy-MM-dd) into a half-open UTC range
+   * (`gte`/`lt`), matching how spending dates are stored (calendar date at UTC
+   * midnight) and how the daily/yearly stats query. `to` is made inclusive by
+   * advancing the exclusive upper bound to the next UTC day. Returns undefined
+   * when neither bound is given (all-time).
    */
-  async getCategoryStats(userID: string): Promise<CategoryStatsResponse> {
+  private dateWindow(from?: string, to?: string): { gte?: Date; lt?: Date } | undefined {
+    const window: { gte?: Date; lt?: Date } = {};
+    if (from) {
+      window.gte = new Date(`${from}T00:00:00.000Z`);
+    }
+    if (to) {
+      window.lt = new Date(new Date(`${to}T00:00:00.000Z`).getTime() + 24 * 60 * 60 * 1000);
+    }
+    return window.gte || window.lt ? window : undefined;
+  }
+
+  /**
+   * Usage aggregate per category: number of spendings and total amount spent,
+   * grouped by category. With no date bounds it covers the user's whole history
+   * (Categories page); with `from`/`to` it scopes to that window — the spending
+   * modal passes the current year to date so its "Fréquentes" quick-picks rank
+   * on recent usage (COS-137). `totalSpent` sums every spending in scope (incl.
+   * uncategorized) so the front can derive each category's share.
+   */
+  async getCategoryStats(userID: string, from?: string, to?: string): Promise<CategoryStatsResponse> {
+    const date = this.dateWindow(from, to);
     const grouped = await this.prisma.spendings.groupBy({
       by: ["categoryID"],
-      where: { userID },
+      where: { userID, ...(date ? { date } : {}) },
       _sum: { amount: true },
       _count: true,
     });


### PR DESCRIPTION
The spending-modal "Fréquentes" quick-picks ranked categories by all-time spending count (COS-22), so a category heavily used years ago could outrank one picked recently. Scope the ranking to the current year to date instead.

Back: /category-stats now accepts optional from/to (yyyy-MM-dd) and filters the groupBy on a half-open UTC window; no bounds = all-time, so the Categories page is unchanged. Front: the modal passes 1 Jan -> today (client-side) to useCategoryStats, and rankFrequentCategories then drops categories unused this year.