### PR TITLE
test(front): add Playwright e2e suite (COS-30)

### DIFF
--- a/front/.env.test.local.example
+++ b/front/.env.test.local.example
@@ -1,0 +1,4 @@
+# Playwright E2E credentials — copy to .env.test.local (git-ignored) and fill in.
+# The account must exist locally (created by `pnpm seed` in nest-api).
+E2E_EMAIL=abc@abc.com
+E2E_PASSWORD=

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -7,6 +7,9 @@
 
 # testing
 /coverage
+/test-results/
+/playwright-report/
+/e2e/.auth/
 
 # next.js
 /.next/

--- a/front/e2e/README.md
+++ b/front/e2e/README.md
@@ -1,0 +1,28 @@
+# E2E (Playwright)
+
+## Prerequisites
+
+1. MySQL and Redis running (same as the regular dev setup).
+2. Seed account present: `pnpm --dir ../nest-api seed` (creates `abc@abc.com` with demo data).
+3. `cp .env.test.local.example .env.test.local` and fill in `E2E_PASSWORD` (git-ignored, never committed).
+
+## Running
+
+```bash
+pnpm test:e2e      # headless
+pnpm test:e2e:ui   # Playwright UI mode
+```
+
+If the front (:3000) and the API (:6100) are already running in your terminals, Playwright
+reuses them (`reuseExistingServer: true`). Otherwise it starts both itself.
+
+## Structure
+
+- `auth.setup.ts` — logs in once through the real login form, saves the session to `.auth/user.json`
+  (git-ignored). Doubles as the login E2E test.
+- `public.spec.ts` — unauthenticated smoke: login and signup forms render.
+- `smoke.spec.ts` — every private page loads and shows its data (not the error boundary,
+  not a stuck skeleton). The regression net for the TanStack Query migration (COS-52).
+- `create-spending.spec.ts` — create a spending through the modal, see it appear, delete it,
+  see it disappear. Self-cleaning: an `afterEach` sweep removes any leftover `E2E …`-labelled
+  spendings via the API even when the test fails midway.

--- a/front/e2e/auth.setup.ts
+++ b/front/e2e/auth.setup.ts
@@ -1,0 +1,23 @@
+import { expect, test as setup } from "@playwright/test";
+
+const AUTH_FILE = "e2e/.auth/user.json";
+
+// Logs in once through the real login form and persists the pfa.sid session cookie.
+// Doubles as the login E2E test.
+setup("login and persist session", async ({ page }) => {
+  const email = process.env.E2E_EMAIL ?? "abc@abc.com";
+  const password = process.env.E2E_PASSWORD;
+  if (!password) {
+    throw new Error("E2E_PASSWORD manquant — copier .env.test.local.example vers .env.test.local et le remplir.");
+  }
+
+  await page.goto("/login");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Mot de passe", { exact: true }).fill(password);
+  await page.getByRole("button", { name: "Se connecter" }).click();
+
+  await page.waitForURL(/\/dashboard/);
+  await expect(page.getByRole("heading", { name: "Plafond hebdomadaire" })).toBeVisible();
+
+  await page.context().storageState({ path: AUTH_FILE });
+});

--- a/front/e2e/create-spending.spec.ts
+++ b/front/e2e/create-spending.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "@playwright/test";
+
+const API = "http://localhost:6100/api";
+// Sentinel prefix identifying spendings created by this suite (cleaned up in afterEach).
+const SENTINEL_PREFIX = "E2E ";
+
+function isoDay(d: Date): string {
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${month}-${day}`;
+}
+
+// Residue guard: even if the test fails midway, no sentinel spending survives
+// in the demo account. page.request shares the browser session cookie.
+test.afterEach(async ({ page }) => {
+  const csrfResponse = await page.request.get(`${API}/users/csrf`);
+  if (!csrfResponse.ok()) {
+    throw new Error(`Nettoyage E2E impossible : /users/csrf a répondu ${csrfResponse.status()}`);
+  }
+  const { csrfToken } = await csrfResponse.json();
+
+  const now = new Date();
+  const from = isoDay(new Date(now.getFullYear(), now.getMonth(), 1));
+  const to = isoDay(new Date(now.getFullYear(), now.getMonth() + 1, 0));
+  const spendings: Array<{ ID: string; label: string }> = await (
+    await page.request.get(`${API}/spendings?from=${from}&to=${to}`)
+  ).json();
+
+  for (const spending of spendings) {
+    if (spending.label?.startsWith(SENTINEL_PREFIX)) {
+      await page.request.delete(`${API}/spendings/${spending.ID}`, {
+        headers: { "x-csrf-token": csrfToken },
+      });
+    }
+  }
+});
+
+test("create then delete a spending through the modal", async ({ page }) => {
+  const label = `${SENTINEL_PREFIX}${Date.now()}`;
+  await page.goto("/spendings");
+  await expect(page.locator("[data-sp-day]")).toHaveCount(7);
+
+  // Create via the floating button (defaults to today's date)
+  await page.getByRole("button", { name: "Nouvelle dépense" }).click();
+  const modal = page.getByRole("dialog", { name: "Nouvelle dépense" });
+  await expect(modal).toBeVisible();
+  await modal.getByLabel("Label").fill(label);
+  await modal.getByLabel("Montant").fill("12.34");
+  // Pick the first existing category from the combobox
+  await modal.getByRole("combobox").click();
+  await page.getByRole("option").first().click();
+  await modal.getByRole("button", { name: "Ajouter la dépense" }).click();
+
+  // Toast + row in today's card = mutation + invalidateQueries refetch both worked
+  await expect(page.getByText("dépense créée")).toBeVisible();
+  const todayCard = page.locator(`[data-sp-day="${isoDay(new Date())}"]`);
+  const rowLabel = todayCard.locator(`span[title="${label}"]`);
+  await expect(rowLabel).toBeVisible();
+
+  // Delete it: hover reveals the row actions (display:none otherwise, so the
+  // only "Supprimer" button in the accessibility tree belongs to this row)
+  await rowLabel.hover();
+  await todayCard.getByRole("button", { name: "Supprimer" }).click();
+  const confirmDialog = page.getByRole("alertdialog", { name: "Confirmer la suppression" });
+  await expect(confirmDialog.getByText("Supprimer cette dépense ?")).toBeVisible();
+  await confirmDialog.getByRole("button", { name: "Confirmer" }).click();
+
+  await expect(page.getByText("dépense supprimée")).toBeVisible();
+  await expect(rowLabel).toHaveCount(0);
+});

--- a/front/e2e/public.spec.ts
+++ b/front/e2e/public.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("public pages", () => {
+  test("login renders its form", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: "Personal Finance Assistant" })).toBeVisible();
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Mot de passe", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Se connecter" })).toBeVisible();
+  });
+
+  test("signup renders its form", async ({ page }) => {
+    await page.goto("/signup");
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(page.getByLabel("Mot de passe", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Confirmer le mot de passe")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Créer un compte" })).toBeVisible();
+  });
+});

--- a/front/e2e/smoke.spec.ts
+++ b/front/e2e/smoke.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from "@playwright/test";
+
+// Text of the global error boundary (src/app/error.tsx) — a broken query throws into it.
+const ERROR_BOUNDARY = "Something went wrong";
+
+test.describe("private pages smoke", () => {
+  test("dashboard renders with data", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: "Plafond hebdomadaire" })).toBeVisible();
+    await expect(page.getByText(/— budget restant/)).toBeVisible();
+    // NavBar only renders once the user context resolved
+    await expect(page.getByRole("link", { name: "Statistiques" })).toBeVisible();
+    await expect(page.getByText(ERROR_BOUNDARY)).toBeHidden();
+  });
+
+  test("spendings renders the week with data", async ({ page }) => {
+    await page.goto("/spendings");
+    // The 7 day cards only render once the spendings query resolved
+    await expect(page.locator("[data-sp-day]")).toHaveCount(7);
+    await expect(page.getByRole("button", { name: "Nouvelle dépense" })).toBeVisible();
+    await expect(page.getByText(ERROR_BOUNDARY)).toBeHidden();
+  });
+
+  test("statistics loads its data", async ({ page }) => {
+    // /statistics swallows query errors (renders zeros instead of throwing) —
+    // assert the API call itself succeeds, not just the static headings.
+    const statsResponse = page.waitForResponse(
+      (r) => r.url().includes("/api/statistics") && r.request().method() === "GET",
+    );
+    await page.goto("/statistics");
+    expect((await statsResponse).ok()).toBeTruthy();
+    await expect(page.getByRole("heading", { name: "Dépenses mensuelles", exact: true })).toBeVisible();
+    await expect(page.getByText(/Total dépensé/)).toBeVisible();
+    await expect(page.getByText(ERROR_BOUNDARY)).toBeHidden();
+  });
+
+  test("categories renders the list", async ({ page }) => {
+    await page.goto("/categories");
+    await expect(page.getByRole("heading", { name: "Catégories" })).toBeVisible();
+    // The loading spinner must resolve into the list
+    await expect(page.locator('img[alt="spinner"]')).toHaveCount(0);
+    await expect(page.getByPlaceholder("Rechercher une catégorie…")).toBeVisible();
+    await expect(page.getByText(ERROR_BOUNDARY)).toBeHidden();
+  });
+
+  test("exceptionals renders stats and list", async ({ page }) => {
+    await page.goto("/exceptionals");
+    await expect(page.getByText("Part des dépenses")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Ajouter", exact: true })).toBeVisible();
+    await expect(page.locator('img[alt="spinner"]')).toHaveCount(0);
+    await expect(page.getByText(ERROR_BOUNDARY)).toBeHidden();
+  });
+});

--- a/front/package.json
+++ b/front/package.json
@@ -11,6 +11,8 @@
     "lint:fix": "biome check --write ./src",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "ds:prepare": "node .design-sync/prepare.mjs"
   },
   "dependencies": {
@@ -60,11 +62,13 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.3",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.3.2",
     "@types/node": "25.0.3",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "babel-plugin-react-compiler": "^1.0.0",
+    "dotenv": "^17.4.2",
     "postcss": "^8.4.12",
     "tailwindcss": "^4.3.2",
     "typescript": "5.9.3",

--- a/front/playwright.config.ts
+++ b/front/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+
+// E2E credentials (E2E_EMAIL / E2E_PASSWORD) — see .env.test.local.example
+config({ path: ".env.test.local", quiet: true });
+
+const AUTH_STATE = "e2e/.auth/user.json";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./test-results",
+  fullyParallel: false,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+    locale: "fr-FR",
+  },
+  projects: [
+    // Logs in once via the real UI and saves the session cookie for the other projects.
+    {
+      name: "setup",
+      testMatch: /auth\.setup\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    // Unauthenticated pages (login / signup render).
+    {
+      name: "public",
+      testMatch: /public\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    // Authenticated pages, reusing the saved session.
+    {
+      name: "chromium",
+      testIgnore: [/auth\.setup\.ts/, /public\.spec\.ts/],
+      dependencies: ["setup"],
+      use: { ...devices["Desktop Chrome"], storageState: AUTH_STATE },
+    },
+  ],
+  // Reuses servers already running on :3000 / :6100 (dev workflow), starts them otherwise.
+  // Prerequisites when starting from scratch: MySQL + Redis up, seed account created (see e2e/README.md).
+  webServer: [
+    {
+      command: "pnpm dev",
+      url: "http://localhost:3000",
+      reuseExistingServer: true,
+      timeout: 120_000,
+    },
+    {
+      command: "pnpm --dir ../nest-api start:dev",
+      url: "http://localhost:6100/api/users/csrf",
+      reuseExistingServer: true,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -91,13 +91,13 @@ importers:
         version: 2.0.5
       next:
         specifier: 16.1.0
-        version: 16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.0(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       nuqs:
         specifier: ^2.9.0
-        version: 2.9.0(next@16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
+        version: 2.9.0(next@16.1.0(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       query-string:
         specifier: ^7.1.1
         version: 7.1.1
@@ -141,6 +141,9 @@ importers:
       '@biomejs/biome':
         specifier: 2.5.3
         version: 2.5.3
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.3.2
         version: 4.3.2
@@ -156,6 +159,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       postcss:
         specifier: ^8.4.12
         version: 8.5.6
@@ -512,6 +518,11 @@ packages:
 
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1335,6 +1346,10 @@ packages:
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
+
   enhanced-resolve@5.21.6:
     resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
     engines: {node: '>=10.13.0'}
@@ -1373,6 +1388,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1607,6 +1627,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -2218,6 +2248,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.139.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -2979,6 +3013,8 @@ snapshots:
 
   detect-node@2.1.0: {}
 
+  dotenv@17.4.2: {}
+
   enhanced-resolve@5.21.6:
     dependencies:
       graceful-fs: 4.2.11
@@ -3005,6 +3041,9 @@ snapshots:
   follow-redirects@1.15.0: {}
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -3128,7 +3167,7 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
 
-  next@16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.0(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.1.0
       '@swc/helpers': 0.5.15
@@ -3147,18 +3186,19 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.0
       '@next/swc-win32-arm64-msvc': 16.1.0
       '@next/swc-win32-x64-msvc': 16.1.0
+      '@playwright/test': 1.61.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nuqs@2.9.0(next@16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+  nuqs@2.9.0(next@16.1.0(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 19.2.3
     optionalDependencies:
-      next: 16.1.0(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.1.0(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   object-assign@4.1.1: {}
 
@@ -3179,6 +3219,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:


### PR DESCRIPTION
- login via real form once (auth.setup), session reused via storageState
- smoke per page: dashboard, spendings, statistics, categories, exceptionals + login/signup forms, asserting data rendered and no error boundary (regression net for the TanStack Query v5 migration)
- create-then-delete spending flow through the modal, self-cleaning (afterEach API sweep on the E2E label sentinel)
- webServer reuses running dev servers (:3000/:6100), starts them otherwise
- credentials in git-ignored .env.test.local (see .env.test.local.example)