### PR TITLE
feat(dashboard): busiest-transactions week widget (COS-139)

### DIFF
--- a/front/src/components/dashboard/sections/InsightsRibbon.tsx
+++ b/front/src/components/dashboard/sections/InsightsRibbon.tsx
@@ -11,8 +11,10 @@ import { Overline } from "@components/shared/Overline";
 import { MONTHLY } from "@components/spendings/config/constants";
 import { categoryDeltaPct, STABLE_TREND_THRESHOLD } from "@components/spendings/helpers/categoryTrend";
 import dailyRemainingBudget from "@components/spendings/helpers/dailyBudget";
+import useBusiestWeek from "@components/spendings/services/useBusiestWeek";
 import useCategoryTrends from "@components/spendings/services/useCategoryTrends";
 import useDashboard from "@components/spendings/services/useDashboard";
+import { buildSpendingsPath } from "@helpers/dateRoute";
 import { euro0 } from "@lib/format";
 import { cn } from "@lib/utils";
 import dashboardText from "@text/dashboard";
@@ -22,7 +24,9 @@ import getDate from "date-fns/getDate";
 import getDaysInMonth from "date-fns/getDaysInMonth";
 import isSameMonth from "date-fns/isSameMonth";
 import fr from "date-fns/locale/fr";
-import { TrendingUp, TriangleAlert, Wallet } from "lucide-react";
+import parseISO from "date-fns/parseISO";
+import { ArrowRightLeft, TrendingUp, TriangleAlert, Wallet } from "lucide-react";
+import Link from "next/link";
 
 import type { ReactNode } from "react";
 
@@ -55,6 +59,7 @@ const InsightsRibbon = () => {
   } = useDashboard();
   const { data: trendsData } = useCategoryTrends(MONTHLY);
   const trends = trendsData?.trends;
+  const { data: busiest } = useBusiestWeek();
   const { insightsRibbon: t } = dashboardText;
 
   const budget = Number(dashboard?.initialAmount ?? 0);
@@ -79,9 +84,15 @@ const InsightsRibbon = () => {
     })
     .sort((a, b) => b.delta - a.delta)[0];
   const lastDayLabel = format(endOfMonth(monthRef), "d MMMM", { locale: fr });
+  // The month's calendar week-range with the most transactions (COS-139); from/to
+  // come back as ISO strings — parseISO keeps them on the client's calendar day.
+  const busiestRange =
+    busiest && busiest.count > 0 && busiest.from && busiest.to
+      ? { count: busiest.count, fromIso: busiest.from, from: parseISO(busiest.from), to: parseISO(busiest.to) }
+      : null;
 
   return (
-    <DividedStrip className="grid-cols-1 sm:grid-cols-3">
+    <DividedStrip className="grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
       <Insight
         tone="bg-accent-strong/10 text-accent-strong"
         icon={<TrendingUp className="size-3.5" />}
@@ -113,6 +124,29 @@ const InsightsRibbon = () => {
         Il reste <b className="num font-semibold text-ink">{euro0(perDay)} €</b>
         /jour à dépenser d&apos;ici le <b className="font-semibold text-ink">{lastDayLabel}</b> pour rester dans le
         budget.
+      </Insight>
+      <Insight
+        tone="bg-surface-hi text-ink-2"
+        icon={<ArrowRightLeft className="size-3.5" />}
+        label={t.busiestLabel}
+      >
+        {busiestRange ? (
+          <>
+            <b className="num font-semibold text-ink">
+              {busiestRange.count} transaction{busiestRange.count > 1 ? "s" : ""}
+            </b>{" "}
+            du{" "}
+            <Link
+              href={buildSpendingsPath(busiestRange.fromIso)}
+              className="cursor-pointer font-semibold text-ink underline-offset-4 transition-colors hover:text-accent-strong hover:underline"
+            >
+              {format(busiestRange.from, "d", { locale: fr })} au {format(busiestRange.to, "d MMMM", { locale: fr })}
+            </Link>
+            .
+          </>
+        ) : (
+          t.busiestEmpty
+        )}
       </Insight>
     </DividedStrip>
   );

--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -11,6 +11,7 @@ export const QUERY_KEYS = {
   DAILY_PROJECTION: "dailyProjection",
   MONTHLY_INCOME: "monthlyIncome",
   CATEGORY_TRENDS: "categoryTrends",
+  BUSIEST_WEEK: "busiestWeek",
   WEEKLY_STATS: "weeklyStats",
   DAILY_STATS: "dailyStats",
   BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",

--- a/front/src/components/spendings/services/useBusiestWeek.ts
+++ b/front/src/components/spendings/services/useBusiestWeek.ts
@@ -1,0 +1,40 @@
+import { useAuth } from "@auth/context/AuthContext";
+import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { DATE_FORMAT, QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@helpers/useRequestHelper";
+import { BusiestWeekResponseSchema } from "@src/schemas/stats";
+import format from "date-fns/format";
+import startOfMonth from "date-fns/startOfMonth";
+import { useQuery } from "react-query";
+
+import type { BusiestWeekResponse } from "@src/schemas/stats";
+
+/**
+ * The displayed month's busiest calendar week-range by transaction count
+ * (COS-139): the Sun→Sat slice (truncated at the month edges, like the rest of
+ * the app) with the most one-off spendings, as `{ count, from, to }` — from/to
+ * null when the month is empty. Backs the dashboard's 4th ribbon insight. The
+ * month is passed as its 1st day; userID is read from the session server-side.
+ */
+const useBusiestWeek = () => {
+  const { privateRequest } = useRequestHelper();
+  const { from } = useDatePickerWrapperStore();
+  const { user } = useAuth();
+  const userID = user?.id;
+  const monthBeginning = from ? startOfMonth(from) : null;
+
+  const getBusiestWeek = async (): Promise<BusiestWeekResponse> => {
+    if (!monthBeginning || !userID) return { count: 0, from: null, to: null };
+    const query = new URLSearchParams({ start: format(monthBeginning, DATE_FORMAT) });
+    const response = await privateRequest(`/busiest-week?${query}`);
+    return BusiestWeekResponseSchema.parse(response.data);
+  };
+
+  return useQuery([QUERY_KEYS.BUSIEST_WEEK, monthBeginning], getBusiestWeek, {
+    retry: false,
+    enabled: !!monthBeginning && !!userID,
+    ...QUERY_OPTIONS,
+  });
+};
+
+export default useBusiestWeek;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -84,3 +84,15 @@ export const BiggestRegularExpenseResponseSchema = z.object({
 });
 
 export type BiggestRegularExpenseResponse = z.infer<typeof BiggestRegularExpenseResponseSchema>;
+
+// Busiest calendar week-range of a month by transaction count (COS-139) — GET
+// /busiest-week. "Week" = the month's calendar-aligned Sun→Sat slices, truncated
+// at the month edges (not a rolling window). `from`/`to` are null when the month
+// has no spending. Backs the dashboard's 4th ribbon insight.
+export const BusiestWeekResponseSchema = z.object({
+  count: numberLikeSchema,
+  from: z.string().nullable(),
+  to: z.string().nullable(),
+});
+
+export type BusiestWeekResponse = z.infer<typeof BusiestWeekResponseSchema>;

--- a/front/src/text/dashboard.ts
+++ b/front/src/text/dashboard.ts
@@ -72,6 +72,8 @@ const dashboard = {
     risingLabel: "Catégorie en hausse",
     risingEmpty: "Aucune hausse ce mois.",
     remainingLabel: "Reste à vivre",
+    busiestLabel: "Semaine la plus active",
+    busiestEmpty: "Aucune transaction ce mois.",
   },
   weeklyCeiling: {
     title: "Plafond hebdomadaire",

--- a/nest-api/src/stats/dto/busiest-week-query.dto.ts
+++ b/nest-api/src/stats/dto/busiest-week-query.dto.ts
@@ -1,0 +1,14 @@
+import { Matches } from "class-validator";
+
+const YMD = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The month to scan for its busiest calendar week-range (GET /busiest-week): any
+ * day of the target month as a yyyy-MM-dd date. The front passes the 1st of the
+ * displayed dashboard month; the service derives the month (and its week slices)
+ * from it, so any in-month day would work too.
+ */
+export class BusiestWeekQueryDto {
+  @Matches(YMD, { message: "start must be a yyyy-MM-dd date" })
+  start: string;
+}

--- a/nest-api/src/stats/dto/busiest-week-response.interface.ts
+++ b/nest-api/src/stats/dto/busiest-week-response.interface.ts
@@ -1,0 +1,20 @@
+/**
+ * The calendar week-range of a month with the most one-off spendings
+ * (GET /busiest-week?start=YYYY-MM-DD), backing the dashboard's 4th ribbon
+ * insight (COS-139). "Week" = the month's calendar-aligned Sun→Sat ranges,
+ * truncated at the month edges — the same slices the rest of the app shows
+ * (datepicker, Dépenses, weekly ceiling), NOT a rolling 7-day window. Counts the
+ * one-off `Spendings` table only, so recurrings/exceptionals — which live in
+ * their own tables — are excluded by construction. Ties resolve to the earliest
+ * range. `from`/`to` are null when the month has no spending.
+ *
+ * @example { count: 9, from: "2026-06-07", to: "2026-06-13" }
+ */
+export interface BusiestWeekResponse {
+  /** Number of spendings in the busiest range (0 when the month is empty). */
+  count: number;
+  /** ISO date (YYYY-MM-DD, UTC) of the range's first day, or null when empty. */
+  from: string | null;
+  /** ISO date (YYYY-MM-DD, UTC) of the range's last day, or null when empty. */
+  to: string | null;
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -8,6 +8,7 @@ import { DailyStatsQueryDto } from "@stats/dto/daily-stats-query.dto";
 import { CategoryStatsQueryDto } from "@stats/dto/category-stats-query.dto";
 import { BiggestRegularExpenseQueryDto } from "@stats/dto/biggest-regular-expense-query.dto";
 import { CategoryTrendsQueryDto } from "@stats/dto/category-trends-query.dto";
+import { BusiestWeekQueryDto } from "@stats/dto/busiest-week-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 
@@ -82,6 +83,17 @@ export class CategoryTrendsController {
   @Get()
   async getCategoryTrends(@Query() query: CategoryTrendsQueryDto, @GetUserId() userID: string) {
     return this.statsService.getCategoryTrends(userID, query.from, query.to, query.prevFrom, query.prevTo);
+  }
+}
+
+@Controller("busiest-week")
+@UseGuards(SessionAuthGuard)
+export class BusiestWeekController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getBusiestWeek(@Query() query: BusiestWeekQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getBusiestWeek(query.start, userID);
   }
 }
 

--- a/nest-api/src/stats/stats.module.ts
+++ b/nest-api/src/stats/stats.module.ts
@@ -7,6 +7,7 @@ import {
   RegularMonthlyAverageController,
   CategoryStatsController,
   CategoryTrendsController,
+  BusiestWeekController,
   DailyStatsController,
   BiggestRegularExpenseController,
 } from "@stats/stats.controller";
@@ -22,6 +23,7 @@ import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
     RegularMonthlyAverageController,
     CategoryStatsController,
     CategoryTrendsController,
+    BusiestWeekController,
     DailyStatsController,
     BiggestRegularExpenseController,
   ],

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -426,3 +426,94 @@ describe("StatsService.getBiggestRegularExpense", () => {
     expect(result.expense?.amount).toBeCloseTo(1499.99, 2);
   });
 });
+
+/**
+ * Unit tests for StatsService.getBusiestWeek — the calendar week-range of a month
+ * with the most one-off spendings, backing the dashboard's 4th ribbon insight
+ * (COS-139). "Week" = the month's calendar-aligned Sun→Sat ranges truncated at
+ * the month edges (the same slices the app shows everywhere), NOT a rolling
+ * window. Prisma is mocked; these assert the query shape (per-day counts over a
+ * half-open UTC month range) and the JS bucketing/max/tie-break.
+ */
+describe("StatsService.getBusiestWeek", () => {
+  const makeService = (groupByResult: { date: Date; _count: number }[]) => {
+    const groupBy = jest.fn().mockResolvedValue(groupByResult);
+    const prisma = { spendings: { groupBy } } as unknown as never;
+    return { service: new StatsService(prisma), groupBy };
+  };
+
+  it("counts spendings per day over a half-open UTC month range, scoped to the user", async () => {
+    const { service, groupBy } = makeService([]);
+
+    await service.getBusiestWeek("2026-06-01", "user-1");
+
+    expect(groupBy).toHaveBeenCalledWith({
+      by: ["date"],
+      where: { userID: "user-1", date: { gte: new Date(Date.UTC(2026, 5, 1)), lt: new Date(Date.UTC(2026, 6, 1)) } },
+      _count: true,
+    });
+  });
+
+  it("returns the calendar week-range with the most spendings (Sun→Sat, truncated at the month edges)", async () => {
+    // June 2026 starts on a Monday → ranges 1–6, 7–13, 14–20, 21–27, 28–30.
+    const { service } = makeService([
+      { date: new Date(Date.UTC(2026, 5, 3)), _count: 1 }, // range 1–6
+      { date: new Date(Date.UTC(2026, 5, 8)), _count: 5 }, // range 7–13
+      { date: new Date(Date.UTC(2026, 5, 10)), _count: 4 }, // range 7–13
+      { date: new Date(Date.UTC(2026, 5, 15)), _count: 2 }, // range 14–20
+    ]);
+
+    await expect(service.getBusiestWeek("2026-06-01", "user-1")).resolves.toEqual({
+      count: 9,
+      from: "2026-06-07",
+      to: "2026-06-13",
+    });
+  });
+
+  it("aligns the partial first week on the 1st of the month, whatever day `start` falls on", async () => {
+    // start is June 4th (a Thursday), but the first slice must still be 1–6 (the
+    // month starts on Monday), not 1–3. A single spending on the 8th belongs to
+    // the 7–13 range, not the buggy 4–10 one.
+    const { service } = makeService([{ date: new Date(Date.UTC(2026, 5, 8)), _count: 3 }]);
+
+    await expect(service.getBusiestWeek("2026-06-04", "user-1")).resolves.toEqual({
+      count: 3,
+      from: "2026-06-07",
+      to: "2026-06-13",
+    });
+  });
+
+  it("treats a month whose 1st is a Sunday as four full Sun→Sat weeks", async () => {
+    // February 2026 starts on a Sunday → ranges 1–7, 8–14, 15–21, 22–28.
+    const { service } = makeService([{ date: new Date(Date.UTC(2026, 1, 10)), _count: 4 }]);
+
+    await expect(service.getBusiestWeek("2026-02-01", "user-1")).resolves.toEqual({
+      count: 4,
+      from: "2026-02-08",
+      to: "2026-02-14",
+    });
+  });
+
+  it("breaks ties toward the earliest range", async () => {
+    const { service } = makeService([
+      { date: new Date(Date.UTC(2026, 5, 3)), _count: 2 }, // range 1–6
+      { date: new Date(Date.UTC(2026, 5, 8)), _count: 2 }, // range 7–13
+    ]);
+
+    await expect(service.getBusiestWeek("2026-06-01", "user-1")).resolves.toEqual({
+      count: 2,
+      from: "2026-06-01",
+      to: "2026-06-06",
+    });
+  });
+
+  it("returns count 0 and null bounds for a month with no spending", async () => {
+    const { service } = makeService([]);
+
+    await expect(service.getBusiestWeek("2026-06-01", "user-1")).resolves.toEqual({
+      count: 0,
+      from: null,
+      to: null,
+    });
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -8,6 +8,7 @@ import type { CategoryStat, CategoryStatsResponse } from "@stats/dto/category-st
 import type { DailyStat, DailyStatsResponse } from "@stats/dto/daily-stats-response.interface";
 import type { BiggestRegularExpenseResponse } from "@stats/dto/biggest-regular-expense-response.interface";
 import type { CategoryTrendPoint, CategoryTrendsResponse } from "@stats/dto/category-trends-response.interface";
+import type { BusiestWeekResponse } from "@stats/dto/busiest-week-response.interface";
 
 /** Rounds to 2 decimal places to avoid JS float precision issues. */
 const roundCurrency = (n: number): number => Math.round(n);
@@ -70,6 +71,83 @@ export class StatsService {
       dayShifter += ranges[slice_i];
     }
     return totalsByWeek;
+  }
+
+  /**
+   * The calendar week-range of a month with the most one-off spendings (COS-139).
+   * "Week" = the month's calendar-aligned Sun→Sat ranges, truncated at the month
+   * edges — the same slices the rest of the app uses (datepicker, Dépenses,
+   * weekly ceiling), NOT a rolling window. Reads the one-off `Spendings` table
+   * only, so recurrings and exceptionals — which live in their own tables — are
+   * excluded by construction. Counts per day over a half-open UTC month range and
+   * buckets in JS (like the daily stats) so day keys are timezone-safe. Ties
+   * resolve to the earliest range; returns count 0 / null bounds for a month with
+   * no spending. Backs the dashboard's 4th ribbon insight.
+   */
+  async getBusiestWeek(start: string, userID: string): Promise<BusiestWeekResponse> {
+    const startDate = new Date(start);
+    const year = startDate.getUTCFullYear();
+    const month = startDate.getUTCMonth();
+
+    const grouped = await this.prisma.spendings.groupBy({
+      by: ["date"],
+      where: { userID, date: { gte: new Date(Date.UTC(year, month, 1)), lt: new Date(Date.UTC(year, month + 1, 1)) } },
+      _count: true,
+    });
+
+    const ranges = this.weekRangesOfMonth(year, month);
+    const counts = new Array<number>(ranges.length).fill(0);
+    for (const group of grouped) {
+      const day = group.date.getUTCDate();
+      const index = ranges.findIndex((range) => day >= range.startDay && day <= range.endDay);
+      if (index !== -1) {
+        counts[index] += group._count;
+      }
+    }
+
+    // Strict `>` keeps the earliest range on ties.
+    let bestIndex = -1;
+    let bestCount = 0;
+    for (let i = 0; i < ranges.length; i += 1) {
+      if (counts[i] > bestCount) {
+        bestCount = counts[i];
+        bestIndex = i;
+      }
+    }
+
+    if (bestIndex === -1) {
+      return { count: 0, from: null, to: null };
+    }
+
+    const { startDay, endDay } = ranges[bestIndex];
+    return {
+      count: bestCount,
+      from: new Date(Date.UTC(year, month, startDay)).toISOString().slice(0, 10),
+      to: new Date(Date.UTC(year, month, endDay)).toISOString().slice(0, 10),
+    };
+  }
+
+  /**
+   * A month's calendar-aligned week slices as inclusive day-of-month ranges: a
+   * (possibly short) first slice from day 1 to the first Saturday, full Sun→Sat
+   * weeks, then a (possibly short) trailing slice. Same slicing as `makeRange`,
+   * but the first slice is derived from the 1st of the month (UTC) so it is
+   * correct whatever day `start` falls on.
+   */
+  private weekRangesOfMonth(year: number, month: number): { startDay: number; endDay: number }[] {
+    const firstWeekday = new Date(Date.UTC(year, month, 1)).getUTCDay();
+    const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+
+    const ranges: { startDay: number; endDay: number }[] = [];
+    let day = 1;
+    let sliceLength = 7 - firstWeekday;
+    while (day <= daysInMonth) {
+      const endDay = Math.min(day + sliceLength - 1, daysInMonth);
+      ranges.push({ startDay: day, endDay });
+      day = endDay + 1;
+      sliceLength = 7;
+    }
+    return ranges;
   }
 
   async getRegularMonthlyAverage(yearStr: string, userID: string): Promise<{ monthlyAverage: number }> {


### PR DESCRIPTION
Add a 4th InsightsRibbon cell showing the displayed month's calendar week-range with the most transactions ("N transactions du X au Y"), where the range links through to that week on the Dépenses page.

Backend: new GET /busiest-week (StatsService.getBusiestWeek) counts Spendings per calendar-aligned week slice (Sun→Sat, truncated at the month edges, UTC) and returns the busiest as { count, from, to }; ties go to the earliest range. Covered by 6 unit tests.

Front: useBusiestWeek hook + zod schema, the ribbon grid widened to 4-up, and the date range wired to buildSpendingsPath — the Dépenses week (getWeekRange) uses the same truncated model, so the link lands exactly on that range.