### PR TITLE
feat(statistics): enrich weekday widget (COS-127)

### DIFF
--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -16,6 +16,7 @@ export const QUERY_KEYS = {
   SPENDING_PACE: "spendingPace",
   WEEKLY_STATS: "weeklyStats",
   DAILY_STATS: "dailyStats",
+  WEEKDAY_CATEGORIES: "weekdayCategories",
   BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",
   CATEGORIES: "categories",
   CATEGORY_STATS: "categoryStats",

--- a/front/src/components/spendings/helpers/overspendLevel.ts
+++ b/front/src/components/spendings/helpers/overspendLevel.ts
@@ -26,3 +26,13 @@ export default function overspendLevel(value: number, budget: number | null): Ov
   }
   return value > budget * OVERSPEND_DANGER_RATIO ? "danger" : "warn";
 }
+
+/**
+ * Amount-text colour for an overspend level — the single source of truth for
+ * colouring a total by how far it is over budget (COS-34 Dépenses day cards,
+ * COS-127 weekday averages): under budget stays neutral `ink`, over budget goes
+ * amber, well over goes red. Only warn/danger stand out, so the column never
+ * turns into a rainbow.
+ */
+export const overspendTextClass = (level: OverspendLevel): string =>
+  level === "warn" ? "text-warn" : level === "danger" ? "text-neg" : "text-ink";

--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -3,63 +3,190 @@
 import { CardSectionHeader } from "@components/shared/CardSectionHeader";
 import GlowCard from "@components/shared/GlowCard";
 import { MeterBar } from "@components/shared/MeterBar";
-import { OVERSPEND_DANGER_RATIO } from "@components/spendings/helpers/overspendLevel";
+import overspendLevel, {
+  OVERSPEND_DANGER_RATIO,
+  overspendTextClass,
+} from "@components/spendings/helpers/overspendLevel";
 import { scaleFrac } from "@components/statistics/helpers/weekdayBullet";
-import { weekdayAverages } from "@components/statistics/helpers/weekdayStats";
+import { overallDailyAverage, weekdayAverages, weekdayInsights } from "@components/statistics/helpers/weekdayStats";
 import WeekdayBulletBar from "@components/statistics/WeekdayBulletBar";
+import { AnimatedNumber, CursorTooltip, useCursorHover } from "@lib/dataviz";
 import { euro, euro0, pct1 } from "@lib/format";
 import common from "@text/common";
 import statistics from "@text/statistics";
+import { useEffect, useState } from "react";
 
-import type { DailyStat } from "@src/schemas/stats";
+import type { DailyStat, WeekdayCategory } from "@src/schemas/stats";
+import type { ReactNode } from "react";
 
 const { dayOfWeek: t } = statistics;
 
 // Row layout: fixed day-name and amount columns around the elastic bar column.
-const GRID_COLS = "grid grid-cols-[90px_1fr_130px] gap-3";
+const GRID_COLS = "grid grid-cols-[92px_1fr_152px] gap-3";
 const ROW_GRID = `${GRID_COLS} items-center`;
 
-// Bar-column geometry, mirrored by the threshold guides so they span the full
-// height of the plot and line up with the bars. Must match GRID_COLS: a 90px
-// day-name column and a 130px amount column, each separated from the elastic bar
+// Bar-column geometry, mirrored by the full-height overlays (the moyenne line) so
+// they span the plot and line up with the bars. Must match GRID_COLS: a 92px
+// day-name column and a 152px amount column, each separated from the elastic bar
 // column by gap-3 (12px).
-const DAY_COL_PX = 90;
-const AMOUNT_COL_PX = 130;
+const DAY_COL_PX = 92;
+const AMOUNT_COL_PX = 152;
 const COL_GAP_PX = 12;
 
-// Fixed-scale headroom so the 2×budget marker always sits inside the bar with a
-// little air past it, even when every weekday stays under it (COS-132).
+// Fixed-scale headroom so the top marker (2×budget, or the widest whisker) always
+// sits inside the plot with a little air past it (COS-132, COS-127).
 const SCALE_HEADROOM = 1.12;
+
+// Compare-year bar + swatch fill: the darker accent green with a light diagonal
+// hatch — the same muted-green hatch idiom as the forecast strip, distinct from
+// the bright main-bar gradient. Echoes the monthly chart's "comparison" visual
+// language (COS-127).
+const COMPARE_FILL =
+  "repeating-linear-gradient(45deg, var(--accent-d) 0 3px, color-mix(in oklch, var(--accent-d) 55%, var(--accent-strong)) 3px 6px)";
+
+// Legend colour-band swatch fills, matching the bullet-bar zones.
+const BAND_FILL = { under: "var(--bar-fill)", between: "var(--warn)", over: "var(--neg)" } as const;
+
+// Enter/exit duration (ms) for the compare-year marks collapsing + fading in and
+// out when "Comparer à" is toggled.
+const COMPARE_ANIM_MS = 280;
 
 interface StatisticsDayOfWeekProps {
   year: number;
   now: Date;
   /** Per-day spending totals for the year (COS-45); `undefined` while the request is in flight. */
   days: DailyStat[] | undefined;
+  /** Compare-year daily totals; `undefined` when "Comparer à" is off (COS-127). */
+  compareDays?: DailyStat[];
+  /** The year being compared against, shown on each compare row + the legend. */
+  compareYear: number;
+  /** Whether year comparison is active — gates the compare-year legend item. */
+  compareEnabled: boolean;
+  /** Dominant category per weekday (index 0 = Monday), for the tooltip; `undefined` while loading. */
+  weekdayCategories?: (WeekdayCategory | null)[];
   /** Weekly ceiling (real data) — its per-day share drives the colour zones. */
   weeklyCeiling: number | null;
 }
 
-/** A dashed threshold line running the full height of the plot, over every bar. */
-const ThresholdGuide = ({ frac }: { frac: number }) => (
+/** Signed % of `value` relative to `base` (spent-more is positive), or null when there is no base. */
+const deltaPct = (value: number, base: number): number | null => (base > 0 ? (value / base - 1) * 100 : null);
+
+/** Year-over-year delta coloured by direction: spending up = worse (red), down = better (green). */
+const DeltaBadge = ({ pct }: { pct: number }) => {
+  const up = pct >= 0;
+  return (
+    <span className={up ? "text-neg" : "text-accent-strong"}>
+      {up ? "↑" : "↓"} {t.deltaPct(String(Math.abs(Math.round(pct))))}
+    </span>
+  );
+};
+
+/** Thin darker-green hatched bar for the compared year, on the shared fixed scale. */
+const CompareBar = ({ frac, expanded }: { frac: number; expanded: boolean }) => (
   <span
-    className="absolute inset-y-0"
-    style={{ left: `${frac * 100}%`, marginLeft: -1, borderLeft: "2px dashed var(--ink)", opacity: 0.6 }}
+    className="block h-2 rounded-sm"
+    // Width (not scaleX) so the diagonal hatch reveals instead of stretching. Grows
+    // from 0 on show; the collapse back to 0 is deferred until after the fade-out
+    // (off-screen), so hiding never visibly changes the bar's length.
+    style={{
+      width: expanded ? `${frac * 100}%` : 0,
+      background: COMPARE_FILL,
+      transition: `width ${COMPARE_ANIM_MS}ms ease-out`,
+    }}
   />
 );
 
-/** A dashed threshold's euro value, centred under its guide on the bar column. */
-const ThresholdLabel = ({ frac, amount }: { frac: number; amount: number }) => (
+/** A dashed grey guide delimiting a colour zone, running the full height of the plot.
+ *  1px to match the budget ticks at the bottom. */
+const ThresholdGuide = ({ frac }: { frac: number }) => (
   <span
-    className="num absolute top-0 -translate-x-1/2 whitespace-nowrap text-2xs text-ink-4"
-    style={{ left: `${frac * 100}%` }}
+    className="absolute inset-y-0"
+    style={{ left: `${frac * 100}%`, marginLeft: -0.5, borderLeft: "1px dashed var(--ink)", opacity: 0.6 }}
+  />
+);
+
+/** min→max "fourchette" whisker: a thin connector with end caps, over the main bar. */
+const Whisker = ({ minFrac, maxFrac }: { minFrac: number; maxFrac: number }) => (
+  <div
+    className="pointer-events-none absolute inset-0"
+    aria-hidden
   >
-    {euro0(amount)} €
+    <span
+      className="absolute top-1/2 h-px -translate-y-1/2 bg-ink-2/45"
+      style={{ left: `${minFrac * 100}%`, width: `${Math.max(0, maxFrac - minFrac) * 100}%` }}
+    />
+    <span
+      className="absolute inset-y-1 w-px bg-ink-2/80"
+      style={{ left: `${minFrac * 100}%` }}
+    />
+    <span
+      className="absolute inset-y-1 w-px bg-ink-2/80"
+      style={{ left: `${maxFrac * 100}%` }}
+    />
+  </div>
+);
+
+/** One header insight chip: a coloured dot + label. */
+const Chip = ({ dot, children }: { dot: string; children: ReactNode }) => (
+  <span className="inline-flex items-center gap-1.5 rounded-full border border-line bg-surface-hi/60 px-2.5 py-1 text-2xs">
+    <span
+      className="size-1.5 shrink-0 rounded-full"
+      style={{ background: dot }}
+    />
+    {children}
   </span>
 );
 
-/** "Dépenses par jour de la semaine" — real weekday spending rhythm (COS-48, COS-132). */
-const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOfWeekProps) => {
+/** A swatch + label pair in the bottom legend. */
+const LegendItem = ({ swatch, children }: { swatch: ReactNode; children: ReactNode }) => (
+  <span className="inline-flex items-center gap-1.5">
+    {swatch}
+    {children}
+  </span>
+);
+
+/** One label/value line in the hover tooltip. */
+const TipRow = ({ label, value }: { label: string; value: ReactNode }) => (
+  <div className="flex items-baseline justify-between gap-6">
+    <span className="text-ink-4">{label}</span>
+    <span className="text-ink-2">{value}</span>
+  </div>
+);
+
+/** "Dépenses par jour de la semaine" — real weekday spending rhythm (COS-48, COS-132, COS-127). */
+const StatisticsDayOfWeek = ({
+  year,
+  now,
+  days,
+  compareDays,
+  compareYear,
+  compareEnabled,
+  weekdayCategories,
+  weeklyCeiling,
+}: StatisticsDayOfWeekProps) => {
+  const rowTip = useCursorHover<number>();
+
+  // Compare-year marks: `hasCompareData` (the compared year has spending, and the
+  // fetch keeps it cached even when the toggle is off) reserves their layout space,
+  // so toggling "Comparer à" only fades them in/out and the widget keeps its height.
+  // `showCompare` (fade state) additionally requires the toggle to be on.
+  const compareStats = compareDays ? weekdayAverages(compareDays, compareYear, now) : null;
+  const hasCompareData = compareStats?.some((s) => s.avgAmount > 0) ?? false;
+  const showCompare = compareEnabled && hasCompareData;
+
+  // Compare bars grow from 0 on show; on hide they only fade — the width is held
+  // through the fade, then reset to 0 off-screen, so hiding never shrinks the bar
+  // and the next show grows again.
+  const [barsCollapsed, setBarsCollapsed] = useState(true);
+  useEffect(() => {
+    if (showCompare) {
+      setBarsCollapsed(false);
+      return;
+    }
+    const timer = setTimeout(() => setBarsCollapsed(true), COMPARE_ANIM_MS);
+    return () => clearTimeout(timer);
+  }, [showCompare]);
+
   if (days === undefined) {
     return (
       <GlowCard
@@ -76,15 +203,27 @@ const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOf
   }
 
   const stats = weekdayAverages(days, year, now);
-  const maxAmount = Math.max(...stats.map((s) => s.avgAmount), 1);
+  const overall = overallDailyAverage(days, year, now);
+  const { peakDow, troughDow, weekendDeltaPct } = weekdayInsights(stats);
+
   // Per-weekday budget = the weekly ceiling spread over 7 days (COS-34 rule).
   const dayBudget = weeklyCeiling != null && weeklyCeiling > 0 ? weeklyCeiling / 7 : null;
 
-  // Fixed euro scale shared by all seven bars: wide enough to always show the
-  // 2×budget marker, so the two thresholds stay put across the days and only the
-  // bar lengths change. Without a ceiling there are no thresholds — fall back to
-  // the old scale-to-day-max neutral bar.
-  const scaleMax = dayBudget != null ? Math.max(maxAmount, dayBudget * OVERSPEND_DANGER_RATIO) * SCALE_HEADROOM : 1;
+  // One euro scale shared by every mark — both years' averages, the selected
+  // year's whisker maxes and the budget markers — so bars, whiskers, the moyenne
+  // line and the ticks are all directly comparable (COS-127).
+  const rawMax = Math.max(
+    ...stats.map((s) => s.avgAmount),
+    ...stats.map((s) => s.max),
+    ...(compareStats?.map((s) => s.avgAmount) ?? []),
+    1,
+  );
+  const scaleMax =
+    dayBudget != null ? Math.max(rawMax, dayBudget * OVERSPEND_DANGER_RATIO) * SCALE_HEADROOM : rawMax * SCALE_HEADROOM;
+
+  const avgFrac = scaleFrac(overall.avgAmount, scaleMax);
+  const hasInsights = peakDow != null;
+  const dangerBudget = dayBudget != null ? dayBudget * OVERSPEND_DANGER_RATIO : null;
 
   return (
     <GlowCard
@@ -93,71 +232,343 @@ const StatisticsDayOfWeek = ({ year, now, days, weeklyCeiling }: StatisticsDayOf
     >
       <CardSectionHeader
         title={t.title}
-        meta={t.meta(year)}
+        meta={
+          <>
+            <span className="font-semibold text-ink">{year}</span>{" "}
+            {t.subtitle(pct1(overall.avgTx), euro(overall.avgAmount))}
+          </>
+        }
       />
 
-      <div className="relative mt-4.5">
-        <div className="flex flex-col gap-2">
-          {stats.map((s, dow) => (
-            <div
-              key={t.days[dow]}
-              className={`${ROW_GRID} text-sm`}
-            >
-              <span className="text-ink-2">{t.days[dow]}</span>
-              {dayBudget != null ? (
-                <WeekdayBulletBar
-                  value={s.avgAmount}
-                  dayBudget={dayBudget}
-                  scaleMax={scaleMax}
-                  height={22}
-                />
-              ) : (
-                <MeterBar
-                  value={(s.avgAmount / maxAmount) * 100}
-                  height={22}
-                  opacity={0.85}
-                />
-              )}
-              <span className="num text-right font-medium text-ink">
-                {euro(s.avgAmount)} €
-                <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
+      {hasInsights && (
+        <div className="mt-3.5 flex flex-wrap items-center gap-2 text-ink-4">
+          {peakDow != null && (
+            <Chip dot="var(--neg)">
+              {t.chips.peak}{" "}
+              <span className="num text-neg">
+                {t.chips.dayAmount(t.days[peakDow].toLowerCase(), euro0(stats[peakDow].avgAmount))}
               </span>
-            </div>
-          ))}
+            </Chip>
+          )}
+          {troughDow != null && troughDow !== peakDow && (
+            <Chip dot="var(--accent-strong)">
+              {t.chips.trough}{" "}
+              <span className="num text-accent-strong">
+                {t.chips.dayAmount(t.days[troughDow].toLowerCase(), euro0(stats[troughDow].avgAmount))}
+              </span>
+            </Chip>
+          )}
+          {weekendDeltaPct != null && (
+            <Chip dot="var(--ink-4)">
+              {t.chips.weekend}{" "}
+              <span className="num text-accent-strong">
+                {weekendDeltaPct >= 0 ? "+" : "−"}
+                {t.deltaPct(String(Math.abs(Math.round(weekendDeltaPct))))}
+              </span>{" "}
+              {t.chips.weekendVsWeek}
+            </Chip>
+          )}
         </div>
+      )}
 
-        {/* Continuous threshold guides: the budget and 2×budget markers are the
-            same for the seven days, so they run top-to-bottom over the whole plot
-            (across the gaps too) as one reference axis, not per-bar dashes. */}
-        {dayBudget != null && (
-          <div
-            className="pointer-events-none absolute inset-y-0"
-            style={{ left: DAY_COL_PX + COL_GAP_PX, right: AMOUNT_COL_PX + COL_GAP_PX }}
-            aria-hidden
+      {/* moyenne reference-line label, positioned over the bar column at its fraction. */}
+      <div className={`${ROW_GRID} mt-4`}>
+        <span aria-hidden />
+        <div className="relative h-4">
+          <span
+            className="num absolute top-0 -translate-x-1/2 whitespace-nowrap text-2xs text-accent-strong"
+            style={{ left: `${avgFrac * 100}%` }}
           >
-            <ThresholdGuide frac={scaleFrac(dayBudget, scaleMax)} />
-            <ThresholdGuide frac={scaleFrac(dayBudget * OVERSPEND_DANGER_RATIO, scaleMax)} />
-          </div>
-        )}
+            {t.averageLine(euro0(overall.avgAmount))}
+          </span>
+        </div>
+        <span aria-hidden />
       </div>
 
-      {/* Threshold values, labelled once beneath the bar column. */}
-      {dayBudget != null && (
-        <div className={`${ROW_GRID} mt-1.5`}>
+      <div className="relative mt-1">
+        {/* One delegated hover handler on the plot resolves the row by its
+            data-dow attribute (like the heatmap), so the tooltip follows the
+            cursor across the rows without making each row separately interactive. */}
+        <div
+          className="flex flex-col gap-2"
+          role="img"
+          aria-label={t.title}
+          onMouseMove={(e) => {
+            const row = (e.target as HTMLElement).closest<HTMLElement>("[data-dow]");
+            if (row?.dataset.dow) {
+              rowTip.show(e.clientX, e.clientY, Number(row.dataset.dow));
+            }
+          }}
+          onMouseLeave={rowTip.clear}
+        >
+          {stats.map((s, dow) => {
+            // Cached even when the toggle is off, so the compare marks can animate
+            // out (gated on `renderCompare` at the render site, not here).
+            const cs = compareStats?.[dow] ?? null;
+            const level = overspendLevel(s.avgAmount, dayBudget);
+            const compareDelta = cs ? deltaPct(s.avgAmount, cs.avgAmount) : null;
+            const marker =
+              dow === peakDow ? (
+                <span className="text-neg">▲</span>
+              ) : dow === troughDow ? (
+                <span className="text-accent-strong">▼</span>
+              ) : null;
+            return (
+              <div
+                key={t.days[dow]}
+                data-dow={dow}
+                className={`${ROW_GRID} text-sm`}
+              >
+                <span className="flex items-center gap-1.5 text-ink-2">
+                  <span className="inline-flex w-2 justify-center text-2xs leading-none">{marker}</span>
+                  {t.days[dow]}
+                </span>
+                <div className="flex flex-col justify-center">
+                  <div className="relative">
+                    {dayBudget != null ? (
+                      <WeekdayBulletBar
+                        value={s.avgAmount}
+                        dayBudget={dayBudget}
+                        scaleMax={scaleMax}
+                        height={22}
+                      />
+                    ) : (
+                      <MeterBar
+                        value={scaleFrac(s.avgAmount, scaleMax) * 100}
+                        height={22}
+                        opacity={0.85}
+                      />
+                    )}
+                    {s.max > 0 && (
+                      <Whisker
+                        minFrac={scaleFrac(s.min, scaleMax)}
+                        maxFrac={scaleFrac(s.max, scaleMax)}
+                      />
+                    )}
+                  </div>
+                  {hasCompareData && cs && (
+                    <div
+                      className="pt-1"
+                      style={{ opacity: showCompare ? 1 : 0, transition: `opacity ${COMPARE_ANIM_MS}ms ease-out` }}
+                    >
+                      <CompareBar
+                        frac={scaleFrac(cs.avgAmount, scaleMax)}
+                        expanded={!barsCollapsed}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div className="num text-right">
+                  <div className={`font-medium ${overspendTextClass(level)}`}>{euro(s.avgAmount)} €</div>
+                  <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
+                  {hasCompareData && cs && (
+                    <small
+                      className="mt-0.5 flex items-center justify-end gap-1 whitespace-nowrap text-2xs font-normal text-accent-d"
+                      style={{ opacity: showCompare ? 1 : 0, transition: `opacity ${COMPARE_ANIM_MS}ms ease-out` }}
+                    >
+                      <span
+                        className="inline-block size-2.5 shrink-0 rounded-sm"
+                        style={{ background: COMPARE_FILL }}
+                        aria-hidden
+                      />
+                      {compareYear}{" "}
+                      <AnimatedNumber
+                        value={showCompare ? cs.avgAmount : 0}
+                        decimals={2}
+                        suffix=" €"
+                      />
+                      {compareDelta != null && (
+                        <span className={compareDelta >= 0 ? "text-neg" : "text-accent-strong"}>
+                          {compareDelta >= 0 ? "↑" : "↓"}{" "}
+                          <AnimatedNumber
+                            value={showCompare ? Math.abs(compareDelta) : 0}
+                            decimals={0}
+                            suffix=" %"
+                          />
+                        </span>
+                      )}
+                    </small>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Full-height reference lines over the bar column: the optional colour-zone
+            guides at the budget thresholds, plus the moyenne line. */}
+        <div
+          className="pointer-events-none absolute inset-y-0"
+          style={{ left: DAY_COL_PX + COL_GAP_PX, right: AMOUNT_COL_PX + COL_GAP_PX }}
+          aria-hidden
+        >
+          {dayBudget != null && dangerBudget != null && (
+            <>
+              <ThresholdGuide frac={scaleFrac(dayBudget, scaleMax)} />
+              <ThresholdGuide frac={scaleFrac(dangerBudget, scaleMax)} />
+            </>
+          )}
+          <span
+            className="absolute inset-y-0"
+            style={{
+              left: `${avgFrac * 100}%`,
+              marginLeft: -1,
+              borderLeft: "2px dashed var(--accent-strong)",
+              opacity: 0.7,
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Budget thresholds as small ticks beneath the bar column (36 € / 71 €). */}
+      {dayBudget != null && dangerBudget != null && (
+        <div className={`${ROW_GRID} mt-2`}>
           <span aria-hidden />
-          <div className="relative h-3.5">
-            <ThresholdLabel
-              frac={scaleFrac(dayBudget, scaleMax)}
-              amount={dayBudget}
-            />
-            <ThresholdLabel
-              frac={scaleFrac(dayBudget * OVERSPEND_DANGER_RATIO, scaleMax)}
-              amount={dayBudget * OVERSPEND_DANGER_RATIO}
-            />
+          <div className="relative h-5">
+            {[dayBudget, dangerBudget].map((amount) => (
+              <div
+                key={amount}
+                className="absolute top-0 flex -translate-x-1/2 flex-col items-center"
+                style={{ left: `${scaleFrac(amount, scaleMax) * 100}%` }}
+              >
+                <span className="h-1.5 w-px bg-ink-4" />
+                <span className="num mt-1 whitespace-nowrap text-2xs text-ink-4">{euro0(amount)} €</span>
+              </div>
+            ))}
           </div>
           <span aria-hidden />
         </div>
       )}
+
+      {/* Legend. */}
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-line pt-3 text-2xs text-ink-4">
+        {dayBudget != null && dangerBudget != null && (
+          <>
+            <LegendItem
+              swatch={
+                <span
+                  className="h-2 w-4 rounded-xs"
+                  style={{ background: BAND_FILL.under }}
+                />
+              }
+            >
+              {t.legend.under(euro0(dayBudget))}
+            </LegendItem>
+            <LegendItem
+              swatch={
+                <span
+                  className="h-2 w-4 rounded-xs"
+                  style={{ background: BAND_FILL.between }}
+                />
+              }
+            >
+              {t.legend.between(euro0(dayBudget), euro0(dangerBudget))}
+            </LegendItem>
+            <LegendItem
+              swatch={
+                <span
+                  className="h-2 w-4 rounded-xs"
+                  style={{ background: BAND_FILL.over }}
+                />
+              }
+            >
+              {t.legend.over(euro0(dangerBudget))}
+            </LegendItem>
+          </>
+        )}
+        <LegendItem
+          swatch={
+            <span className="relative inline-block h-2.5 w-4">
+              <span className="absolute top-1/2 h-px w-full -translate-y-1/2 bg-ink-2/60" />
+              <span className="absolute inset-y-0 left-0 w-px bg-ink-2" />
+              <span className="absolute inset-y-0 right-0 w-px bg-ink-2" />
+            </span>
+          }
+        >
+          {t.legend.range}
+        </LegendItem>
+        <LegendItem swatch={<span className="inline-block h-0 w-4 border-t-2 border-dashed border-accent-strong/80" />}>
+          {t.legend.average}
+        </LegendItem>
+        {hasCompareData && (
+          <span
+            className="inline-flex"
+            style={{ opacity: showCompare ? 1 : 0, transition: `opacity ${COMPARE_ANIM_MS}ms ease-out` }}
+          >
+            <LegendItem
+              swatch={
+                <span
+                  className="h-2 w-4 rounded-xs"
+                  style={{ background: COMPARE_FILL }}
+                />
+              }
+            >
+              {t.legend.comparedYear(compareYear)}
+            </LegendItem>
+          </span>
+        )}
+      </div>
+
+      <CursorTooltip
+        point={rowTip.hover}
+        maxWidth={270}
+      >
+        {rowTip.hover &&
+          (() => {
+            const dow = rowTip.hover.data;
+            const s = stats[dow];
+            const cs = showCompare && compareStats ? compareStats[dow] : null;
+            const level = overspendLevel(s.avgAmount, dayBudget);
+            const category = weekdayCategories?.[dow];
+            const compareDelta = cs ? deltaPct(s.avgAmount, cs.avgAmount) : null;
+            return (
+              <div className="min-w-45">
+                <div className="flex items-baseline justify-between gap-6 border-b border-line pb-1.5">
+                  <span className="font-medium text-ink">{t.days[dow]}</span>
+                  <span className={`num font-semibold ${overspendTextClass(level)}`}>{euro(s.avgAmount)} €</span>
+                </div>
+                <div className="mt-1.5 flex flex-col gap-0.5">
+                  <TipRow
+                    label={t.tooltip.range}
+                    value={
+                      <span className="num whitespace-nowrap">{t.tooltip.rangeValue(euro0(s.min), euro0(s.max))}</span>
+                    }
+                  />
+                  <TipRow
+                    label={t.tooltip.txPerDay}
+                    value={<span className="num">{pct1(s.avgTx)}</span>}
+                  />
+                  <TipRow
+                    label={t.tooltip.dominantCategory}
+                    value={category?.name ?? t.tooltip.none}
+                  />
+                </div>
+                {cs && (
+                  <div className="mt-2 flex flex-col gap-0.5 border-t border-line pt-2">
+                    <TipRow
+                      label={String(compareYear)}
+                      value={
+                        <span className="num text-accent-d">
+                          {t.tooltip.compareValue(euro(cs.avgAmount), pct1(cs.avgTx))}
+                        </span>
+                      }
+                    />
+                    {compareDelta != null && (
+                      <TipRow
+                        label={t.tooltip.compareDelta}
+                        value={
+                          <span className="num">
+                            <DeltaBadge pct={compareDelta} />
+                          </span>
+                        }
+                      />
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })()}
+      </CursorTooltip>
     </GlowCard>
   );
 };

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -25,6 +25,7 @@ import useDailyStats from "@components/statistics/services/useDailyStats";
 import useMonthlyIncome from "@components/statistics/services/useMonthlyIncome";
 import useRecurringsDrawn from "@components/statistics/services/useRecurringsDrawn";
 import useStatistics from "@components/statistics/services/useStatistics";
+import useWeekdayCategories from "@components/statistics/services/useWeekdayCategories";
 import { useMemo, useState } from "react";
 
 const MAX_CATEGORIES = 3;
@@ -58,6 +59,15 @@ const StatisticsView = () => {
 
   const { statistics, categories } = useStatistics({ years });
   const { dailyStats } = useDailyStats({ year: selectedYear });
+  // Compare-year daily series for the day-of-week widget (COS-127) — only fetched
+  // when "Comparer à" is on.
+  const { dailyStats: compareDailyStats } = useDailyStats({
+    year: compareYear,
+    enabled: compareEnabled,
+    keepPreviousData: true,
+  });
+  // Dominant category per weekday, for that widget's hover tooltip (COS-127).
+  const { weekdayCategories } = useWeekdayCategories({ year: selectedYear });
   const { biggestRegular } = useBiggestRegularExpense({ year: selectedYear });
   const { exceptionals } = useExceptionals({ year: selectedYear });
   const { exceptionals: compareExceptionals } = useExceptionals({
@@ -214,6 +224,12 @@ const StatisticsView = () => {
         year={selectedYear}
         now={now}
         days={dailyStats?.days}
+        // The cached compare series is passed even when the toggle is off so the
+        // widget can animate the compare marks out; the fetch itself stays gated.
+        compareDays={compareDailyStats?.days}
+        compareYear={compareYear}
+        compareEnabled={compareEnabled}
+        weekdayCategories={weekdayCategories?.weekdays}
         weeklyCeiling={dashboard.get.data?.initialCeiling ?? null}
       />
     </div>

--- a/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
@@ -1,5 +1,6 @@
-import { weekdayAverages } from "@components/statistics/helpers/weekdayStats";
+import { overallDailyAverage, weekdayAverages, weekdayInsights } from "@components/statistics/helpers/weekdayStats";
 
+import type { WeekdayStat } from "@components/statistics/helpers/weekdayStats";
 import type { DailyStat } from "@src/schemas/stats";
 
 const day = (date: string, total: number, count: number): DailyStat => ({ date, total, count });
@@ -17,20 +18,83 @@ describe("weekdayAverages", () => {
 
   it("averages amount and tx per weekday over the weekday's real occurrences", () => {
     const result = weekdayAverages(days, 2023, now);
-    expect(result[0]).toEqual({ avgAmount: 100, avgTx: 2 }); // Monday: 100 over 1 occurrence
-    expect(result[6]).toEqual({ avgAmount: 20, avgTx: 1 }); // Sunday: (10+30)/2, (1+1)/2
-    expect(result[1]).toEqual({ avgAmount: 0, avgTx: 0 }); // Tuesday: no spending
+    expect(result[0]).toEqual({ avgAmount: 100, avgTx: 2, min: 100, max: 100 }); // Monday: 100 over 1 occurrence
+    expect(result[6]).toEqual({ avgAmount: 20, avgTx: 1, min: 10, max: 30 }); // Sunday: (10+30)/2, (1+1)/2, range 10–30
+    expect(result[1]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0 }); // Tuesday: no spending
+  });
+
+  it("ranges min/max over that weekday's spending days only (not zero-spend occurrences)", () => {
+    // Sunday has two spending days (10 and 30) among more Sunday occurrences; the
+    // whisker spans the actual spend, not a 0 floor.
+    const result = weekdayAverages(days, 2023, now);
+    expect(result[6].min).toBe(10);
+    expect(result[6].max).toBe(30);
   });
 
   it("excludes future-dated spendings from the averages", () => {
     const result = weekdayAverages(days, 2023, now);
     // 2023-06-01 (Thursday, index 3) is in the future → must not inflate Thursday.
-    expect(result[3]).toEqual({ avgAmount: 0, avgTx: 0 });
+    expect(result[3]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0 });
   });
 
   it("returns zeros for every weekday when there is no spending", () => {
     const result = weekdayAverages([], 2023, new Date(2023, 5, 1));
     expect(result).toHaveLength(7);
     expect(result.every((s) => s.avgAmount === 0 && s.avgTx === 0)).toBe(true);
+  });
+});
+
+describe("overallDailyAverage", () => {
+  const now = new Date(2023, 0, 8); // Jan 1–8 realized → 8 elapsed days
+  const days = [
+    day("2023-01-02", 100, 2),
+    day("2023-01-01", 10, 1),
+    day("2023-01-08", 30, 1),
+    day("2023-06-01", 999, 9), // future (excluded)
+  ];
+
+  it("divides realized spend and tx by the elapsed-day count", () => {
+    // (100+10+30)=140 € over 8 realized days; (2+1+1)=4 tx over 8 days.
+    expect(overallDailyAverage(days, 2023, now)).toEqual({ avgAmount: 140 / 8, avgTx: 4 / 8 });
+  });
+
+  it("excludes future-dated spendings", () => {
+    const withoutFuture = days.filter((d) => d.date !== "2023-06-01");
+    expect(overallDailyAverage(days, 2023, now)).toEqual(overallDailyAverage(withoutFuture, 2023, now));
+  });
+
+  it("returns zeros when there is no realized spending", () => {
+    expect(overallDailyAverage([], 2023, new Date(2023, 5, 1))).toEqual({ avgAmount: 0, avgTx: 0 });
+  });
+
+  it("weights a completed past year over its full 365 days", () => {
+    // 2022 is fully realized and not a leap year: one 50 €/3-tx day ÷ 365 days.
+    const oneDay = [day("2022-03-15", 50, 3)];
+    expect(overallDailyAverage(oneDay, 2022, now)).toEqual({ avgAmount: 50 / 365, avgTx: 3 / 365 });
+  });
+});
+
+describe("weekdayInsights", () => {
+  const s = (avgAmount: number): WeekdayStat => ({ avgAmount, avgTx: 0, min: 0, max: 0 });
+
+  it("flags the priciest and cheapest weekdays and the weekend delta", () => {
+    // Mon40 Tue40 Wed80 Thu20 Fri40 Sat60 Sun60
+    const stats = [40, 40, 80, 20, 40, 60, 60].map(s);
+    const { peakDow, troughDow, weekendDeltaPct } = weekdayInsights(stats);
+    expect(peakDow).toBe(2); // Wednesday
+    expect(troughDow).toBe(3); // Thursday
+    // weekday mean = (40+40+80+20+40)/5 = 44; weekend mean = (60+60)/2 = 60.
+    expect(weekendDeltaPct).toBeCloseTo((60 / 44 - 1) * 100, 5);
+  });
+
+  it("ignores zero-spend weekdays when picking the trough", () => {
+    // Tuesday has no spending (0) — it must not be flagged as the creux.
+    const stats = [40, 0, 80, 30, 40, 60, 60].map(s);
+    expect(weekdayInsights(stats).troughDow).toBe(3); // Thursday (30), not Tuesday (0)
+  });
+
+  it("returns nulls when no weekday has spending", () => {
+    const stats = Array.from({ length: 7 }, () => s(0));
+    expect(weekdayInsights(stats)).toEqual({ peakDow: null, troughDow: null, weekendDeltaPct: null });
   });
 });

--- a/front/src/components/statistics/helpers/weekdayStats.ts
+++ b/front/src/components/statistics/helpers/weekdayStats.ts
@@ -4,11 +4,19 @@ import parseISO from "date-fns/parseISO";
 
 import type { DailyStat } from "@src/schemas/stats";
 
-export interface WeekdayStat {
-  /** Average spend on that weekday over the year (0 when the weekday never occurred). */
+/** Daily averages shared by the per-weekday and the overall (header) figures. */
+export interface DailyAverage {
+  /** Average spend per realized day (0 when none). */
   avgAmount: number;
-  /** Average number of transactions on that weekday. */
+  /** Average number of transactions per realized day. */
   avgTx: number;
+}
+
+export interface WeekdayStat extends DailyAverage {
+  /** Lowest single-day total among that weekday's spending days (0 when none). */
+  min: number;
+  /** Highest single-day total among that weekday's spending days (0 when none). */
+  max: number;
 }
 
 /** Monday-based day of week: 0 = Monday … 6 = Sunday (date-fns getDay is 0=Sunday). */
@@ -21,17 +29,31 @@ const isoOf = (date: Date): string => {
   return `${date.getFullYear()}-${month}-${day}`;
 };
 
+const mean = (values: number[]): number => (values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 0);
+
 /**
- * Average spend + transaction count per weekday (Mon..Sun) over the realized part
- * of `year`, from the shared /daily-stats series (COS-45, COS-48). Zero-spend
- * days count toward the average: the sparse `days` only carries spending days, so
- * the denominator is each weekday's real occurrence count (not `days.length`).
- * Future-dated spendings (current year) are excluded, matching the heatmap.
+ * Elapsed (non-future) window of a year: how many days are realized and the ISO
+ * date of the last one. The current year stops at `now`; past years span the full
+ * year. Shared by the weekday and overall averages so both use one definition of
+ * "realized" and exclude the same future-dated spendings.
  */
-export function weekdayAverages(days: DailyStat[], year: number, now: Date): WeekdayStat[] {
+function realizedWindow(year: number, now: Date): { realizedDays: number; lastRealizedIso: string } {
   const isCurrentYear = year === now.getFullYear();
   const realizedDays = isCurrentYear ? getDayOfYear(now) : getDayOfYear(new Date(year, 11, 31));
-  const lastRealizedIso = isoOf(new Date(year, 0, realizedDays));
+  return { realizedDays, lastRealizedIso: isoOf(new Date(year, 0, realizedDays)) };
+}
+
+/**
+ * Average spend + transaction count per weekday (Mon..Sun) over the realized part
+ * of `year`, plus each weekday's min/max single-day total, from the shared
+ * /daily-stats series (COS-45, COS-48, COS-127). Zero-spend days count toward the
+ * average: the sparse `days` only carries spending days, so the denominator is
+ * each weekday's real occurrence count (not `days.length`). The min/max range,
+ * however, spans only the days that actually had spending (the "fourchette"
+ * whisker). Future-dated spendings (current year) are excluded, matching the heatmap.
+ */
+export function weekdayAverages(days: DailyStat[], year: number, now: Date): WeekdayStat[] {
+  const { realizedDays, lastRealizedIso } = realizedWindow(year, now);
 
   const occurrences = new Array<number>(7).fill(0);
   for (let doy = 1; doy <= realizedDays; doy++) {
@@ -40,6 +62,8 @@ export function weekdayAverages(days: DailyStat[], year: number, now: Date): Wee
 
   const sumAmount = new Array<number>(7).fill(0);
   const sumTx = new Array<number>(7).fill(0);
+  const minAmount = new Array<number>(7).fill(Number.POSITIVE_INFINITY);
+  const maxAmount = new Array<number>(7).fill(0);
   for (const day of days) {
     if (day.date.slice(0, 10) > lastRealizedIso) {
       continue; // future-dated spending
@@ -47,10 +71,84 @@ export function weekdayAverages(days: DailyStat[], year: number, now: Date): Wee
     const w = mondayDow(parseISO(day.date));
     sumAmount[w] += day.total;
     sumTx[w] += day.count;
+    if (day.total < minAmount[w]) {
+      minAmount[w] = day.total;
+    }
+    if (day.total > maxAmount[w]) {
+      maxAmount[w] = day.total;
+    }
   }
 
   return occurrences.map((occ, w) => ({
     avgAmount: occ > 0 ? sumAmount[w] / occ : 0,
     avgTx: occ > 0 ? sumTx[w] / occ : 0,
+    min: Number.isFinite(minAmount[w]) ? minAmount[w] : 0,
+    max: maxAmount[w],
   }));
+}
+
+/**
+ * Overall daily averages over the realized part of the year — total spend and
+ * transaction count ÷ elapsed days. Properly weighted (≈ the mean of the seven
+ * weekday means), it backs the widget's header subtitle (COS-127).
+ */
+export function overallDailyAverage(days: DailyStat[], year: number, now: Date): DailyAverage {
+  const { realizedDays, lastRealizedIso } = realizedWindow(year, now);
+  if (realizedDays <= 0) {
+    return { avgAmount: 0, avgTx: 0 };
+  }
+
+  let sumAmount = 0;
+  let sumTx = 0;
+  for (const day of days) {
+    if (day.date.slice(0, 10) > lastRealizedIso) {
+      continue; // future-dated spending
+    }
+    sumAmount += day.total;
+    sumTx += day.count;
+  }
+
+  return { avgAmount: sumAmount / realizedDays, avgTx: sumTx / realizedDays };
+}
+
+export interface WeekdayInsights {
+  /** Weekday (0 = Mon) with the highest average spend — the "pic"; null when no weekday has spending. */
+  peakDow: number | null;
+  /** Weekday with the lowest positive average spend — the "creux"; null when no weekday has spending. */
+  troughDow: number | null;
+  /** Weekend (Sat+Sun) vs weekday (Mon–Fri) daily-average, as a signed %; null when weekdays have no spending. */
+  weekendDeltaPct: number | null;
+}
+
+/**
+ * Header-chip insights derived from the weekday averages (COS-127): the priciest
+ * and cheapest weekdays and how weekend days compare to the working week. Only
+ * weekdays that actually had spending are ranked, so an all-zero weekday is never
+ * flagged as the "creux". All from the same real averages, no extra source.
+ */
+export function weekdayInsights(stats: WeekdayStat[]): WeekdayInsights {
+  let peakDow: number | null = null;
+  let troughDow: number | null = null;
+  let peakAmount = Number.NEGATIVE_INFINITY;
+  let troughAmount = Number.POSITIVE_INFINITY;
+  for (let w = 0; w < 7; w++) {
+    const amount = stats[w].avgAmount;
+    if (amount <= 0) {
+      continue; // rank only weekdays with spending
+    }
+    if (amount > peakAmount) {
+      peakAmount = amount;
+      peakDow = w;
+    }
+    if (amount < troughAmount) {
+      troughAmount = amount;
+      troughDow = w;
+    }
+  }
+
+  const weekdayMean = mean([0, 1, 2, 3, 4].map((w) => stats[w].avgAmount));
+  const weekendMean = mean([5, 6].map((w) => stats[w].avgAmount));
+  const weekendDeltaPct = weekdayMean > 0 ? (weekendMean / weekdayMean - 1) * 100 : null;
+
+  return { peakDow, troughDow, weekendDeltaPct };
 }

--- a/front/src/components/statistics/services/useDailyStats.tsx
+++ b/front/src/components/statistics/services/useDailyStats.tsx
@@ -7,6 +7,11 @@ import type { DailyStatsResponse } from "@src/schemas/stats";
 
 interface UseDailyStatsOptions {
   year: number;
+  /** Gate the request — skips the compare-year fetch when comparison is off (COS-127). */
+  enabled?: boolean;
+  /** Keep the previous year's data while a new year loads, so a year switch doesn't
+   *  flash undefined — used by the day-of-week compare series for a smooth swap. */
+  keepPreviousData?: boolean;
 }
 
 /**
@@ -14,7 +19,7 @@ interface UseDailyStatsOptions {
  * cached like the other stats queries. Feeds the daily heatmap and, later, the
  * day-of-week averages (COS-48) — both read the same daily series.
  */
-const useDailyStats = ({ year }: UseDailyStatsOptions) => {
+const useDailyStats = ({ year, enabled = true, keepPreviousData = false }: UseDailyStatsOptions) => {
   const { privateRequest } = useRequestHelper();
 
   const getDailyStats = async (): Promise<DailyStatsResponse> => {
@@ -24,6 +29,8 @@ const useDailyStats = ({ year }: UseDailyStatsOptions) => {
 
   const { data, isLoading, error } = useQuery([QUERY_KEYS.DAILY_STATS, year], getDailyStats, {
     retry: false,
+    enabled,
+    keepPreviousData,
     ...QUERY_OPTIONS,
   });
 

--- a/front/src/components/statistics/services/useWeekdayCategories.tsx
+++ b/front/src/components/statistics/services/useWeekdayCategories.tsx
@@ -1,0 +1,33 @@
+import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import useRequestHelper from "@src/helpers/useRequestHelper";
+import { WeekdayCategoriesResponseSchema } from "@src/schemas/stats";
+import { useQuery } from "react-query";
+
+import type { WeekdayCategoriesResponse } from "@src/schemas/stats";
+
+interface UseWeekdayCategoriesOptions {
+  year: number;
+}
+
+/**
+ * Dominant spending category per weekday for the given year (COS-127). One
+ * request per year, cached like the other stats queries. Feeds the day-of-week
+ * widget's hover tooltip — the one field that isn't derivable from /daily-stats.
+ */
+const useWeekdayCategories = ({ year }: UseWeekdayCategoriesOptions) => {
+  const { privateRequest } = useRequestHelper();
+
+  const getWeekdayCategories = async (): Promise<WeekdayCategoriesResponse> => {
+    const response = await privateRequest(`/weekday-categories?year=${year}`);
+    return WeekdayCategoriesResponseSchema.parse(response.data);
+  };
+
+  const { data, isLoading, error } = useQuery([QUERY_KEYS.WEEKDAY_CATEGORIES, year], getWeekdayCategories, {
+    retry: false,
+    ...QUERY_OPTIONS,
+  });
+
+  return { weekdayCategories: data, isLoading, error };
+};
+
+export default useWeekdayCategories;

--- a/front/src/lib/dataviz/CursorTooltip.tsx
+++ b/front/src/lib/dataviz/CursorTooltip.tsx
@@ -30,6 +30,8 @@ interface CursorTooltipProps {
   /** Border colour — defaults to the hairline token. Pass a light tint of the
    *  background for coloured tooltips so the edge stays coherent and visible. */
   borderColor?: string;
+  /** Max width in px (default 240) — widen for tooltips with longer rows. */
+  maxWidth?: number;
 }
 
 interface Snapshot {
@@ -47,7 +49,7 @@ interface Snapshot {
  * shown content, so consumers can render it unconditionally and pass
  * `point={hover}` (null to hide) with the body guarded by the same hover.
  */
-const CursorTooltip = ({ point, children, background, color, borderColor }: CursorTooltipProps) => {
+const CursorTooltip = ({ point, children, background, color, borderColor, maxWidth }: CursorTooltipProps) => {
   const [snapshot, setSnapshot] = useState<Snapshot | null>(null);
   const [visible, setVisible] = useState(false);
   const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
@@ -101,7 +103,7 @@ const CursorTooltip = ({ point, children, background, color, borderColor }: Curs
         top: pos ? pos.top : snapshot.point.y + 16,
         opacity: visible ? 1 : 0,
         transition: `opacity ${TOOLTIP_FADE_MS}ms ease-out`,
-        maxWidth: 240,
+        maxWidth: maxWidth ?? 240,
         padding: "8px 10px",
         fontSize: "12px",
         lineHeight: 1.35,

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -66,6 +66,23 @@ export const DailyStatsResponseSchema = z.object({
 
 export type DailyStatsResponse = z.infer<typeof DailyStatsResponseSchema>;
 
+// Dominant spending category per weekday for a year (COS-127) — GET
+// /weekday-categories. `weekdays` is length 7, index 0 = Monday … 6 = Sunday;
+// each entry's name/color is null when that weekday has no categorized spending.
+// Backs the day-of-week widget's hover tooltip.
+export const WeekdayCategorySchema = z.object({
+  name: z.string().nullable(),
+  color: z.string().nullable(),
+});
+
+export type WeekdayCategory = z.infer<typeof WeekdayCategorySchema>;
+
+export const WeekdayCategoriesResponseSchema = z.object({
+  weekdays: z.array(WeekdayCategorySchema),
+});
+
+export type WeekdayCategoriesResponse = z.infer<typeof WeekdayCategoriesResponseSchema>;
+
 // Biggest single one-off (non-exceptional) expense of a year (COS-46) — GET
 // /biggest-regular-expense. `expense` is null when the user has no spending that
 // year. Backs the "courante" row of the "Plus grosse dépense" KPI card.

--- a/front/src/text/statistics.ts
+++ b/front/src/text/statistics.ts
@@ -78,8 +78,40 @@ const statistics = {
   dayOfWeek: {
     title: "Dépenses par jour de la semaine (moyenne sur l'année)",
     meta: (year: number) => `${year}`,
+    // Header subtitle tail after the bold year — the year's overall daily rhythm (COS-127).
+    subtitle: (avgTx: string, avgAmount: string) => `· ${avgTx} transactions/j · ${avgAmount} €/j en moyenne`,
     days: ["Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche"],
     transactionsPerDay: (value: string) => `${value} transactions/j`,
+    // Full-height reference line at the year's average daily spend.
+    averageLine: (amount: string) => `moy. ${amount} €`,
+    // Header insight chips (COS-127) — priciest/cheapest weekday, weekend vs week.
+    chips: {
+      peak: "Pic",
+      trough: "Creux",
+      dayAmount: (day: string, amount: string) => `${day} · ${amount} €`,
+      weekend: "Week-end",
+      weekendVsWeek: "vs semaine",
+    },
+    // Signed delta % suffix (e.g. the tooltip's Écart badge).
+    deltaPct: (pct: string) => `${pct} %`,
+    tooltip: {
+      range: "Fourchette (semaines)",
+      rangeValue: (min: string, max: string) => `${min} € - ${max} €`,
+      txPerDay: "Transactions / jour",
+      dominantCategory: "Catégorie dominante",
+      none: "—",
+      // Compared-year row in the tooltip: average amount + average tx/day.
+      compareValue: (amount: string, avgTx: string) => `${amount} € · ${avgTx}/j`,
+      compareDelta: "Écart",
+    },
+    legend: {
+      under: (budget: string) => `≤ ${budget} €`,
+      between: (budget: string, danger: string) => `${budget} – ${danger} €`,
+      over: (danger: string) => `> ${danger} €`,
+      range: "min – max sur l'année",
+      average: "moyenne",
+      comparedYear: (year: number) => `année comparée (${year})`,
+    },
   },
   fixedExpenses: {
     title: "Dépenses fixes",

--- a/nest-api/src/stats/dto/weekday-categories-query.dto.ts
+++ b/nest-api/src/stats/dto/weekday-categories-query.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class WeekdayCategoriesQueryDto {
+  @IsString()
+  @IsNotEmpty()
+  year: string;
+}

--- a/nest-api/src/stats/dto/weekday-categories-response.interface.ts
+++ b/nest-api/src/stats/dto/weekday-categories-response.interface.ts
@@ -1,0 +1,20 @@
+/**
+ * Dominant spending category per weekday for a year (GET /weekday-categories?year=YYYY).
+ *
+ * For each weekday (Monday..Sunday), the category with the highest total one-off
+ * spend on that weekday across the year. Reads the `Spendings` table only —
+ * recurrings and exceptionals live in their own tables — so it shares the "hors
+ * récurrent / hors exceptionnel" scope of the daily stats (COS-45). Backs the
+ * hover tooltip of the day-of-week widget (COS-127).
+ */
+export interface WeekdayCategory {
+  /** Category name, or null when that weekday has no categorized spending. */
+  name: string | null;
+  /** Category colour, or null. */
+  color: string | null;
+}
+
+export interface WeekdayCategoriesResponse {
+  /** Length 7, index 0 = Monday … 6 = Sunday. */
+  weekdays: WeekdayCategory[];
+}

--- a/nest-api/src/stats/stats.controller.ts
+++ b/nest-api/src/stats/stats.controller.ts
@@ -10,6 +10,7 @@ import { BiggestRegularExpenseQueryDto } from "@stats/dto/biggest-regular-expens
 import { CategoryTrendsQueryDto } from "@stats/dto/category-trends-query.dto";
 import { BusiestWeekQueryDto } from "@stats/dto/busiest-week-query.dto";
 import { SpendingPaceQueryDto } from "@stats/dto/spending-pace-query.dto";
+import { WeekdayCategoriesQueryDto } from "@stats/dto/weekday-categories-query.dto";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { GetUserId } from "@spendings/decorators/get-user.decorator";
 
@@ -128,5 +129,16 @@ export class BiggestRegularExpenseController {
   @Get()
   async getBiggestRegularExpense(@Query() query: BiggestRegularExpenseQueryDto, @GetUserId() userID: string) {
     return this.statsService.getBiggestRegularExpense(query.year, userID);
+  }
+}
+
+@Controller("weekday-categories")
+@UseGuards(SessionAuthGuard)
+export class WeekdayCategoriesController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get()
+  async getWeekdayCategories(@Query() query: WeekdayCategoriesQueryDto, @GetUserId() userID: string) {
+    return this.statsService.getWeekdayCategories(query.year, userID);
   }
 }

--- a/nest-api/src/stats/stats.module.ts
+++ b/nest-api/src/stats/stats.module.ts
@@ -11,6 +11,7 @@ import {
   SpendingPaceController,
   DailyStatsController,
   BiggestRegularExpenseController,
+  WeekdayCategoriesController,
 } from "@stats/stats.controller";
 import { PrismaModule } from "../prisma/prisma.module";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
@@ -28,6 +29,7 @@ import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
     SpendingPaceController,
     DailyStatsController,
     BiggestRegularExpenseController,
+    WeekdayCategoriesController,
   ],
   providers: [StatsService, SessionAuthGuard],
 })

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -590,3 +590,98 @@ describe("StatsService.getSpendingPace", () => {
     });
   });
 });
+
+/**
+ * Unit tests for StatsService.getWeekdayCategories — the dominant spending
+ * category per weekday for a year, backing the day-of-week widget's hover tooltip
+ * (COS-127). Prisma is mocked; these assert the query shape (categorized
+ * Spendings over a half-open UTC year range) and the JS weekday×category
+ * bucketing / winner selection.
+ */
+describe("StatsService.getWeekdayCategories", () => {
+  const emptyWeekdays = () => Array.from({ length: 7 }, () => ({ name: null, color: null }));
+
+  const makeService = (spendingRows: unknown[], categories: unknown[] = []) => {
+    const spendingsFindMany = jest.fn().mockResolvedValue(spendingRows);
+    const categoriesFindMany = jest.fn().mockResolvedValue(categories);
+    const prisma = {
+      spendings: { findMany: spendingsFindMany },
+      categories: { findMany: categoriesFindMany },
+    } as unknown as never;
+    return { service: new StatsService(prisma), spendingsFindMany, categoriesFindMany };
+  };
+
+  it("returns seven null weekdays and skips the query for a non-numeric year", async () => {
+    const { service, spendingsFindMany } = makeService([]);
+
+    await expect(service.getWeekdayCategories("nope", "user-1")).resolves.toEqual({ weekdays: emptyWeekdays() });
+    expect(spendingsFindMany).not.toHaveBeenCalled();
+  });
+
+  it("queries the year's categorized spendings as a half-open UTC range, scoped to the user", async () => {
+    const { service, spendingsFindMany } = makeService([]);
+
+    await service.getWeekdayCategories("2023", "user-1");
+
+    expect(spendingsFindMany).toHaveBeenCalledWith({
+      where: {
+        userID: "user-1",
+        date: { gte: new Date(Date.UTC(2023, 0, 1)), lt: new Date(Date.UTC(2024, 0, 1)) },
+        categoryID: { not: null },
+      },
+      select: { date: true, amount: true, categoryID: true },
+    });
+  });
+
+  it("picks the highest-total category per weekday (index 0 = Monday) and resolves its name/colour", async () => {
+    // Jan 1 2023 is a Sunday, so Jan 2/9/16 are Mondays.
+    const { service, categoriesFindMany } = makeService(
+      [
+        { date: new Date("2023-01-02T00:00:00.000Z"), amount: 70, categoryID: "cat-a" }, // Mon
+        { date: new Date("2023-01-09T00:00:00.000Z"), amount: 40, categoryID: "cat-a" }, // Mon → cat-a = 110
+        { date: new Date("2023-01-16T00:00:00.000Z"), amount: 90, categoryID: "cat-b" }, // Mon → cat-b = 90
+        { date: new Date("2023-01-01T00:00:00.000Z"), amount: 50, categoryID: "cat-b" }, // Sun
+      ],
+      [
+        { ID: "cat-a", name: "Alimentation", color: "#22c55e" },
+        { ID: "cat-b", name: "Transports", color: "#0ea5e9" },
+      ],
+    );
+
+    const { weekdays } = await service.getWeekdayCategories("2023", "user-1");
+
+    expect(weekdays[0]).toEqual({ name: "Alimentation", color: "#22c55e" }); // Monday: cat-a (110) beats cat-b (90)
+    expect(weekdays[6]).toEqual({ name: "Transports", color: "#0ea5e9" }); // Sunday: cat-b
+    expect(weekdays[1]).toEqual({ name: null, color: null }); // Tuesday: no spending
+    expect(categoriesFindMany).toHaveBeenCalledWith({
+      where: { ID: { in: ["cat-a", "cat-b"] }, OR: [{ userID: "user-1" }, { userID: null }] },
+      select: { ID: true, name: true, color: true },
+    });
+  });
+
+  it("skips the category lookup and returns all-null weekdays with no categorized spending", async () => {
+    const { service, categoriesFindMany } = makeService([]);
+
+    await expect(service.getWeekdayCategories("2023", "user-1")).resolves.toEqual({ weekdays: emptyWeekdays() });
+    expect(categoriesFindMany).not.toHaveBeenCalled();
+  });
+
+  it("coerces Prisma Decimal amounts and breaks ties toward the first-seen category", async () => {
+    const decimal = (v: string) => ({ toString: () => v });
+    const { service } = makeService(
+      [
+        { date: new Date("2023-01-02T00:00:00.000Z"), amount: decimal("50"), categoryID: "cat-a" }, // Mon
+        { date: new Date("2023-01-09T00:00:00.000Z"), amount: decimal("50"), categoryID: "cat-b" }, // Mon, ties cat-a
+      ],
+      [
+        { ID: "cat-a", name: "Alimentation", color: "#22c55e" },
+        { ID: "cat-b", name: "Transports", color: "#0ea5e9" },
+      ],
+    );
+
+    const { weekdays } = await service.getWeekdayCategories("2023", "user-1");
+
+    // Ties use strict-greater, so cat-a (seen first) keeps Monday.
+    expect(weekdays[0]).toEqual({ name: "Alimentation", color: "#22c55e" });
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -10,6 +10,7 @@ import type { BiggestRegularExpenseResponse } from "@stats/dto/biggest-regular-e
 import type { CategoryTrendPoint, CategoryTrendsResponse } from "@stats/dto/category-trends-response.interface";
 import type { BusiestWeekResponse } from "@stats/dto/busiest-week-response.interface";
 import type { SpendingPaceResponse } from "@stats/dto/spending-pace-response.interface";
+import type { WeekdayCategoriesResponse, WeekdayCategory } from "@stats/dto/weekday-categories-response.interface";
 
 /** Rounds to 2 decimal places to avoid JS float precision issues. */
 const roundCurrency = (n: number): number => Math.round(n);
@@ -343,6 +344,73 @@ export class StatsService {
       .sort((a, b) => a.date.localeCompare(b.date));
 
     return { days };
+  }
+
+  /**
+   * Dominant spending category per weekday for a year (COS-127): the category
+   * with the highest total one-off spend on each weekday (Mon..Sun). Reads the
+   * `Spendings` table only (recurrings/exceptionals live elsewhere), scoped to the
+   * user, over the same half-open UTC year range as the daily stats. Buckets by
+   * UTC weekday in JS so day keys are timezone-safe, resolves the winner's
+   * name/colour, and ignores uncategorized spend — a weekday with no categorized
+   * spending yields a null category. Backs the day-of-week widget's tooltip.
+   */
+  async getWeekdayCategories(yearStr: string, userID: string): Promise<WeekdayCategoriesResponse> {
+    const emptyWeekdays = (): WeekdayCategory[] => Array.from({ length: 7 }, () => ({ name: null, color: null }));
+    const year = parseInt(yearStr, 10);
+    if (Number.isNaN(year)) {
+      return { weekdays: emptyWeekdays() };
+    }
+
+    const yearStart = new Date(Date.UTC(year, 0, 1));
+    const nextYearStart = new Date(Date.UTC(year + 1, 0, 1));
+
+    const rows = await this.prisma.spendings.findMany({
+      where: { userID, date: { gte: yearStart, lt: nextYearStart }, categoryID: { not: null } },
+      select: { date: true, amount: true, categoryID: true },
+    });
+
+    // Sum spend per (weekday, category). Monday-based weekday (0 = Mon … 6 = Sun)
+    // from the UTC date, matching the daily stats' UTC day keys.
+    const totalsByWeekday: Array<Map<string, number>> = Array.from({ length: 7 }, () => new Map());
+    for (const row of rows) {
+      if (!row.categoryID) {
+        continue;
+      }
+      const dow = (row.date.getUTCDay() + 6) % 7;
+      const totals = totalsByWeekday[dow];
+      totals.set(row.categoryID, (totals.get(row.categoryID) ?? 0) + Number(row.amount));
+    }
+
+    // Winner category id per weekday (highest total; null when the weekday is empty).
+    const winnerIds = totalsByWeekday.map((totals) => {
+      let winnerId: string | null = null;
+      let winnerTotal = 0;
+      for (const [categoryID, total] of totals) {
+        if (total > winnerTotal) {
+          winnerTotal = total;
+          winnerId = categoryID;
+        }
+      }
+      return winnerId;
+    });
+
+    const ids = [...new Set(winnerIds.filter((id): id is string => id !== null))];
+    const categories =
+      ids.length > 0
+        ? await this.prisma.categories.findMany({
+            where: { ID: { in: ids }, OR: [{ userID }, { userID: null }] },
+            select: { ID: true, name: true, color: true },
+          })
+        : [];
+    const categoryMap = new Map(categories.map((c) => [c.ID, c]));
+
+    const weekdays = winnerIds.map((id) => {
+      const category = id ? categoryMap.get(id) : null;
+      return { name: category?.name ?? null, color: category?.color ?? null };
+    });
+
+    return { weekdays };
   }
 
   /**


### PR DESCRIPTION
Enrich the "Dépenses par jour de la semaine" chart:

- Header subtitle: year + avg transactions/day + avg €/day.
- Insight chips: peak/trough weekday and week-end vs week delta.
- Peak/trough markers, per-bar min-max range whiskers and a full-height dashed year-average reference line.
- Amounts coloured by overspend level; two dashed zone guides and bottom budget ticks driven by the weekly ceiling.
- Selectable compare year: hatched bars grow from 0 on show and only fade on hide, with count-up euro/percent deltas.
- Hover tooltip: average, range, tx/day, dominant category and, in compare mode, the compared-year average and écart.

Backend: new /weekday-categories endpoint returning the dominant category per weekday for the tooltip.