### PR TITLE
refactor(spendings): ?date= via nuqs (COS-117)

### DIFF
--- a/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
+++ b/front/src/components/datePickerWrapper/DatePickerWrapper.tsx
@@ -2,13 +2,13 @@
 
 import { parseDateParam } from "@components/datePickerWrapper/helpers";
 import useDatePickerState from "@components/datePickerWrapper/helpers/useDatePickerState";
-import { DATE_QUERY_PARAM } from "@helpers/dateRoute";
+import { DATE_QUERY_PARAM, parseAsSpendingsDate } from "@helpers/dateRoute";
 import { cn } from "@lib/utils";
 import common from "@text/common";
 import format from "date-fns/format";
 import fr from "date-fns/locale/fr";
 import { Calendar as CalendarIcon, ChevronDown } from "lucide-react";
-import { useSearchParams } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useEffect, useRef } from "react";
 import DayPicker from "react-day-picker";
 // NOTE: react-day-picker/lib/style.css is intentionally NOT imported — the pfa
@@ -32,10 +32,8 @@ const DatePickerWrapper = () => {
     handleDayLeave,
   } = useDatePickerState();
 
-  const searchParams = useSearchParams();
+  const [selectedDateParam] = useQueryState(DATE_QUERY_PARAM, parseAsSpendingsDate);
   const ref = useRef<HTMLDivElement>(null);
-
-  const selectedDateParam = searchParams.get(DATE_QUERY_PARAM);
 
   const daysAreSelected = selectedDays.length > 0;
 

--- a/front/src/components/datePickerWrapper/helpers/useDatePickerState.ts
+++ b/front/src/components/datePickerWrapper/helpers/useDatePickerState.ts
@@ -3,9 +3,10 @@
 import useBlur from "@components/common/helpers/blurHelper";
 import { getWeekDays, getWeekRange } from "@components/datePickerWrapper/helpers";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { DATE_QUERY_PARAM, SPENDINGS_PATH } from "@helpers/dateRoute";
+import { DATE_QUERY_PARAM, parseAsSpendingsDate, SPENDINGS_PATH } from "@helpers/dateRoute";
 import formatISO from "date-fns/formatISO";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { usePathname } from "next/navigation";
+import { useQueryState } from "nuqs";
 import { useState } from "react";
 
 import type { Days, HoverRange } from "@components/datePickerWrapper/types";
@@ -17,9 +18,8 @@ const useDatePickerState = () => {
   const [hoverRange, setHoverRange] = useState<HoverRange>(null);
   const [selectedDays, setSelectedDays] = useState<Days>([]);
 
-  const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
+  const [dateInUrl, setDateInUrl] = useQueryState(DATE_QUERY_PARAM, parseAsSpendingsDate);
 
   const { setFrom, setTo, setRange, setSelectedDateIso, setScrollToDayIso } = useDatePickerWrapperStore();
 
@@ -47,13 +47,10 @@ const useDatePickerState = () => {
     if (updateUrl) {
       setScrollToDayIso(null);
     }
-    if (updateUrl && normalizePath(pathname) === SPENDINGS_PATH) {
-      const dateInUrl = searchParams.get(DATE_QUERY_PARAM);
-      if (dateInUrl !== dateISO) {
-        const params = new URLSearchParams(searchParams.toString());
-        params.set(DATE_QUERY_PARAM, dateISO);
-        router.push(`${SPENDINGS_PATH}?${params.toString()}`);
-      }
+    // A deliberate week pick pushes a new history entry so Back returns to the
+    // previous week; nuqs leaves any other query param on /spendings untouched.
+    if (updateUrl && normalizePath(pathname) === SPENDINGS_PATH && dateInUrl !== dateISO) {
+      setDateInUrl(dateISO, { history: "push" });
     }
 
     const weekRange = getWeekRange(date);

--- a/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
+++ b/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
@@ -4,7 +4,7 @@ import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import { DATE_FORMAT, MONTHLY } from "@components/spendings/config/constants";
 import useSpendings from "@components/spendings/services/useSpendings";
-import { DATE_QUERY_PARAM, SPENDINGS_PATH } from "@helpers/dateRoute";
+import { buildSpendingsPath } from "@helpers/dateRoute";
 import { euro } from "@lib/format";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import texts from "@text/spendings";
@@ -12,7 +12,7 @@ import format from "date-fns/format";
 import fr from "date-fns/locale/fr";
 import parseISO from "date-fns/parseISO";
 import { ChevronRight, Search, X } from "lucide-react";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 
 import type { SpendingItem } from "@components/spendings/types";
@@ -48,8 +48,6 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
   const [searchTerm, setSearchTerm] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
 
   const { spendingsListModal: t } = texts;
   const isMonthly = periodType === MONTHLY;
@@ -78,14 +76,12 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
       ? `${format(from, "dd")} — ${format(to, "dd MMM yyyy", { locale: fr })}`
       : "";
 
-  // Click a day → jump to the Dépenses page on the week that contains it.
+  // Click a day → jump to the Dépenses page on the week that contains it. This is
+  // a cross-page navigation (the modal opens from the Dashboard too), so it keeps
+  // building a real href via buildSpendingsPath rather than an in-page nuqs setter.
   const goToDayWeek = (date: string) => {
     const dateISO = format(parseISO(date), DATE_FORMAT);
-    const normalizedPath = pathname.replace(/\/+$/, "") || "/";
-    const params =
-      normalizedPath === SPENDINGS_PATH ? new URLSearchParams(searchParams.toString()) : new URLSearchParams();
-    params.set(DATE_QUERY_PARAM, dateISO);
-    router.push(`${SPENDINGS_PATH}?${params.toString()}`);
+    router.push(buildSpendingsPath(dateISO));
     handleClickOutside();
   };
 

--- a/front/src/components/spendings/view/SpendingPageClient.tsx
+++ b/front/src/components/spendings/view/SpendingPageClient.tsx
@@ -3,31 +3,32 @@
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
 import useGlobalStore from "@components/shared/globalStore";
 import SpendingView from "@components/spendings/view/SpendingView";
-import { buildSpendingsPath, DATE_QUERY_PARAM, getTodayIsoDate, isValidIsoDate } from "@helpers/dateRoute";
-import { useRouter, useSearchParams } from "next/navigation";
+import { DATE_QUERY_PARAM, getTodayIsoDate, parseAsSpendingsDate } from "@helpers/dateRoute";
+import { useQueryState } from "nuqs";
 import { useEffect } from "react";
 
 export default function SpendingPageClient() {
   const { setIsCalendarVisible } = useGlobalStore();
   const { setSelectedDateIso } = useDatePickerWrapperStore();
-  const router = useRouter();
-  const searchParams = useSearchParams();
+  // The `?date=` param is the URL source of truth for the selected week; the
+  // parser drops any invalid value to null (see parseAsSpendingsDate).
+  const [date, setDate] = useQueryState(DATE_QUERY_PARAM, parseAsSpendingsDate);
 
   useEffect(() => {
     setIsCalendarVisible(true);
   }, [setIsCalendarVisible]);
 
   useEffect(() => {
-    const date = searchParams.get(DATE_QUERY_PARAM) ?? undefined;
-    if (isValidIsoDate(date)) {
+    if (date) {
       setSelectedDateIso(date);
       return;
     }
     // No/invalid ?date= → default to the BROWSER-LOCAL today and canonicalise the
-    // URL. "Today" must be resolved client-side: the server timezone can differ
-    // from the user's, so it must never decide the day (COS-73).
-    router.replace(buildSpendingsPath(getTodayIsoDate()));
-  }, [searchParams, setSelectedDateIso, router]);
+    // URL in place (replace, not push). "Today" must be resolved client-side: the
+    // server timezone can differ from the user's, so it must never decide the day
+    // (COS-73).
+    setDate(getTodayIsoDate(), { history: "replace" });
+  }, [date, setSelectedDateIso, setDate]);
 
   return <SpendingView />;
 }

--- a/front/src/helpers/__tests__/dateRoute.test.ts
+++ b/front/src/helpers/__tests__/dateRoute.test.ts
@@ -1,4 +1,4 @@
-import { formatMonthParam, parseMonthParam, resolveMonthParam } from "@helpers/dateRoute";
+import { formatMonthParam, parseAsSpendingsDate, parseMonthParam, resolveMonthParam } from "@helpers/dateRoute";
 import { describe, expect, it } from "vitest";
 
 describe("formatMonthParam / parseMonthParam", () => {
@@ -28,5 +28,25 @@ describe("resolveMonthParam", () => {
   it("returns the YYYY-MM of any other month", () => {
     expect(resolveMonthParam(new Date(2025, 8, 10), currentMonthStart)).toBe("2025-09");
     expect(resolveMonthParam(new Date(2027, 0, 1), currentMonthStart)).toBe("2027-01");
+  });
+});
+
+describe("parseAsSpendingsDate", () => {
+  it("keeps a valid ISO calendar day as a plain local string (never a Date)", () => {
+    const parsed = parseAsSpendingsDate.parse("2026-07-12");
+    expect(parsed).toBe("2026-07-12");
+    expect(typeof parsed).toBe("string");
+  });
+
+  it("rejects malformed or out-of-range values to null (page falls back to today)", () => {
+    expect(parseAsSpendingsDate.parse("")).toBeNull();
+    expect(parseAsSpendingsDate.parse("2026-7-2")).toBeNull();
+    expect(parseAsSpendingsDate.parse("20260712")).toBeNull();
+    expect(parseAsSpendingsDate.parse("not-a-date")).toBeNull();
+    expect(parseAsSpendingsDate.parse("2026-13-01")).toBeNull();
+  });
+
+  it("serializes back to the untouched ISO string", () => {
+    expect(parseAsSpendingsDate.serialize("2026-07-12")).toBe("2026-07-12");
   });
 });

--- a/front/src/helpers/dateRoute.ts
+++ b/front/src/helpers/dateRoute.ts
@@ -1,5 +1,6 @@
 import formatISO from "date-fns/formatISO";
 import startOfMonth from "date-fns/startOfMonth";
+import { createParser } from "nuqs";
 
 export const DATE_QUERY_PARAM = "date";
 // The Dépenses (weekly) page carries the selected week as a ?date= query param.
@@ -22,6 +23,19 @@ export const isValidIsoDate = (value?: string): value is string => {
 };
 
 export const buildSpendingsPath = (date = getTodayIsoDate()): string => `${SPENDINGS_PATH}?${DATE_QUERY_PARAM}=${date}`;
+
+/**
+ * nuqs parser for the Dépenses `?date=` param: a validated ISO calendar day
+ * ("YYYY-MM-DD") kept as a LOCAL string — the whole app treats the selected week
+ * as this string, never a Date. Deliberately NOT nuqs' built-in `parseAsIsoDate`,
+ * which decodes to `new Date("YYYY-MM-DD")` (UTC midnight) and would reintroduce
+ * the west-of-UTC off-by-one-day bug (COS-73). An invalid value parses to null so
+ * the page falls back to today, matching the former isValidIsoDate guard.
+ */
+export const parseAsSpendingsDate = createParser({
+  parse: (value) => (isValidIsoDate(value) ? value : null),
+  serialize: (value) => value,
+});
 
 // The Dashboard carries its viewed month as a ?month=YYYY-MM query param (COS-118).
 // Absent = current month (resolved client-side, COS-73), keeping /dashboard clean.


### PR DESCRIPTION
The Dépenses week param was hand-rolled (useSearchParams + router.push/replace + URLSearchParams). Move the in-page read/write to nuqs useQueryState behind a custom parseAsSpendingsDate parser — a validated ISO calendar day kept as a local string, deliberately not nuqs' built-in parseAsIsoDate which decodes to a UTC-midnight Date and would reintroduce the COS-73 off-by-one.

Cross-page navigation (NavBar links + Aujourd'hui, SpendingsListModal opened from the Dashboard) stays on buildSpendingsPath, since a nuqs setter can't change route; SpendingsListModal now builds its href via buildSpendingsPath instead of hand-rolled URLSearchParams. Behaviour unchanged: week, scroll-to-day, Aujourd'hui, deep-link, Back/Forward.