### PR TITLE
fix(dashboard): size month picker to longest label (COS-152)

### DIFF
--- a/front/src/components/dashboard/MonthPickerPopover.tsx
+++ b/front/src/components/dashboard/MonthPickerPopover.tsx
@@ -50,11 +50,12 @@ const MonthPickerPopover = ({ month, currentMonthStart, onSelectMonth }: MonthPi
       onOpenChange={handleOpenChange}
     >
       {/* Trigger = the month label itself (no caret — matches the datepicker).
-          Fixed width (fits the longest month, "septembre") so the control never
-          resizes as the month changes. */}
+          Fixed width from the spacing scale (w-36 holds the longest "MMMM yyyy",
+          "septembre 2025", in mono) so the control never resizes between months;
+          whitespace-nowrap keeps it on one line — a wrapped label grows the navbar. */}
       <PopoverTrigger
         aria-label={text.chooseMonth(label)}
-        className="num w-[116px] cursor-pointer rounded-sm px-1 py-0.5 text-center text-sm capitalize tracking-normal text-ink-2 transition-colors hover:text-ink"
+        className="num w-36 cursor-pointer whitespace-nowrap rounded-sm px-1 py-0.5 text-center text-sm capitalize tracking-normal text-ink-2 transition-colors hover:text-ink"
       >
         {label}
       </PopoverTrigger>


### PR DESCRIPTION
The month label trigger used a hardcoded w-[116px] sized for the month name alone. The rendered "MMMM yyyy" label (Geist Mono) overflowed for long months like "septembre 2025"/"novembre 2025", wrapping to two lines and growing the navbar height.

Replace the arbitrary width with w-36, a spacing-scale step wide enough to hold the longest label on one line, and add whitespace-nowrap as a guard so it never wraps.