### PR TITLE
refactor(front): extract exported types (COS-77)

### DIFF
--- a/front/src/app/(public)/about/page.tsx
+++ b/front/src/app/(public)/about/page.tsx
@@ -4,15 +4,15 @@ import AuthBrand from "@components/auth/AuthBrand";
 import AuthCard from "@components/auth/AuthCard";
 import app from "@text/app";
 
-const { about: t } = app;
+const { about } = app;
 
-const LEGAL = [t.legal.host, t.legal.address, t.legal.ape, t.legal.vat];
+const LEGAL = [about.legal.host, about.legal.address, about.legal.ape, about.legal.vat];
 
 export default function About() {
   return (
     <AuthCard>
       <AuthBrand
-        title={t.title}
+        title={about.title}
         subtitle="Personal Finance Assistant"
       />
 

--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -8,12 +8,7 @@ import useElementWidth from "@lib/dataviz/useElementWidth";
 import { euro0 } from "@lib/format";
 import statistics from "@text/statistics";
 
-export interface CategorySeries {
-  name: string;
-  color: string;
-  /** 12-slot Jan→Dec monthly spend for this category. */
-  monthly: number[];
-}
+import type { CategorySeries } from "@components/statistics/interfaces/statisticsCategoryChartTypes";
 
 interface StatisticsCategoryChartProps {
   year: number;

--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState } from "react";
 import type { DailyStat, WeekdayCategory } from "@src/schemas/stats";
 import type { ReactNode } from "react";
 
-const { dayOfWeek: t } = statistics;
+const { dayOfWeek } = statistics;
 
 // Row layout: fixed day-name and amount columns around the elastic bar column.
 const GRID_COLS = "grid grid-cols-[92px_1fr_152px] gap-3";
@@ -76,7 +76,7 @@ const DeltaBadge = ({ pct }: { pct: number }) => {
   const up = pct >= 0;
   return (
     <span className={up ? "text-neg" : "text-accent-strong"}>
-      {up ? "↑" : "↓"} {t.deltaPct(String(Math.abs(Math.round(pct))))}
+      {up ? "↑" : "↓"} {dayOfWeek.deltaPct(String(Math.abs(Math.round(pct))))}
     </span>
   );
 };
@@ -194,8 +194,8 @@ const StatisticsDayOfWeek = ({
         className="px-6 py-5.5"
       >
         <CardSectionHeader
-          title={t.title}
-          meta={t.meta(year)}
+          title={dayOfWeek.title}
+          meta={dayOfWeek.meta(year)}
         />
         <div className="grid place-items-center py-10 text-sm text-ink-4">{common.loading}</div>
       </GlowCard>
@@ -231,11 +231,11 @@ const StatisticsDayOfWeek = ({
       className="px-6 py-5.5"
     >
       <CardSectionHeader
-        title={t.title}
+        title={dayOfWeek.title}
         meta={
           <>
             <span className="font-semibold text-ink">{year}</span>{" "}
-            {t.subtitle(pct1(overall.avgTx), euro(overall.avgAmount))}
+            {dayOfWeek.subtitle(pct1(overall.avgTx), euro(overall.avgAmount))}
           </>
         }
       />
@@ -244,28 +244,28 @@ const StatisticsDayOfWeek = ({
         <div className="mt-3.5 flex flex-wrap items-center gap-2 text-ink-4">
           {peakDow != null && (
             <Chip dot="var(--neg)">
-              {t.chips.peak}{" "}
+              {dayOfWeek.chips.peak}{" "}
               <span className="num text-neg">
-                {t.chips.dayAmount(t.days[peakDow].toLowerCase(), euro0(stats[peakDow].avgAmount))}
+                {dayOfWeek.chips.dayAmount(dayOfWeek.days[peakDow].toLowerCase(), euro0(stats[peakDow].avgAmount))}
               </span>
             </Chip>
           )}
           {troughDow != null && troughDow !== peakDow && (
             <Chip dot="var(--accent-strong)">
-              {t.chips.trough}{" "}
+              {dayOfWeek.chips.trough}{" "}
               <span className="num text-accent-strong">
-                {t.chips.dayAmount(t.days[troughDow].toLowerCase(), euro0(stats[troughDow].avgAmount))}
+                {dayOfWeek.chips.dayAmount(dayOfWeek.days[troughDow].toLowerCase(), euro0(stats[troughDow].avgAmount))}
               </span>
             </Chip>
           )}
           {weekendDeltaPct != null && (
             <Chip dot="var(--ink-4)">
-              {t.chips.weekend}{" "}
+              {dayOfWeek.chips.weekend}{" "}
               <span className="num text-accent-strong">
                 {weekendDeltaPct >= 0 ? "+" : "−"}
-                {t.deltaPct(String(Math.abs(Math.round(weekendDeltaPct))))}
+                {dayOfWeek.deltaPct(String(Math.abs(Math.round(weekendDeltaPct))))}
               </span>{" "}
-              {t.chips.weekendVsWeek}
+              {dayOfWeek.chips.weekendVsWeek}
             </Chip>
           )}
         </div>
@@ -279,7 +279,7 @@ const StatisticsDayOfWeek = ({
             className="num absolute top-0 -translate-x-1/2 whitespace-nowrap text-2xs text-accent-strong"
             style={{ left: `${avgFrac * 100}%` }}
           >
-            {t.averageLine(euro0(overall.avgAmount))}
+            {dayOfWeek.averageLine(euro0(overall.avgAmount))}
           </span>
         </div>
         <span aria-hidden />
@@ -292,7 +292,7 @@ const StatisticsDayOfWeek = ({
         <div
           className="flex flex-col gap-2"
           role="img"
-          aria-label={t.title}
+          aria-label={dayOfWeek.title}
           onMouseMove={(e) => {
             const row = (e.target as HTMLElement).closest<HTMLElement>("[data-dow]");
             if (row?.dataset.dow) {
@@ -315,13 +315,13 @@ const StatisticsDayOfWeek = ({
               ) : null;
             return (
               <div
-                key={t.days[dow]}
+                key={dayOfWeek.days[dow]}
                 data-dow={dow}
                 className={`${ROW_GRID} text-sm`}
               >
                 <span className="flex items-center gap-1.5 text-ink-2">
                   <span className="inline-flex w-2 justify-center text-2xs leading-none">{marker}</span>
-                  {t.days[dow]}
+                  {dayOfWeek.days[dow]}
                 </span>
                 <div className="flex flex-col justify-center">
                   <div className="relative">
@@ -360,7 +360,9 @@ const StatisticsDayOfWeek = ({
                 </div>
                 <div className="num text-right">
                   <div className={`font-medium ${overspendTextClass(level)}`}>{euro(s.avgAmount)} €</div>
-                  <small className="block text-2xs font-normal text-ink-4">{t.transactionsPerDay(pct1(s.avgTx))}</small>
+                  <small className="block text-2xs font-normal text-ink-4">
+                    {dayOfWeek.transactionsPerDay(pct1(s.avgTx))}
+                  </small>
                   {hasCompareData && cs && (
                     <small
                       className="mt-0.5 flex items-center justify-end gap-1 whitespace-nowrap text-2xs font-normal text-accent-d"
@@ -452,7 +454,7 @@ const StatisticsDayOfWeek = ({
                 />
               }
             >
-              {t.legend.under(euro0(dayBudget))}
+              {dayOfWeek.legend.under(euro0(dayBudget))}
             </LegendItem>
             <LegendItem
               swatch={
@@ -462,7 +464,7 @@ const StatisticsDayOfWeek = ({
                 />
               }
             >
-              {t.legend.between(euro0(dayBudget), euro0(dangerBudget))}
+              {dayOfWeek.legend.between(euro0(dayBudget), euro0(dangerBudget))}
             </LegendItem>
             <LegendItem
               swatch={
@@ -472,7 +474,7 @@ const StatisticsDayOfWeek = ({
                 />
               }
             >
-              {t.legend.over(euro0(dangerBudget))}
+              {dayOfWeek.legend.over(euro0(dangerBudget))}
             </LegendItem>
           </>
         )}
@@ -485,10 +487,10 @@ const StatisticsDayOfWeek = ({
             </span>
           }
         >
-          {t.legend.range}
+          {dayOfWeek.legend.range}
         </LegendItem>
         <LegendItem swatch={<span className="inline-block h-0 w-4 border-t-2 border-dashed border-accent-strong/80" />}>
-          {t.legend.average}
+          {dayOfWeek.legend.average}
         </LegendItem>
         {hasCompareData && (
           <span
@@ -503,7 +505,7 @@ const StatisticsDayOfWeek = ({
                 />
               }
             >
-              {t.legend.comparedYear(compareYear)}
+              {dayOfWeek.legend.comparedYear(compareYear)}
             </LegendItem>
           </span>
         )}
@@ -524,23 +526,25 @@ const StatisticsDayOfWeek = ({
             return (
               <div className="min-w-45">
                 <div className="flex items-baseline justify-between gap-6 border-b border-line pb-1.5">
-                  <span className="font-medium text-ink">{t.days[dow]}</span>
+                  <span className="font-medium text-ink">{dayOfWeek.days[dow]}</span>
                   <span className={`num font-semibold ${overspendTextClass(level)}`}>{euro(s.avgAmount)} €</span>
                 </div>
                 <div className="mt-1.5 flex flex-col gap-0.5">
                   <TipRow
-                    label={t.tooltip.range}
+                    label={dayOfWeek.tooltip.range}
                     value={
-                      <span className="num whitespace-nowrap">{t.tooltip.rangeValue(euro0(s.min), euro0(s.max))}</span>
+                      <span className="num whitespace-nowrap">
+                        {dayOfWeek.tooltip.rangeValue(euro0(s.min), euro0(s.max))}
+                      </span>
                     }
                   />
                   <TipRow
-                    label={t.tooltip.txPerDay}
+                    label={dayOfWeek.tooltip.txPerDay}
                     value={<span className="num">{pct1(s.avgTx)}</span>}
                   />
                   <TipRow
-                    label={t.tooltip.dominantCategory}
-                    value={category?.name ?? t.tooltip.none}
+                    label={dayOfWeek.tooltip.dominantCategory}
+                    value={category?.name ?? dayOfWeek.tooltip.none}
                   />
                 </div>
                 {cs && (
@@ -549,13 +553,13 @@ const StatisticsDayOfWeek = ({
                       label={String(compareYear)}
                       value={
                         <span className="num text-accent-d">
-                          {t.tooltip.compareValue(euro(cs.avgAmount), pct1(cs.avgTx))}
+                          {dayOfWeek.tooltip.compareValue(euro(cs.avgAmount), pct1(cs.avgTx))}
                         </span>
                       }
                     />
                     {compareDelta != null && (
                       <TipRow
-                        label={t.tooltip.compareDelta}
+                        label={dayOfWeek.tooltip.compareDelta}
                         value={
                           <span className="num">
                             <DeltaBadge pct={compareDelta} />

--- a/front/src/components/statistics/StatisticsTopCategories.tsx
+++ b/front/src/components/statistics/StatisticsTopCategories.tsx
@@ -7,17 +7,9 @@ import { euro0 } from "@lib/format";
 import statistics from "@text/statistics";
 import { ChevronDown, ChevronUp } from "lucide-react";
 
-const { topCategories: t } = statistics;
+import type { TopCategoryRow } from "@components/statistics/interfaces/statisticsTopCategoriesTypes";
 
-export interface TopCategoryRow {
-  name: string;
-  color: string;
-  value: number;
-  /** Year-over-year change in %, or null when the category is new this year. */
-  deltaPct: number | null;
-  /** The compare-year total for this category (0 when absent that year). */
-  compareValue: number;
-}
+const { topCategories } = statistics;
 
 interface StatisticsTopCategoriesProps {
   rows: TopCategoryRow[];
@@ -38,7 +30,7 @@ const Trend = ({
   const trendTip = useCursorHover();
   let inner: React.ReactNode;
   if (deltaPct == null) {
-    inner = <span className="text-ink-4">{t.new}</span>;
+    inner = <span className="text-ink-4">{topCategories.new}</span>;
   } else {
     const rounded = Math.round(deltaPct);
     if (rounded === 0) {
@@ -69,8 +61,12 @@ const Trend = ({
   const diff = value - compareValue;
   const tooltip =
     deltaPct == null
-      ? t.tooltip.newCategory(compareYear)
-      : t.tooltip.trend(compareYear, euro0(compareValue), `${diff >= 0 ? "+" : "−"}${euro0(Math.abs(diff))}`);
+      ? topCategories.tooltip.newCategory(compareYear)
+      : topCategories.tooltip.trend(
+          compareYear,
+          euro0(compareValue),
+          `${diff >= 0 ? "+" : "−"}${euro0(Math.abs(diff))}`,
+        );
 
   return (
     <>
@@ -94,16 +90,16 @@ const StatisticsTopCategories = ({ rows, compareYear }: StatisticsTopCategoriesP
   return (
     <GlowCard className="flex flex-col px-6 py-5.5">
       <CardSectionHeader
-        title={t.title}
-        meta={t.meta(compareYear)}
+        title={topCategories.title}
+        meta={topCategories.meta(compareYear)}
       />
 
       <div className="mt-4.5 flex flex-col">
         <div className="mb-0.5 grid grid-cols-[14px_1fr_90px_80px] items-center gap-2.5 border-b border-line pb-2 text-2xs font-medium uppercase tracking-caps text-ink-4">
           <span />
-          <span>{t.colCategory}</span>
-          <span className="text-right">{t.colTotal}</span>
-          <span className="text-right">{t.colVs(compareYear)}</span>
+          <span>{topCategories.colCategory}</span>
+          <span className="text-right">{topCategories.colTotal}</span>
+          <span className="text-right">{topCategories.colVs(compareYear)}</span>
         </div>
 
         {rows.map((row) => (

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -28,6 +28,9 @@ import useStatistics from "@components/statistics/services/useStatistics";
 import useWeekdayCategories from "@components/statistics/services/useWeekdayCategories";
 import { useMemo, useState } from "react";
 
+import type { CategorySeries } from "@components/statistics/interfaces/statisticsCategoryChartTypes";
+import type { TopCategoryRow } from "@components/statistics/interfaces/statisticsTopCategoriesTypes";
+
 const MAX_CATEGORIES = 3;
 
 const yearOptions = (currentYear: number): number[] => Array.from({ length: 7 }, (_, i) => currentYear - i);
@@ -101,7 +104,7 @@ const StatisticsView = () => {
 
   const prevTotals = perCategoryTotals(data, colors, compareYear);
   const prevByName = new Map(prevTotals.map((c) => [c.name, c.value]));
-  const topCategoryRows = perCategoryTotals(data, colors, selectedYear)
+  const topCategoryRows: TopCategoryRow[] = perCategoryTotals(data, colors, selectedYear)
     .slice(0, 8)
     .map((c) => {
       const prev = prevByName.get(c.name) ?? 0;
@@ -114,7 +117,7 @@ const StatisticsView = () => {
       };
     });
 
-  const categorySeries = selectedCategoryIds
+  const categorySeries: CategorySeries[] = selectedCategoryIds
     .map((id) => categories.find((c) => c.ID === id))
     .filter((c): c is (typeof categories)[number] => Boolean(c))
     .map((category) => ({

--- a/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
+++ b/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
@@ -1,0 +1,10 @@
+/**
+ * One selected category's monthly series — built by StatisticsView, rendered as
+ * a group of bars by StatisticsCategoryChart.
+ */
+export interface CategorySeries {
+  name: string;
+  color: string;
+  /** 12-slot Jan→Dec monthly spend for this category. */
+  monthly: number[];
+}

--- a/front/src/components/statistics/interfaces/statisticsTopCategoriesTypes.ts
+++ b/front/src/components/statistics/interfaces/statisticsTopCategoriesTypes.ts
@@ -1,0 +1,13 @@
+/**
+ * One row of the "Top catégories" table — built by StatisticsView, rendered by
+ * StatisticsTopCategories.
+ */
+export interface TopCategoryRow {
+  name: string;
+  color: string;
+  value: number;
+  /** Year-over-year change in %, or null when the category is new this year. */
+  deltaPct: number | null;
+  /** The compare-year total for this category (0 when absent that year). */
+  compareValue: number;
+}

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -5,47 +5,17 @@ import { euro } from "@lib/format";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import type { CategoryTrendData } from "@lib/dataviz/CategoryTrend";
+import type { CategoryTooltipDatum } from "@lib/dataviz/dataVizTypes";
 
 // Measure-then-position must run before paint to clamp the tooltip at the
 // viewport edge without a flash; fall back to useEffect on the server, where
 // layout effects warn (and never run) anyway.
 const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-/** One category's display data — mirrors its list row. */
-export interface CategoryTooltipDatum {
-  color: string;
-  name: string;
-  /** Item count pill. Omit for data that has no count (e.g. the budget donut's
-   *  Fixes / Variables segments) — the pill is then hidden. */
-  count?: number;
-  /** Share of the total, 0-100 (already computed — the tooltip only formats). */
-  pct: number;
-  /** Amount in euros. */
-  total: number;
-  /** Trend data — the page computes it from its own source (weekly vs monthly).
-   *  Omit for data with no trend — the "Tendance" row is then hidden. */
-  trend?: CategoryTrendData;
-}
-
-export interface CategoryBarTooltipProps {
+interface CategoryBarTooltipProps {
   /** Cursor position in viewport coords, or null when the tooltip is hidden. */
   point: { x: number; y: number } | null;
   datum: CategoryTooltipDatum;
-}
-
-/**
- * Local hover state a consumer keeps to drive this tooltip: viewport coords
- * plus the hovered target. `T` is whatever resolves the datum — the row object
- * itself, or its index into a rows array.
- */
-export interface BarHover<T> {
-  /** Cursor X in viewport coords (clientX). */
-  x: number;
-  /** Cursor Y in viewport coords (clientY). */
-  y: number;
-  /** The hovered target (a row, an index, …). */
-  target: T;
 }
 
 /**

--- a/front/src/lib/dataviz/CategoryTrend.tsx
+++ b/front/src/lib/dataviz/CategoryTrend.tsx
@@ -3,12 +3,7 @@
 import { cn } from "@lib/utils";
 import { ArrowDown, ArrowUp } from "lucide-react";
 
-export type TrendDirection = "up" | "down" | "flat";
-
-export interface CategoryTrendData {
-  direction: TrendDirection;
-  label: string;
-}
+import type { CategoryTrendData } from "@lib/dataviz/dataVizTypes";
 
 interface CategoryTrendProps extends CategoryTrendData {
   /** Extra classes (e.g. responsive show/hide when it sits in a grid cell). */

--- a/front/src/lib/dataviz/CursorTooltip.tsx
+++ b/front/src/lib/dataviz/CursorTooltip.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import type { CursorPoint } from "@lib/dataviz/dataVizTypes";
 import type { ReactNode } from "react";
 
 // Measure-then-position must run before paint to clamp the tooltip at the
@@ -11,13 +12,6 @@ const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : us
 
 /** Tooltip appear/disappear fade duration (ms). Tune here — applies everywhere. */
 export const TOOLTIP_FADE_MS = 150;
-
-export interface CursorPoint {
-  /** Cursor X in viewport coords (clientX). */
-  x: number;
-  /** Cursor Y in viewport coords (clientY). */
-  y: number;
-}
 
 interface CursorTooltipProps {
   /** Cursor position, or null when hidden (triggers the fade-out). */

--- a/front/src/lib/dataviz/dataVizTypes.ts
+++ b/front/src/lib/dataviz/dataVizTypes.ts
@@ -45,3 +45,51 @@ export interface SeriesDot {
   y: number;
   color?: string;
 }
+
+// Interaction contracts — hover state and tooltip data shared by the charts and
+// the mouse-following tooltips (CategoryBarTooltip / CursorTooltip).
+
+export type TrendDirection = "up" | "down" | "flat";
+
+export interface CategoryTrendData {
+  direction: TrendDirection;
+  label: string;
+}
+
+/** One category's display data — mirrors its list row. */
+export interface CategoryTooltipDatum {
+  color: string;
+  name: string;
+  /** Item count pill. Omit for data that has no count (e.g. the budget donut's
+   *  Fixes / Variables segments) — the pill is then hidden. */
+  count?: number;
+  /** Share of the total, 0-100 (already computed — the tooltip only formats). */
+  pct: number;
+  /** Amount in euros. */
+  total: number;
+  /** Trend data — the page computes it from its own source (weekly vs monthly).
+   *  Omit for data with no trend — the "Tendance" row is then hidden. */
+  trend?: CategoryTrendData;
+}
+
+/**
+ * Local hover state a consumer keeps to drive the category bar tooltip: viewport
+ * coords plus the hovered target. `T` is whatever resolves the datum — the row
+ * object itself, or its index into a rows array.
+ */
+export interface BarHover<T> {
+  /** Cursor X in viewport coords (clientX). */
+  x: number;
+  /** Cursor Y in viewport coords (clientY). */
+  y: number;
+  /** The hovered target (a row, an index, …). */
+  target: T;
+}
+
+/** Cursor position in viewport coords, driving a mouse-following tooltip. */
+export interface CursorPoint {
+  /** Cursor X in viewport coords (clientX). */
+  x: number;
+  /** Cursor Y in viewport coords (clientY). */
+  y: number;
+}

--- a/front/src/lib/dataviz/index.ts
+++ b/front/src/lib/dataviz/index.ts
@@ -20,18 +20,14 @@ export { default as useElementWidth } from "@lib/dataviz/useElementWidth";
 export { default as useTween } from "@lib/dataviz/useTween";
 
 export type {
-  BarHover,
-  CategoryTooltipDatum,
-} from "@lib/dataviz/CategoryBarTooltip";
-export type {
-  CategoryTrendData,
-  TrendDirection,
-} from "@lib/dataviz/CategoryTrend";
-export type {
   AxisMarker,
   BarDatum,
+  BarHover,
+  CategoryTooltipDatum,
+  CategoryTrendData,
   DonutSegment,
   LinePoint,
   LineSeries,
   SeriesDot,
+  TrendDirection,
 } from "@lib/dataviz/dataVizTypes";

--- a/front/src/lib/dataviz/useCursorHover.ts
+++ b/front/src/lib/dataviz/useCursorHover.ts
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 
-import type { CursorPoint } from "@lib/dataviz/CursorTooltip";
+import type { CursorPoint } from "@lib/dataviz/dataVizTypes";
 
 export interface CursorHover<T> extends CursorPoint {
   data: T;


### PR DESCRIPTION
Component files should only export their component; an exported type means it is consumed elsewhere and belongs in a shared, explicitly-named types file.

- dataviz: centralize CategoryTooltipDatum, BarHover, TrendDirection, CategoryTrendData and CursorPoint in dataVizTypes.ts (the barrel already re-exported from there, so consumers are untouched); de-export the co-located CategoryBarTooltipProps.
- statistics: CategorySeries and TopCategoryRow -> statistics/interfaces/, with StatisticsView annotating its builders so each type is shared View<->component, mirroring the BreakdownRow / FilterCategory precedent.

Also drop the opaque `t` alias for @text groups (it could mean anything) in StatisticsTopCategories, StatisticsDayOfWeek and the about page, using the full key name instead.