### PR TITLE
feat(dashboard): de-mock spending-pace insight (COS-40)

### DIFF
--- a/front/src/components/dashboard/sections/InsightsRibbon.tsx
+++ b/front/src/components/dashboard/sections/InsightsRibbon.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-// Partly MOCK — the pace framing ("~16% moins vite") is still a placeholder
-// needing real 3-month history. The end-of-month conclusion, the rising category
-// (name + real % vs last month) and "reste à vivre" are derived from real data.
-// See REFACTO_NOTES.md §6.
+// All four insights are derived from real data: the pace vs the preceding
+// months' daily average and the end-of-month budget conclusion (COS-40), the top
+// rising category (name + real % vs last month), "reste à vivre", and the
+// busiest week.
 
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { DividedStrip } from "@components/shared/DividedStrip";
@@ -11,9 +11,11 @@ import { Overline } from "@components/shared/Overline";
 import { MONTHLY } from "@components/spendings/config/constants";
 import { categoryDeltaPct, STABLE_TREND_THRESHOLD } from "@components/spendings/helpers/categoryTrend";
 import dailyRemainingBudget from "@components/spendings/helpers/dailyBudget";
+import { spendingPaceDelta } from "@components/spendings/helpers/spendingPace";
 import useBusiestWeek from "@components/spendings/services/useBusiestWeek";
 import useCategoryTrends from "@components/spendings/services/useCategoryTrends";
 import useDashboard from "@components/spendings/services/useDashboard";
+import useSpendingPace from "@components/spendings/services/useSpendingPace";
 import { buildSpendingsPath } from "@helpers/dateRoute";
 import { euro0 } from "@lib/format";
 import { cn } from "@lib/utils";
@@ -60,6 +62,7 @@ const InsightsRibbon = () => {
   const { data: trendsData } = useCategoryTrends(MONTHLY);
   const trends = trendsData?.trends;
   const { data: busiest } = useBusiestWeek();
+  const { data: pace } = useSpendingPace();
   const { insightsRibbon: t } = dashboardText;
 
   const budget = Number(dashboard?.initialAmount ?? 0);
@@ -70,6 +73,20 @@ const InsightsRibbon = () => {
   const dayOfMonth = isThisMonth ? getDate(now) : daysInMonth;
   const projection = dayOfMonth > 0 ? (monthlyTotal / dayOfMonth) * daysInMonth : monthlyTotal;
   const underBudget = budget <= 0 || projection <= budget;
+  // The budget line is a forecast only while the month is still running; on its
+  // last day and for past months there are no days left to project, so it reads
+  // as a bilan instead ("projection" then equals the month's actual total).
+  const inProgress = isThisMonth && dayOfMonth < daysInMonth;
+  const budgetLead = inProgress
+    ? "À ce rythme, le mois se termine"
+    : isThisMonth
+      ? "Le mois se termine aujourd'hui,"
+      : "Le mois s'est terminé";
+  // Real pace vs the preceding months' daily average (COS-40); null when there is
+  // not enough to compare (no prior month with spending, or too few days elapsed
+  // this month), in which case we show a waiting note instead of a figure.
+  const paceComparison = spendingPaceDelta(monthlyTotal, dayOfMonth, pace?.months ?? []);
+  const paceDelta = paceComparison ? Math.round(Math.abs(paceComparison.deltaPct)) : 0;
   // same figure as the Dépenses "Budget du jour maximum" (shared helper)
   const perDay = dailyRemainingBudget(remaining, isThisMonth ? now : endOfMonth(monthRef));
   // The named category whose spending rose the most vs last month. Gated on the
@@ -98,9 +115,20 @@ const InsightsRibbon = () => {
         icon={<TrendingUp className="size-3.5" />}
         label={t.paceLabel}
       >
-        Consommation <b className="font-semibold text-ink">~16% moins vite</b> {/* MOCK pace */}que la moyenne 3 mois. À
-        ce rythme, le mois se termine{" "}
-        <b className="font-semibold text-ink">{underBudget ? "sous le budget" : "au-dessus du budget"}</b>.
+        {paceComparison ? (
+          <>
+            Consommation{" "}
+            <b className="font-semibold text-ink">
+              {paceDelta === 0
+                ? "au même rythme"
+                : `~${paceDelta}% ${paceComparison.faster ? "plus vite" : "moins vite"}`}
+            </b>{" "}
+            que la moyenne 3 mois.{" "}
+          </>
+        ) : (
+          <>{t.paceEmpty} </>
+        )}
+        {budgetLead} <b className="font-semibold text-ink">{underBudget ? "sous le budget" : "au-dessus du budget"}</b>.
       </Insight>
       <Insight
         tone="bg-neg/10 text-neg"

--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -12,6 +12,7 @@ export const QUERY_KEYS = {
   MONTHLY_INCOME: "monthlyIncome",
   CATEGORY_TRENDS: "categoryTrends",
   BUSIEST_WEEK: "busiestWeek",
+  SPENDING_PACE: "spendingPace",
   WEEKLY_STATS: "weeklyStats",
   DAILY_STATS: "dailyStats",
   BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",

--- a/front/src/components/spendings/helpers/__tests__/spendingPace.test.ts
+++ b/front/src/components/spendings/helpers/__tests__/spendingPace.test.ts
@@ -1,0 +1,62 @@
+import { PACE_MIN_DAYS, spendingPaceDelta } from "@components/spendings/helpers/spendingPace";
+
+import type { MonthlyTotal } from "@src/schemas/stats";
+
+// May 2026 = 31 days, April = 30, March = 31. Totals are chosen so each month's
+// daily rate is exact (total ÷ days) — a rate of 10/day is 310 in May, 300 in
+// April, 310 in March. Current-month inputs use 30 elapsed days (≥ PACE_MIN_DAYS)
+// so `monthlyTotal / elapsedDays` is the intended daily rate.
+const month = (m: string, total: number): MonthlyTotal => ({ month: m, total });
+const flatTen = [month("2026-05-01", 310), month("2026-04-01", 300), month("2026-03-01", 310)];
+const atRate = (rate: number) => rate * 30; // monthlyTotal for a given daily rate over 30 elapsed days
+
+describe("spendingPaceDelta", () => {
+  it("reports the current month as slower when its daily rate is below the 3-month average", () => {
+    const result = spendingPaceDelta(atRate(8), 30, flatTen);
+    expect(result?.faster).toBe(false);
+    expect(result?.deltaPct).toBeCloseTo(-20, 6); // (8 − 10) / 10
+  });
+
+  it("reports faster when the current daily rate is above the average", () => {
+    const result = spendingPaceDelta(atRate(12), 30, flatTen);
+    expect(result?.faster).toBe(true);
+    expect(result?.deltaPct).toBeCloseTo(20, 6);
+  });
+
+  it("normalizes each month by its own length, not by its raw total", () => {
+    // Both months spend at 10/day despite different totals (May 31d, April 30d).
+    const result = spendingPaceDelta(atRate(10), 30, [month("2026-05-01", 310), month("2026-04-01", 300)]);
+    expect(result?.deltaPct).toBeCloseTo(0, 6);
+  });
+
+  it("averages the kept months' rates equally", () => {
+    // May 620 → 20/day, April 300 → 10/day → average 15/day.
+    const result = spendingPaceDelta(atRate(15), 30, [month("2026-05-01", 620), month("2026-04-01", 300)]);
+    expect(result?.deltaPct).toBeCloseTo(0, 6);
+  });
+
+  it("excludes empty months instead of averaging in a zero", () => {
+    // Only May (10/day) counts; a naive (10+0+0)/3 average would flip the sign.
+    const result = spendingPaceDelta(atRate(5), 30, [
+      month("2026-05-01", 310),
+      month("2026-04-01", 0),
+      month("2026-03-01", 0),
+    ]);
+    expect(result?.deltaPct).toBeCloseTo(-50, 6);
+  });
+
+  it("returns null when no prior month has spending", () => {
+    expect(spendingPaceDelta(atRate(10), 30, [])).toBeNull();
+    expect(spendingPaceDelta(atRate(10), 30, [month("2026-05-01", 0), month("2026-04-01", 0)])).toBeNull();
+  });
+
+  it("returns null before enough of the month has elapsed, even with a baseline", () => {
+    expect(spendingPaceDelta(atRate(10), PACE_MIN_DAYS - 1, flatTen)).toBeNull();
+  });
+
+  it("computes as soon as PACE_MIN_DAYS have elapsed", () => {
+    // 70 over 7 days = 10/day, matching the baseline → 0% gap (not null).
+    const result = spendingPaceDelta(10 * PACE_MIN_DAYS, PACE_MIN_DAYS, flatTen);
+    expect(result?.deltaPct).toBeCloseTo(0, 6);
+  });
+});

--- a/front/src/components/spendings/helpers/spendingPace.ts
+++ b/front/src/components/spendings/helpers/spendingPace.ts
@@ -1,0 +1,46 @@
+import getDaysInMonth from "date-fns/getDaysInMonth";
+import parseISO from "date-fns/parseISO";
+
+import type { MonthlyTotal } from "@src/schemas/stats";
+
+/**
+ * Days that must have elapsed in the current month before its daily rate is
+ * stable enough to compare — under a week, one purchase swings the pace wildly.
+ * Past months are always full, so this only gates the in-progress month.
+ */
+export const PACE_MIN_DAYS = 7;
+
+export interface PaceComparison {
+  /** Signed gap of the current daily rate vs the recent average, as a % (>0 = faster). */
+  deltaPct: number;
+  /** True when the current month is spending faster than the recent average. */
+  faster: boolean;
+}
+
+/**
+ * The current month's spending pace vs the average daily rate of the preceding
+ * months that had spending (COS-40). Each month contributes its own daily rate
+ * (total ÷ days in that month); the rates are averaged equally. Months with no
+ * spending are excluded rather than averaged in as a zero — the same
+ * "no average-of-nothing" spirit as the projection chain — so a fresh user with
+ * only one prior active month still gets a real comparison.
+ *
+ * Null — meaning "not enough data, show the waiting copy instead of a figure" —
+ * when either input is too thin to be trustworthy: fewer than `PACE_MIN_DAYS`
+ * elapsed this month (rate too noisy) or no prior month with spending (no
+ * baseline). `elapsedDays` is the days elapsed in the current month, or the
+ * month's full length when viewing a past month.
+ */
+export const spendingPaceDelta = (
+  monthlyTotal: number,
+  elapsedDays: number,
+  previousMonths: readonly MonthlyTotal[],
+): PaceComparison | null => {
+  if (elapsedDays < PACE_MIN_DAYS) return null;
+  const rates = previousMonths.filter((m) => m.total > 0).map((m) => m.total / getDaysInMonth(parseISO(m.month)));
+  if (rates.length === 0) return null;
+  const averageRate = rates.reduce((sum, rate) => sum + rate, 0) / rates.length;
+  if (averageRate <= 0) return null;
+  const deltaPct = ((monthlyTotal / elapsedDays - averageRate) / averageRate) * 100;
+  return { deltaPct, faster: deltaPct > 0 };
+};

--- a/front/src/components/spendings/services/useSpendingPace.ts
+++ b/front/src/components/spendings/services/useSpendingPace.ts
@@ -1,0 +1,40 @@
+import { useAuth } from "@auth/context/AuthContext";
+import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { DATE_FORMAT, QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@helpers/useRequestHelper";
+import { SpendingPaceResponseSchema } from "@src/schemas/stats";
+import format from "date-fns/format";
+import startOfMonth from "date-fns/startOfMonth";
+import { useQuery } from "react-query";
+
+import type { SpendingPaceResponse } from "@src/schemas/stats";
+
+/**
+ * The totals of the three months before the displayed month (COS-40), newest→
+ * oldest, as `{ months: [{ month, total }] }`. Backs the dashboard's "Sur le
+ * rythme" insight, which turns them into daily rates to gauge the current month's
+ * pace. The month is passed as its 1st day; userID is read from the session
+ * server-side.
+ */
+const useSpendingPace = () => {
+  const { privateRequest } = useRequestHelper();
+  const { from } = useDatePickerWrapperStore();
+  const { user } = useAuth();
+  const userID = user?.id;
+  const monthBeginning = from ? startOfMonth(from) : null;
+
+  const getSpendingPace = async (): Promise<SpendingPaceResponse> => {
+    if (!monthBeginning || !userID) return { months: [] };
+    const query = new URLSearchParams({ start: format(monthBeginning, DATE_FORMAT) });
+    const response = await privateRequest(`/spending-pace?${query}`);
+    return SpendingPaceResponseSchema.parse(response.data);
+  };
+
+  return useQuery([QUERY_KEYS.SPENDING_PACE, monthBeginning], getSpendingPace, {
+    retry: false,
+    enabled: !!monthBeginning && !!userID,
+    ...QUERY_OPTIONS,
+  });
+};
+
+export default useSpendingPace;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -96,3 +96,20 @@ export const BusiestWeekResponseSchema = z.object({
 });
 
 export type BusiestWeekResponse = z.infer<typeof BusiestWeekResponseSchema>;
+
+// Totals of the three months before the displayed month (COS-40) — GET
+// /spending-pace. Newest→oldest (M-1, M-2, M-3); `month` is the month's first day
+// (YYYY-MM-DD). Feeds the dashboard's "Sur le rythme" insight, which turns these
+// into daily rates and compares them to the current month's pace.
+export const MonthlyTotalSchema = z.object({
+  month: z.string(),
+  total: numberLikeSchema,
+});
+
+export type MonthlyTotal = z.infer<typeof MonthlyTotalSchema>;
+
+export const SpendingPaceResponseSchema = z.object({
+  months: z.array(MonthlyTotalSchema),
+});
+
+export type SpendingPaceResponse = z.infer<typeof SpendingPaceResponseSchema>;

--- a/front/src/text/dashboard.ts
+++ b/front/src/text/dashboard.ts
@@ -69,6 +69,7 @@ const dashboard = {
   },
   insightsRibbon: {
     paceLabel: "Sur le rythme",
+    paceEmpty: "En attente de plus de données pour comparer le rythme.",
     risingLabel: "Catégorie en hausse",
     risingEmpty: "Aucune hausse ce mois.",
     remainingLabel: "Reste à vivre",

--- a/nest-api/src/stats/dto/spending-pace-query.dto.ts
+++ b/nest-api/src/stats/dto/spending-pace-query.dto.ts
@@ -1,0 +1,14 @@
+import { Matches } from "class-validator";
+
+const YMD = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * The reference month whose spending pace is compared to the preceding months
+ * (GET /spending-pace): any day of the target month as a yyyy-MM-dd date. The
+ * front passes the 1st of the displayed dashboard month; the service derives the
+ * three months before it from this date (UTC), so any in-month day works too.
+ */
+export class SpendingPaceQueryDto {
+  @Matches(YMD, { message: "start must be a yyyy-MM-dd date" })
+  start: string;
+}

--- a/nest-api/src/stats/dto/spending-pace-response.interface.ts
+++ b/nest-api/src/stats/dto/spending-pace-response.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * The total one-off spending of each of the three months preceding a reference
+ * month (GET /spending-pace?start=YYYY-MM-DD), backing the dashboard's "Sur le
+ * rythme" ribbon insight (COS-40). The front turns these into daily rates and
+ * compares them to the current month's pace. Counts the one-off `Spendings`
+ * table only, so recurrings/exceptionals — which live in their own tables — are
+ * excluded by construction, matching the projection and the other ribbon
+ * insights. Ordered newest→oldest (M-1, M-2, M-3). A month with no spending
+ * comes back as total 0 — the front excludes it rather than averaging in a zero.
+ *
+ * @example { months: [
+ *   { month: "2026-06-01", total: 1240.5 },
+ *   { month: "2026-05-01", total: 1310 },
+ *   { month: "2026-04-01", total: 0 },
+ * ] }
+ */
+export interface MonthlyTotal {
+  /** ISO date (YYYY-MM-DD, UTC) of the month's first day. */
+  month: string;
+  /** Sum of the month's one-off spendings, rounded to the cent (0 when empty). */
+  total: number;
+}
+
+export interface SpendingPaceResponse {
+  months: MonthlyTotal[];
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -9,6 +9,7 @@ import { CategoryStatsQueryDto } from "@stats/dto/category-stats-query.dto";
 import { BiggestRegularExpenseQueryDto } from "@stats/dto/biggest-regular-expense-query.dto";
 import { CategoryTrendsQueryDto } from "@stats/dto/category-trends-query.dto";
 import { BusiestWeekQueryDto } from "@stats/dto/busiest-week-query.dto";
+import { SpendingPaceQueryDto } from "@stats/dto/spending-pace-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 
@@ -94,6 +95,17 @@ export class BusiestWeekController {
   @Get()
   async getBusiestWeek(@Query() query: BusiestWeekQueryDto, @GetUserId() userID: string) {
     return this.statsService.getBusiestWeek(query.start, userID);
+  }
+}
+
+@Controller("spending-pace")
+@UseGuards(SessionAuthGuard)
+export class SpendingPaceController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getSpendingPace(@Query() query: SpendingPaceQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getSpendingPace(query.start, userID);
   }
 }
 

--- a/nest-api/src/stats/stats.module.ts
+++ b/nest-api/src/stats/stats.module.ts
@@ -8,6 +8,7 @@ import {
   CategoryStatsController,
   CategoryTrendsController,
   BusiestWeekController,
+  SpendingPaceController,
   DailyStatsController,
   BiggestRegularExpenseController,
 } from "@stats/stats.controller";
@@ -24,6 +25,7 @@ import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
     CategoryStatsController,
     CategoryTrendsController,
     BusiestWeekController,
+    SpendingPaceController,
     DailyStatsController,
     BiggestRegularExpenseController,
   ],

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -517,3 +517,76 @@ describe("StatsService.getBusiestWeek", () => {
     });
   });
 });
+
+/**
+ * Unit tests for StatsService.getSpendingPace — the totals of the three months
+ * before a reference month, backing the dashboard's "Sur le rythme" insight
+ * (COS-40). Prisma is mocked, so these assert the (half-open, UTC) query shape
+ * and the newest→oldest transformation without a DB.
+ */
+describe("StatsService.getSpendingPace", () => {
+  const makeService = (totals: number[]) => {
+    // One aggregate call per month back (M-1, M-2, M-3), resolved in call order.
+    const aggregate = jest.fn();
+    totals.forEach((total) => aggregate.mockResolvedValueOnce({ _sum: { amount: total } }));
+    const prisma = { spendings: { aggregate } } as unknown as never;
+    return { service: new StatsService(prisma), aggregate };
+  };
+
+  it("sums each of the three preceding months over a half-open UTC range, scoped to the user", async () => {
+    const { service, aggregate } = makeService([0, 0, 0]);
+
+    await service.getSpendingPace("2026-06-01", "user-1");
+
+    expect(aggregate).toHaveBeenCalledTimes(3);
+    expect(aggregate).toHaveBeenNthCalledWith(1, {
+      where: { userID: "user-1", date: { gte: new Date(Date.UTC(2026, 4, 1)), lt: new Date(Date.UTC(2026, 5, 1)) } },
+      _sum: { amount: true },
+    });
+    expect(aggregate).toHaveBeenNthCalledWith(2, {
+      where: { userID: "user-1", date: { gte: new Date(Date.UTC(2026, 3, 1)), lt: new Date(Date.UTC(2026, 4, 1)) } },
+      _sum: { amount: true },
+    });
+    expect(aggregate).toHaveBeenNthCalledWith(3, {
+      where: { userID: "user-1", date: { gte: new Date(Date.UTC(2026, 2, 1)), lt: new Date(Date.UTC(2026, 3, 1)) } },
+      _sum: { amount: true },
+    });
+  });
+
+  it("returns the three totals newest→oldest with their month's first day", async () => {
+    const { service } = makeService([1240.5, 1310, 980.25]);
+
+    await expect(service.getSpendingPace("2026-06-01", "user-1")).resolves.toEqual({
+      months: [
+        { month: "2026-05-01", total: 1240.5 },
+        { month: "2026-04-01", total: 1310 },
+        { month: "2026-03-01", total: 980.25 },
+      ],
+    });
+  });
+
+  it("wraps across the year boundary and reports 0 for an empty month", async () => {
+    // Reference January 2026 → M-1 Dec, M-2 Nov, M-3 Oct 2025.
+    const { service } = makeService([0, 500, 300]);
+
+    await expect(service.getSpendingPace("2026-01-01", "user-1")).resolves.toEqual({
+      months: [
+        { month: "2025-12-01", total: 0 },
+        { month: "2025-11-01", total: 500 },
+        { month: "2025-10-01", total: 300 },
+      ],
+    });
+  });
+
+  it("coerces a null Prisma sum to 0", async () => {
+    const { service } = makeService([null as unknown as number, null as unknown as number, null as unknown as number]);
+
+    await expect(service.getSpendingPace("2026-06-01", "user-1")).resolves.toEqual({
+      months: [
+        { month: "2026-05-01", total: 0 },
+        { month: "2026-04-01", total: 0 },
+        { month: "2026-03-01", total: 0 },
+      ],
+    });
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -9,6 +9,7 @@ import type { DailyStat, DailyStatsResponse } from "@stats/dto/daily-stats-respo
 import type { BiggestRegularExpenseResponse } from "@stats/dto/biggest-regular-expense-response.interface";
 import type { CategoryTrendPoint, CategoryTrendsResponse } from "@stats/dto/category-trends-response.interface";
 import type { BusiestWeekResponse } from "@stats/dto/busiest-week-response.interface";
+import type { SpendingPaceResponse } from "@stats/dto/spending-pace-response.interface";
 
 /** Rounds to 2 decimal places to avoid JS float precision issues. */
 const roundCurrency = (n: number): number => Math.round(n);
@@ -148,6 +149,37 @@ export class StatsService {
       sliceLength = 7;
     }
     return ranges;
+  }
+
+  /**
+   * The total one-off spending of each of the three months before the reference
+   * month (COS-40), so the dashboard's "Sur le rythme" insight can compare the
+   * current month's daily pace to the recent average. Reads the one-off
+   * `Spendings` table only (recurrings/exceptionals live in their own tables), the
+   * same basis as the projection and the other ribbon insights. Sums each month
+   * over a half-open UTC range so month keys are timezone-safe; `Date.UTC`
+   * normalizes negative months, so no manual year wrap is needed. Returned
+   * newest→oldest (M-1, M-2, M-3); an empty month comes back as total 0 and is
+   * excluded — not averaged in — on the front.
+   */
+  async getSpendingPace(start: string, userID: string): Promise<SpendingPaceResponse> {
+    const startDate = new Date(start);
+    const year = startDate.getUTCFullYear();
+    const month = startDate.getUTCMonth();
+
+    const months = await Promise.all(
+      [1, 2, 3].map(async (monthsBack) => {
+        const gte = new Date(Date.UTC(year, month - monthsBack, 1));
+        const lt = new Date(Date.UTC(year, month - monthsBack + 1, 1));
+        const result = await this.prisma.spendings.aggregate({
+          where: { userID, date: { gte, lt } },
+          _sum: { amount: true },
+        });
+        return { month: gte.toISOString().slice(0, 10), total: round2(Number(result._sum.amount ?? 0)) };
+      }),
+    );
+
+    return { months };
   }
 
   async getRegularMonthlyAverage(yearStr: string, userID: string): Promise<{ monthlyAverage: number }> {


### PR DESCRIPTION
The "Sur le rythme" ribbon insight hardcoded "~16% moins vite que la moyenne 3 mois". Replace it with the real comparison.

Backend: new GET /spending-pace (stats module) returns the three preceding months' one-off totals over half-open UTC ranges.

Front: useSpendingPace hook + a pure spendingPaceDelta helper comparing the current month's daily rate to the average daily rate of the prior months that had spending. Empty months are excluded (no average-of-nothing); with no baseline, or fewer than PACE_MIN_DAYS elapsed, the figure gives way to a waiting note instead of a noisy %.

The budget conclusion now matches the viewed month: a forecast while the month is running, "aujourd'hui" on its last day, and a past-tense bilan for a completed month (no more "le mois se termine" on a month that has already ended).

Covered by jest (backend aggregate) and vitest (pace helper).