### PR TITLE
feat(statistics): de-mock drawn total (COS-49)

### DIFF
--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -6,6 +6,7 @@ export const QUERY_OPTIONS = {
 export const QUERY_KEYS = {
   SPENDINGS_BY_MONTH: "spendingsByMonth",
   RECURRINGS: "recurrings",
+  RECURRINGS_DRAWN: "recurringsDrawn",
   INITIAL_AMOUNT: "initialAmount",
   DASHBOARD: "dashboard",
   DAILY_PROJECTION: "dailyProjection",

--- a/front/src/components/statistics/StatisticsFixedExpenses.tsx
+++ b/front/src/components/statistics/StatisticsFixedExpenses.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-// All figures are real (from /reccurings). Recurrings carry no category, so —
-// exactly as the mockup notes — they are totalled by name. The only estimate is
-// "déjà prélevé", derived from each line's charge-day vs today (MOCK: recurrings
-// have no dedicated charge-day field, so the day-of-month of `dateFrom` is used).
+// All figures are real (from /recurrings). Recurrings carry no category, so —
+// exactly as the mockup notes — they are totalled by name. "Déjà prélevé" is the
+// real year-to-date sum of the per-month recurring rows (Jan → current month),
+// computed server-side (GET /recurrings/drawn) and passed in as `drawn`.
 
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
@@ -12,23 +12,14 @@ import { Overline } from "@components/shared/Overline";
 import { CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro, splitAmount } from "@lib/format";
 import statistics from "@text/statistics";
-import format from "date-fns/format";
-import getDate from "date-fns/getDate";
-import fr from "date-fns/locale/fr";
-import parseISO from "date-fns/parseISO";
 
 import type { RecurringItem } from "@src/schemas/spendings";
 
 interface StatisticsFixedExpensesProps {
   recurrings: RecurringItem[];
+  drawn: number;
   now: Date;
 }
-
-/** Charge day-of-month, from the recurring's `dateFrom` (best real proxy). */
-const chargeDay = (r: RecurringItem): number => {
-  const d = getDate(parseISO(r.dateFrom));
-  return Number.isNaN(d) ? 1 : d;
-};
 
 const Stat = ({
   label,
@@ -61,8 +52,8 @@ const Stat = ({
 
 /** "Dépenses fixes" — recurrings annualised, with per-line share and the
  *  year-to-date drawn amount. */
-const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesProps) => {
-  const rowTip = useCursorHover<{ monthly: string; day: number }>();
+const StatisticsFixedExpenses = ({ recurrings, drawn, now }: StatisticsFixedExpensesProps) => {
+  const rowTip = useCursorHover<{ monthly: string }>();
   if (recurrings.length === 0) return null;
 
   const { fixedExpenses: t } = statistics;
@@ -71,10 +62,6 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
   const monthlyTotal = list.reduce((sum, r) => sum + Number(r.amount), 0);
   const annualTotal = monthlyTotal * 12;
   const maxAmount = Number(list[0].amount) || 1;
-
-  const monthsElapsed = now.getMonth(); // fully-elapsed months before this one
-  const today = getDate(now);
-  const drawn = list.reduce((sum, r) => sum + Number(r.amount) * (monthsElapsed + (chargeDay(r) <= today ? 1 : 0)), 0);
   const topShare = Math.round((Number(list[0].amount) / monthlyTotal) * 100);
 
   return (
@@ -98,7 +85,7 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
           small
         />
         <Stat
-          label={t.drawn(format(now, "d MMM", { locale: fr }))}
+          label={t.drawn(now.getFullYear())}
           value={drawn}
           small
           className="ml-auto text-right"
@@ -120,7 +107,7 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
                   className="text-ink"
                   role="img"
                   aria-label={r.label}
-                  onMouseMove={rowTip.move({ monthly: euro(Number(r.amount)), day: chargeDay(r) })}
+                  onMouseMove={rowTip.move({ monthly: euro(Number(r.amount)) })}
                   onMouseLeave={rowTip.clear}
                 >
                   {r.label}
@@ -142,7 +129,7 @@ const StatisticsFixedExpenses = ({ recurrings, now }: StatisticsFixedExpensesPro
       <p className="mt-5 border-t border-line-soft pt-4.5 text-xs text-ink-4">{t.note(list[0].label, topShare)}</p>
 
       <CursorTooltip point={rowTip.hover}>
-        {rowTip.hover ? t.tooltip.row(rowTip.hover.data.monthly, rowTip.hover.data.day) : null}
+        {rowTip.hover ? t.tooltip.row(rowTip.hover.data.monthly) : null}
       </CursorTooltip>
     </GlowCard>
   );

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -23,6 +23,7 @@ import StatisticsTopCategories from "@components/statistics/StatisticsTopCategor
 import useBiggestRegularExpense from "@components/statistics/services/useBiggestRegularExpense";
 import useDailyStats from "@components/statistics/services/useDailyStats";
 import useMonthlyIncome from "@components/statistics/services/useMonthlyIncome";
+import useRecurringsDrawn from "@components/statistics/services/useRecurringsDrawn";
 import useStatistics from "@components/statistics/services/useStatistics";
 import { useMemo, useState } from "react";
 
@@ -65,6 +66,9 @@ const StatisticsView = () => {
   const dashboard = useDashboard();
   const { recurrings } = useReccurings();
   const { monthlyIncome } = useMonthlyIncome({ year: selectedYear });
+  // "Déjà prélevé" is always the real current-year-to-date sum, independent of the
+  // selected stats year — the widget's per-line breakdown stays on the current month.
+  const { drawn } = useRecurringsDrawn({ year: currentYear, month: now.getMonth() });
 
   const data = statistics?.data;
   const colors = statistics?.colors ?? {};
@@ -202,6 +206,7 @@ const StatisticsView = () => {
 
       <StatisticsFixedExpenses
         recurrings={recurrings ?? []}
+        drawn={drawn ?? 0}
         now={now}
       />
 

--- a/front/src/components/statistics/services/useRecurringsDrawn.tsx
+++ b/front/src/components/statistics/services/useRecurringsDrawn.tsx
@@ -1,0 +1,34 @@
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@src/helpers/useRequestHelper";
+import { RecurringsDrawnSchema } from "@src/schemas/spendings";
+import { useQuery } from "react-query";
+
+interface UseRecurringsDrawnOptions {
+  year: number;
+  // Current month index (0 = January … 11 = December), from the client's "today".
+  month: number;
+}
+
+/**
+ * Real year-to-date "déjà prélevé" (COS-49): the sum of the actual per-month
+ * recurring rows from January through the client's current month, computed
+ * server-side (GET /recurrings/drawn). Replaces the old calendar estimate that
+ * projected the current month's list backward from a `dateFrom` charge-day proxy.
+ */
+const useRecurringsDrawn = ({ year, month }: UseRecurringsDrawnOptions) => {
+  const { privateRequest } = useRequestHelper();
+
+  const getDrawn = async () => {
+    const response = await privateRequest(`/recurrings/drawn?year=${year}&month=${month}`);
+    return RecurringsDrawnSchema.parse(response.data);
+  };
+
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.RECURRINGS_DRAWN, year, month], getDrawn, {
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return { drawn: data?.drawn, isLoading, error };
+};
+
+export default useRecurringsDrawn;

--- a/front/src/schemas/spendings.ts
+++ b/front/src/schemas/spendings.ts
@@ -58,6 +58,11 @@ export const RecurringItemSchema = z.object({
 export const RecurringListSchema = z.array(RecurringItemSchema);
 export type RecurringItem = z.infer<typeof RecurringItemSchema>;
 
+// Real year-to-date "déjà prélevé" (COS-49) — GET /recurrings/drawn. The server
+// sums the actual per-month recurring rows from January through the current month.
+export const RecurringsDrawnSchema = z.object({ drawn: numberLikeSchema });
+export type RecurringsDrawn = z.infer<typeof RecurringsDrawnSchema>;
+
 export const SpendingMutationPayloadSchema = z.object({
   date: z.string().nullable().optional(),
   label: z.string().min(1),

--- a/front/src/text/statistics.ts
+++ b/front/src/text/statistics.ts
@@ -86,13 +86,11 @@ const statistics = {
     meta: (count: number) => `annualisé · ${count} lignes récurrentes · sans catégorie`,
     annualTotal: "Total sur l'année",
     monthly: "Mensuel",
-    drawn: (date: string) => `Déjà prélevé · au ${date}`,
+    drawn: (year: number) => `Déjà prélevé · ${year}`,
     note: (topName: string, topShare: number) =>
       `Les dépenses fixes ne portent pas de catégorie — elles sont totalisées par nom. Le ${topName} représente à lui seul ${topShare} % du total annuel des récurrents.`,
     tooltip: {
-      row: (monthly: string, day: number) => `${monthly} €/mois · prélevé le ${day}`,
-      drawn:
-        "Estimation : une ligne est comptée prélevée si son jour de prélèvement (jour du mois de la date de début) est passé.",
+      row: (monthly: string) => `${monthly} €/mois`,
     },
   },
   heatmap: {

--- a/nest-api/src/recurrings/dto/recurrings-drawn-query.dto.ts
+++ b/nest-api/src/recurrings/dto/recurrings-drawn-query.dto.ts
@@ -1,0 +1,14 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class RecurringsDrawnQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  year: string;
+
+  // Through-month index (0 = January … 11 = December), inclusive. Resolved from
+  // the client's "today" (timezone-safe) so the year-to-date bound is the user's
+  // current month, not the server's.
+  @IsString()
+  @IsNotEmpty()
+  month: string;
+}

--- a/nest-api/src/recurrings/recurrings.controller.ts
+++ b/nest-api/src/recurrings/recurrings.controller.ts
@@ -15,6 +15,7 @@ import { RecurringsService } from "@recurrings/recurrings.service";
 import { CreateRecurringDto } from "@recurrings/dto/create-recurring.dto";
 import { UpdateRecurringDto } from "@recurrings/dto/update-recurring.dto";
 import { RecurringsQueryDto } from "@recurrings/dto/recurrings-query.dto";
+import { RecurringsDrawnQueryDto } from "@recurrings/dto/recurrings-drawn-query.dto";
 import { CopyRecurringsDto } from "@recurrings/dto/copy-recurrings.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
@@ -28,6 +29,13 @@ export class RecurringsController {
   @Get()
   async getRecurrings(@Query() query: RecurringsQueryDto, @GetUserId() userID: string) {
     return this.recurringsService.getRecurrings(query.start, userID);
+  }
+
+  // Real year-to-date "déjà prélevé" for the Statistics fixed-expenses widget
+  // (COS-49) — sums the per-month recurring rows Jan → the client's current month.
+  @Get("drawn")
+  async getDrawn(@Query() query: RecurringsDrawnQueryDto, @GetUserId() userID: string): Promise<{ drawn: number }> {
+    return this.recurringsService.getDrawn(query.year, query.month, userID);
   }
 
   @Post()

--- a/nest-api/src/recurrings/recurrings.service.spec.ts
+++ b/nest-api/src/recurrings/recurrings.service.spec.ts
@@ -1,0 +1,61 @@
+import { RecurringsService } from "./recurrings.service";
+
+/**
+ * Unit tests for RecurringsService.getDrawn — the real year-to-date "déjà
+ * prélevé" backing the Statistics fixed-expenses widget (COS-49). Recurrings are
+ * stored one row per month, so this sums the actual rows from January through the
+ * client's current month. Prisma is mocked, so these assert the query window and
+ * the Decimal coercion without touching the DB.
+ */
+describe("RecurringsService.getDrawn", () => {
+  const makeService = (aggregate: jest.Mock) => {
+    const prisma = { recurrings: { aggregate } } as unknown as never;
+    return new RecurringsService(prisma);
+  };
+
+  it("sums the rows from January through the given month (inclusive), timezone-safe", async () => {
+    const aggregate = jest.fn().mockResolvedValue({ _sum: { amount: 1250 } });
+    const service = makeService(aggregate);
+
+    const result = await service.getDrawn("2026", "6", "user-1"); // through July (index 6)
+
+    expect(aggregate).toHaveBeenCalledWith({
+      _sum: { amount: true },
+      where: {
+        userID: "user-1",
+        dateFrom: { gte: new Date(Date.UTC(2026, 0, 1)), lt: new Date(Date.UTC(2026, 7, 1)) },
+      },
+    });
+    expect(result).toEqual({ drawn: 1250 });
+  });
+
+  it("includes the whole current month and crosses the year boundary in December", async () => {
+    const aggregate = jest.fn().mockResolvedValue({ _sum: { amount: 9000 } });
+    const service = makeService(aggregate);
+
+    await service.getDrawn("2026", "11", "user-1"); // December
+
+    expect(aggregate.mock.calls[0][0].where.dateFrom).toEqual({
+      gte: new Date(Date.UTC(2026, 0, 1)),
+      lt: new Date(Date.UTC(2027, 0, 1)),
+    });
+  });
+
+  it("coerces a Prisma Decimal sum and returns 0 when there are no rows", async () => {
+    const service = makeService(jest.fn().mockResolvedValue({ _sum: { amount: null } }));
+    expect(await service.getDrawn("2026", "0", "user-1")).toEqual({ drawn: 0 });
+
+    const withDecimal = makeService(jest.fn().mockResolvedValue({ _sum: { amount: "2750.50" } }));
+    expect(await withDecimal.getDrawn("2026", "6", "user-1")).toEqual({ drawn: 2750.5 });
+  });
+
+  it("returns 0 without querying for an invalid or out-of-range year/month", async () => {
+    const aggregate = jest.fn();
+    const service = makeService(aggregate);
+
+    expect(await service.getDrawn("nope", "6", "user-1")).toEqual({ drawn: 0 });
+    expect(await service.getDrawn("2026", "bad", "user-1")).toEqual({ drawn: 0 });
+    expect(await service.getDrawn("2026", "12", "user-1")).toEqual({ drawn: 0 });
+    expect(aggregate).not.toHaveBeenCalled();
+  });
+});

--- a/nest-api/src/recurrings/recurrings.service.ts
+++ b/nest-api/src/recurrings/recurrings.service.ts
@@ -16,6 +16,31 @@ export class RecurringsService {
     });
   }
 
+  /**
+   * Real year-to-date "déjà prélevé" (COS-49): the sum of the actual per-month
+   * recurring rows from January through the client's current month (inclusive).
+   * Recurrings are stored one row per month (copied forward), so this reflects
+   * what was really committed each month — no calendar estimate, no `dateFrom`
+   * charge-day proxy. A half-open UTC range keeps the month bound timezone-safe.
+   */
+  async getDrawn(yearStr: string, monthStr: string, userID: string): Promise<{ drawn: number }> {
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+    if (Number.isNaN(year) || Number.isNaN(month) || month < 0 || month > 11) {
+      return { drawn: 0 };
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const throughMonthEnd = new Date(Date.UTC(year, month + 1, 1));
+
+    const result = await this.prisma.recurrings.aggregate({
+      _sum: { amount: true },
+      where: { userID, dateFrom: { gte: yearStart, lt: throughMonthEnd } },
+    });
+
+    return { drawn: Number(result._sum.amount ?? 0) };
+  }
+
   async createRecurring(
     dto: { start: string; end: string; label: string; amount: number; currency?: string },
     userID: string,


### PR DESCRIPTION
Replace the "déjà prélevé" calendar estimate (current-month list × monthsElapsed, with a dateFrom day-of-month charge-day proxy) by the real year-to-date sum of the per-month recurring rows.

New GET /recurrings/drawn aggregates SUM(amount) from January to the client's current month — no schema change, it leverages the existing per-month rows. Front adds useRecurringsDrawn feeding a `drawn` prop; the label becomes year-to-date and the row tooltip drops the proxy day.