### PR TITLE
refactor(spendings): extract FilterCategory type (COS-103)

### DIFF
--- a/front/src/components/spendings/interfaces/spendingCategoryFilterTypes.ts
+++ b/front/src/components/spendings/interfaces/spendingCategoryFilterTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * One selectable category in the Dépenses global filter — built by
+ * SpendingView, rendered by SpendingCategoryFilter.
+ */
+export interface FilterCategory {
+  key: string;
+  name: string;
+  color: string;
+  count: number;
+}

--- a/front/src/components/spendings/view/SpendingCategoryFilter.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryFilter.tsx
@@ -8,12 +8,7 @@ import spendings from "@text/spendings";
 import { ChevronDown } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
-export interface FilterCategory {
-  key: string;
-  name: string;
-  color: string;
-  count: number;
-}
+import type { FilterCategory } from "@components/spendings/interfaces/spendingCategoryFilterTypes";
 
 interface SpendingCategoryFilterProps {
   categories: FilterCategory[];

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -26,9 +26,9 @@ import { Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import type { BreakdownRow } from "@components/spendings/interfaces/spendingCategoryBreakdownTypes";
+import type { FilterCategory } from "@components/spendings/interfaces/spendingCategoryFilterTypes";
 import type { MonthRange } from "@components/spendings/interfaces/spendingDashboardTypes";
 import type { SpendingDayGroup } from "@components/spendings/types";
-import type { FilterCategory } from "@components/spendings/view/SpendingCategoryFilter";
 
 const FALLBACK_COLOR = CATEGORY_FALLBACK;
 const UNCATEGORIZED_KEY = "none";


### PR DESCRIPTION
Move the FilterCategory interface out of SpendingCategoryFilter into a dedicated spendings/interfaces/spendingCategoryFilterTypes.ts, matching the existing spendingCategoryBreakdownTypes.ts pattern. Pure type move, no runtime change.