### PR TITLE
refactor(front): centralize query layer (COS-157)

### DIFF
--- a/front/src/app/providers.tsx
+++ b/front/src/app/providers.tsx
@@ -8,7 +8,24 @@ import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { useState } from "react";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  // App-wide query behavior (COS-157): data is month-scoped and refreshed by
+  // explicit invalidation after mutations, hence the long staleTime and no
+  // focus refetch. Errors surface through error.tsx via throwOnError; hooks
+  // whose UI degrades gracefully (search modal, label suggestions…) opt out
+  // locally. Expired sessions never get here — the 401 redirects to /login at
+  // the request layer (COS-26).
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            staleTime: 60 * 60 * 1000, // 1 hour
+            throwOnError: true,
+          },
+        },
+      }),
+  );
 
   return (
     <ThemeProvider

--- a/front/src/components/categories/CategoriesListcontainer.tsx
+++ b/front/src/components/categories/CategoriesListcontainer.tsx
@@ -17,7 +17,7 @@ import type { Category } from "@src/schemas/categories";
 const isMock = (id: string) => id.startsWith("mock-");
 
 const CategoriesListcontainer = () => {
-  const { categories, error, updateCategory, deleteCategory } = useCategories();
+  const { categories, updateCategory, deleteCategory } = useCategories();
   const { categoryStats, error: statsError } = useCategoryStats();
   const { user } = useAuth();
   const { list } = categoriesText;
@@ -43,10 +43,8 @@ const CategoriesListcontainer = () => {
       .filter((c) => !q || c.name.toLowerCase().includes(q));
   }, [allCats, query]);
 
-  if (error) {
-    throw error;
-  }
-
+  // useCategoryStats opts out of the global throwOnError (the spending modal
+  // must survive a stats failure) — this page still wants the error screen.
   if (statsError) {
     throw statsError;
   }

--- a/front/src/components/categories/services/useCategoryStats.ts
+++ b/front/src/components/categories/services/useCategoryStats.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { CategoryStatsResponseSchema } from "@src/schemas/categoryStats";
 import { useQuery } from "@tanstack/react-query";
 
@@ -38,7 +38,10 @@ const useCategoryStats = (range?: CategoryStatsRange) => {
     queryFn: getCategoryStatsService,
     retry: 2,
     enabled: !!userID,
-    ...QUERY_OPTIONS,
+    // The spending modal's "Fréquentes" quick-picks must never block the modal
+    // on a stats failure (COS-137), so this opts out of the global throwOnError;
+    // the Categories page rethrows the returned error itself.
+    throwOnError: false,
   });
 
   return { categoryStats, error };

--- a/front/src/components/dashboard/sections/BudgetHero.tsx
+++ b/front/src/components/dashboard/sections/BudgetHero.tsx
@@ -30,7 +30,7 @@ interface SalaryForm {
 const BudgetHero = () => {
   const { from } = useDatePickerWrapperStore();
   const {
-    get: { data: dashboard, error },
+    get: { data: dashboard },
     mutation,
     remaining,
     monthlyTotal,
@@ -40,10 +40,6 @@ const BudgetHero = () => {
   const [hover, setHover] = useState<BarHover<number> | null>(null);
   const { register, handleSubmit, setFocus } = useForm<SalaryForm>();
   const { budgetHero: t } = dashboardText;
-
-  if (error) {
-    throw error;
-  }
 
   const initialAmount = Number(dashboard?.initialAmount ?? 0);
   const fixed = recurrings?.reduce((a, r) => a + Number(r.amount), 0) ?? 0;

--- a/front/src/components/dashboard/sections/CategoryBreakdown.tsx
+++ b/front/src/components/dashboard/sections/CategoryBreakdown.tsx
@@ -26,16 +26,12 @@ const FALLBACK_COLOR = CATEGORY_FALLBACK;
 /** Monthly category breakdown — stacked bar + list, click a row for details. */
 const CategoryBreakdown = () => {
   const { from } = useDatePickerWrapperStore();
-  const { data, error } = useCategoryTrends(MONTHLY);
+  const { data } = useCategoryTrends(MONTHLY);
   const trends = data?.trends;
   const { spendingsByMonth } = useSpendings();
   const [selected, setSelected] = useState<CategoryTrendPoint | null>(null);
   const [hover, setHover] = useState<BarHover<number> | null>(null);
   const { categoryBreakdown: t } = dashboardText;
-
-  if (error) {
-    throw error;
-  }
 
   const counts = useMemo(() => {
     const map = new Map<string, number>();

--- a/front/src/components/dashboard/sections/FixedExpenses.tsx
+++ b/front/src/components/dashboard/sections/FixedExpenses.tsx
@@ -40,13 +40,11 @@ const dayOf = (r: RecurringItem): number | null => {
 
 /** Fixed expenses (recurrings) — monthly/annualised totals + échéancier list. */
 const FixedExpenses = ({ month }: FixedExpensesProps) => {
-  const { recurrings, deleteRecurring, error } = useReccurings();
+  const { recurrings, deleteRecurring } = useReccurings();
   const { isModalVisible, spending, isEditing, addSpending, closeModal, editSpending } = useSpendingDayItem();
   const [invoiceFor, setInvoiceFor] = useState<RecurringItem | null>(null);
   const [pendingDelete, setPendingDelete] = useState<string | null>(null);
   const { fixedExpenses: t } = dashboardText;
-
-  if (error) throw error;
 
   const now = new Date();
   const viewingCurrentMonth = isSameMonth(month.start, now);

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -34,18 +34,15 @@ const WeeklyCeiling = () => {
   const { from } = useDatePickerWrapperStore();
   const { makeSlices, makeRange, isCurrentWeek } = useWeeklyStatsHelper();
   const {
-    get: { data: weeklyStats, error: wsError },
+    get: { data: weeklyStats },
     mutation,
   } = useWeeklyStats();
   const {
-    get: { data: dashboard, error: dbError },
+    get: { data: dashboard },
   } = useDashboard();
   const [editing, setEditing] = useState(false);
   const { register, handleSubmit, setFocus } = useForm<CeilingForm>();
   const { weeklyCeiling: t } = dashboardText;
-
-  if (wsError) throw wsError;
-  if (dbError) throw dbError;
 
   const now = new Date();
   const ceiling = dashboard ? Number(dashboard.initialCeiling) : 0;

--- a/front/src/components/exceptionals/Exceptionals.tsx
+++ b/front/src/components/exceptionals/Exceptionals.tsx
@@ -23,7 +23,7 @@ const Exceptionals = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const [editing, setEditing] = useState<ExceptionalItem | null>(null);
 
-  const { exceptionals, isLoading, error, years } = useExceptionals({
+  const { exceptionals, isLoading, years } = useExceptionals({
     year: selectedYear ?? undefined,
   });
   const { data: monthlyAverageData } = useRegularMonthlyAverage(selectedYear ?? currentYear);
@@ -70,10 +70,6 @@ const Exceptionals = () => {
     setModalOpen(false);
     setEditing(null);
   };
-
-  if (error) {
-    throw error;
-  }
 
   return (
     <div className="flex flex-col gap-4">

--- a/front/src/components/exceptionals/services/useExceptionals.ts
+++ b/front/src/components/exceptionals/services/useExceptionals.ts
@@ -1,7 +1,7 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import { displayPopup } from "@helpers/swalHelper";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import {
   ExceptionalListSchema,
   ExceptionalMutationPayloadSchema,
@@ -48,7 +48,6 @@ const useExceptionals = ({ year }: UseExceptionalsOptions = {}) => {
     queryFn: getExceptionals,
     retry: false,
     enabled: !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const getYears = async () => {
@@ -61,7 +60,6 @@ const useExceptionals = ({ year }: UseExceptionalsOptions = {}) => {
     queryFn: getYears,
     retry: false,
     enabled: !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const createExceptionalService = async (payload: ExceptionalMutationPayload) => {
@@ -114,7 +112,6 @@ const useExceptionals = ({ year }: UseExceptionalsOptions = {}) => {
   return {
     exceptionals: list.data ?? [],
     isLoading: list.isPending,
-    error: list.error,
     years: years.data ?? [],
     createExceptional,
     updateExceptional,

--- a/front/src/components/exceptionals/services/useRegularMonthlyAverage.ts
+++ b/front/src/components/exceptionals/services/useRegularMonthlyAverage.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { useQuery } from "@tanstack/react-query";
 import { z } from "zod";
 
@@ -21,11 +21,10 @@ const useRegularMonthlyAverage = (year: number) => {
   };
 
   return useQuery({
-    queryKey: ["regularMonthlyAverage", year],
+    queryKey: [QUERY_KEYS.REGULAR_MONTHLY_AVERAGE, year],
     queryFn: fetcher,
     retry: false,
     enabled: !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -65,10 +65,7 @@ const SpendingModal = ({
   const { user } = useAuth();
   const { createSpending, updateSpending } = useSpendings();
   const { recurrings, createRecurring, updateRecurring, copyRecurrings } = useReccurings();
-  const { categories, error: categoriesError } = useCategories();
-  if (categoriesError) {
-    throw categoriesError;
-  }
+  const { categories } = useCategories();
   // Per-category usage scoped to the current year to date (client-side "today",
   // cf COS-73) — ranks the "Fréquentes" quick-picks on recent habits, not
   // all-time cumulative usage (COS-137). Never blocks the modal: while stats load

--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -1,32 +1,3 @@
-export const QUERY_OPTIONS = {
-  refetchOnWindowFocus: false,
-  staleTime: 60 * 60 * 1000, // 1 hour
-};
-
-export const QUERY_KEYS = {
-  SPENDINGS_BY_MONTH: "spendingsByMonth",
-  RECURRINGS: "recurrings",
-  RECURRINGS_DRAWN: "recurringsDrawn",
-  INITIAL_AMOUNT: "initialAmount",
-  DASHBOARD: "dashboard",
-  DAILY_PROJECTION: "dailyProjection",
-  MONTHLY_INCOME: "monthlyIncome",
-  CATEGORY_TRENDS: "categoryTrends",
-  BUSIEST_WEEK: "busiestWeek",
-  SPENDING_PACE: "spendingPace",
-  WEEKLY_STATS: "weeklyStats",
-  DAILY_STATS: "dailyStats",
-  WEEKDAY_CATEGORIES: "weekdayCategories",
-  BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",
-  CATEGORIES: "categories",
-  CATEGORY_STATS: "categoryStats",
-  EXCEPTIONALS: "exceptionals",
-  EXCEPTIONAL_YEARS: "exceptionalYears",
-  SPENDINGS_SEARCH: "spendingsSearch",
-  SPENDINGS_YEARS: "spendingsYears",
-  LABEL_SUGGESTIONS: "labelSuggestions",
-};
-
 // Whole-history search (COS-114): minimum query length before the modal hits the
 // backend, kept in sync with the server-side guard.
 export const SEARCH_MIN_LENGTH = 2;

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -5,11 +5,11 @@ import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors
 import Spinner from "@components/common/Spinner";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { Dropzone } from "@components/shared/Dropzone";
-import { QUERY_KEYS } from "@components/spendings/config/constants";
 import InvoiceImageModal from "@components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal";
 import { Button } from "@components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@components/ui/dialog";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { cn } from "@lib/utils";
 import { useQueryClient } from "@tanstack/react-query";
 import texts from "@text/spendings";

--- a/front/src/components/spendings/services/useBusiestWeek.ts
+++ b/front/src/components/spendings/services/useBusiestWeek.ts
@@ -1,7 +1,8 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { DATE_FORMAT, QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { DATE_FORMAT } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { BusiestWeekResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
 import format from "date-fns/format";
@@ -35,7 +36,6 @@ const useBusiestWeek = () => {
     queryFn: getBusiestWeek,
     retry: false,
     enabled: !!monthBeginning && !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/services/useCategories.ts
+++ b/front/src/components/spendings/services/useCategories.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { CategoryListSchema, UpdateCategoryPayloadSchema } from "@src/schemas/categories";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -39,12 +39,11 @@ const useCategories = () => {
       throw e; // Re-throw pour que React Query gère l'erreur correctement
     }
   };
-  const { data: categories, error } = useQuery({
+  const { data: categories } = useQuery({
     queryKey: [QUERY_KEYS.CATEGORIES],
     queryFn: getCategoriesService,
     retry: 2, // Retry 2 fois en cas d'erreur
     enabled: !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const updateCategoryService = async (category: UpdateCategoryPayload) => {
@@ -93,7 +92,6 @@ const useCategories = () => {
 
   return {
     categories,
-    error,
     deleteCategory,
     updateCategory,
   };

--- a/front/src/components/spendings/services/useCategoryTrends.tsx
+++ b/front/src/components/spendings/services/useCategoryTrends.tsx
@@ -1,6 +1,7 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { DATE_FORMAT, MONTHLY, QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { DATE_FORMAT, MONTHLY } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { CategoryTrendsResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
@@ -89,7 +90,6 @@ const useCategoryTrends = (periodType: string) => {
     queryFn: getCategoryTrends,
     retry: false,
     enabled: !!range && !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/services/useDailyProjection.ts
+++ b/front/src/components/spendings/services/useDailyProjection.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { DailyProjectionSchema } from "@src/schemas/dashboard";
 import { useQuery } from "@tanstack/react-query";
@@ -38,7 +38,6 @@ const useDailyProjection = (): UseQueryResult<DailyProjection> => {
     queryFn: getDailyProjection,
     retry: false,
     enabled: isCurrentMonth && !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/services/useDashboard.ts
+++ b/front/src/components/spendings/services/useDashboard.ts
@@ -1,7 +1,7 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useInitialAmount from "@components/spendings/services/useInitialAmount";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { DashboardResponseSchema } from "@src/schemas/dashboard";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -66,7 +66,6 @@ const useDashboard = (): UseDashboard => {
     queryFn: getDashboard,
     retry: false,
     enabled: !!from && !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const totalOfMonth =

--- a/front/src/components/spendings/services/useInitialAmount.ts
+++ b/front/src/components/spendings/services/useInitialAmount.ts
@@ -1,7 +1,7 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { MonthlyStatsSchema } from "@src/schemas/dashboard";
 import { useQuery } from "@tanstack/react-query";
 import startOfMonth from "date-fns/startOfMonth";
@@ -32,7 +32,6 @@ const useInitialAmount = () => {
     queryFn: getInitialAmount,
     retry: false,
     enabled: !!from && !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/services/useLabelSuggestions.ts
+++ b/front/src/components/spendings/services/useLabelSuggestions.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { LabelSuggestionListSchema } from "@src/schemas/spendings";
 import { useQuery } from "@tanstack/react-query";
 
@@ -30,7 +30,10 @@ const useLabelSuggestions = (query: string, enabled = true): LabelSuggestion[] =
     queryFn: fetchSuggestions,
     enabled: enabled && !!userID,
     retry: false,
-    ...QUERY_OPTIONS,
+    // Autocomplete is a nice-to-have inside the spending modal — a failure just
+    // means no suggestions, never an error screen (opts out of the global
+    // throwOnError).
+    throwOnError: false,
   });
 
   return data ?? [];

--- a/front/src/components/spendings/services/useReccurings.ts
+++ b/front/src/components/spendings/services/useReccurings.ts
@@ -1,8 +1,8 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import { displayPopup } from "@helpers/swalHelper";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import {
   RecurringListSchema,
   RecurringMutationPayloadSchema,
@@ -54,12 +54,11 @@ const useReccurings = () => {
     return RecurringListSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.RECURRINGS, monthBeginning],
     queryFn: getRecurrings,
     retry: false,
     enabled: !!from && !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const queryClient = useQueryClient();
@@ -150,7 +149,6 @@ const useReccurings = () => {
   return {
     recurrings: data ?? [],
     isLoading: isPending,
-    error,
     deleteRecurring,
     createRecurring,
     updateRecurring,

--- a/front/src/components/spendings/services/useSpendingPace.ts
+++ b/front/src/components/spendings/services/useSpendingPace.ts
@@ -1,7 +1,8 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { DATE_FORMAT, QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { DATE_FORMAT } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { SpendingPaceResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
 import format from "date-fns/format";
@@ -35,7 +36,6 @@ const useSpendingPace = () => {
     queryFn: getSpendingPace,
     retry: false,
     enabled: !!monthBeginning && !!userID,
-    ...QUERY_OPTIONS,
   });
 };
 

--- a/front/src/components/spendings/services/useSpendingSearch.ts
+++ b/front/src/components/spendings/services/useSpendingSearch.ts
@@ -1,6 +1,7 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS, SEARCH_MIN_LENGTH } from "@components/spendings/config/constants";
+import { SEARCH_MIN_LENGTH } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { SpendingSearchPageSchema } from "@src/schemas/spendings";
 import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 
@@ -35,7 +36,10 @@ const useSpendingSearch = (query: string, year: number | null) => {
     placeholderData: keepPreviousData,
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
-    ...QUERY_OPTIONS,
+    // The modal surfaces failures inline (empty-state message) instead of the
+    // error boundary — a broken search must not take down the whole page (opts
+    // out of the global throwOnError).
+    throwOnError: false,
     // Keep the loaded pages around longer than the default 5 min so returning
     // to the modal (browser Back) after a detour restores the full list, not
     // just the first page (COS-114).

--- a/front/src/components/spendings/services/useSpendingYears.ts
+++ b/front/src/components/spendings/services/useSpendingYears.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { SpendingYearsSchema } from "@src/schemas/spendings";
 import { useQuery } from "@tanstack/react-query";
 
@@ -24,7 +24,9 @@ const useSpendingYears = () => {
     queryFn: fetchYears,
     enabled: !!userID,
     retry: false,
-    ...QUERY_OPTIONS,
+    // On failure the year chips simply don't render; the search modal surfaces
+    // its own errors inline (opts out of the global throwOnError).
+    throwOnError: false,
   });
 
   return data ?? [];

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -1,8 +1,8 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import { displayPopup } from "@helpers/swalHelper";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { SpendingListSchema, SpendingMutationPayloadSchema } from "@src/schemas/spendings";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import spendingsText from "@text/spendings";
@@ -57,7 +57,7 @@ const useSpendings = () => {
     return SpendingListSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.SPENDINGS_BY_MONTH, monthStart, monthEnd],
     queryFn: getSpendings,
     retry: false,
@@ -69,8 +69,6 @@ const useSpendings = () => {
     // hence this query to fail
     // so enable below
     enabled: !!from && !!to && !!userID,
-
-    ...QUERY_OPTIONS,
   });
 
   const spendingsByMonth = data;
@@ -180,7 +178,6 @@ const useSpendings = () => {
     spendingsByWeek,
     spendingsByMonth,
     isLoading: isPending,
-    error,
     deleteSpending,
     createSpending,
     updateSpending,

--- a/front/src/components/spendings/services/useWeeklyStats.ts
+++ b/front/src/components/spendings/services/useWeeklyStats.ts
@@ -1,8 +1,8 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useDashboard from "@components/spendings/services/useDashboard";
 import useRequestHelper from "@helpers/useRequestHelper";
+import { QUERY_KEYS } from "@lib/query/keys";
 import { WeeklyStatsSchema } from "@src/schemas/dashboard";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { endOfMonth } from "date-fns";
@@ -49,7 +49,6 @@ const useWeeklyStats = () => {
     queryFn: getWeeklyStats,
     retry: false,
     enabled: !!from && !!userID,
-    ...QUERY_OPTIONS,
   });
 
   const mutation = useMutation({

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -56,7 +56,7 @@ const SpendingView = () => {
 
   useEnsureWeekRange();
 
-  const { spendingsByWeek, isLoading, error } = useSpendings();
+  const { spendingsByWeek, isLoading } = useSpendings();
   const { get: dashboardQuery, remaining } = useDashboard();
   // Previous-week aggregates for the "vs sem. dernière" deltas (COS-35): the
   // per-category totals feed the breakdown trend arrows, `previousTotal` the
@@ -127,10 +127,6 @@ const SpendingView = () => {
   // Drop any pending scroll request when leaving the page so it can't fire on a
   // later visit (COS-38).
   useEffect(() => () => setScrollToDayIso(null), [setScrollToDayIso]);
-
-  if (error) {
-    throw error;
-  }
 
   if (!from || !to || !range) {
     return null;

--- a/front/src/components/statistics/services/useBiggestRegularExpense.tsx
+++ b/front/src/components/statistics/services/useBiggestRegularExpense.tsx
@@ -1,4 +1,4 @@
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { BiggestRegularExpenseResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
@@ -22,14 +22,13 @@ const useBiggestRegularExpense = ({ year }: UseBiggestRegularExpenseOptions) => 
     return BiggestRegularExpenseResponseSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.BIGGEST_REGULAR_EXPENSE, year],
     queryFn: getBiggestRegularExpense,
     retry: false,
-    ...QUERY_OPTIONS,
   });
 
-  return { biggestRegular: data?.expense ?? null, isLoading: isPending, error };
+  return { biggestRegular: data?.expense ?? null, isLoading: isPending };
 };
 
 export default useBiggestRegularExpense;

--- a/front/src/components/statistics/services/useDailyStats.tsx
+++ b/front/src/components/statistics/services/useDailyStats.tsx
@@ -1,4 +1,4 @@
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { DailyStatsResponseSchema } from "@src/schemas/stats";
 import { keepPreviousData as keepPreviousDataFn, useQuery } from "@tanstack/react-query";
@@ -27,16 +27,15 @@ const useDailyStats = ({ year, enabled = true, keepPreviousData = false }: UseDa
     return DailyStatsResponseSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.DAILY_STATS, year],
     queryFn: getDailyStats,
     retry: false,
     enabled,
     placeholderData: keepPreviousData ? keepPreviousDataFn : undefined,
-    ...QUERY_OPTIONS,
   });
 
-  return { dailyStats: data, isLoading: isPending, error };
+  return { dailyStats: data, isLoading: isPending };
 };
 
 export default useDailyStats;

--- a/front/src/components/statistics/services/useMonthlyIncome.tsx
+++ b/front/src/components/statistics/services/useMonthlyIncome.tsx
@@ -1,4 +1,4 @@
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { MonthlyIncomeResponseSchema } from "@src/schemas/dashboard";
 import { useQuery } from "@tanstack/react-query";
@@ -22,14 +22,13 @@ const useMonthlyIncome = ({ year }: UseMonthlyIncomeOptions) => {
     return MonthlyIncomeResponseSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.MONTHLY_INCOME, year],
     queryFn: getMonthlyIncome,
     retry: false,
-    ...QUERY_OPTIONS,
   });
 
-  return { monthlyIncome: data?.income, isLoading: isPending, error };
+  return { monthlyIncome: data?.income, isLoading: isPending };
 };
 
 export default useMonthlyIncome;

--- a/front/src/components/statistics/services/useRecurringsDrawn.tsx
+++ b/front/src/components/statistics/services/useRecurringsDrawn.tsx
@@ -1,4 +1,4 @@
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { RecurringsDrawnSchema } from "@src/schemas/spendings";
 import { useQuery } from "@tanstack/react-query";
@@ -23,14 +23,13 @@ const useRecurringsDrawn = ({ year, month }: UseRecurringsDrawnOptions) => {
     return RecurringsDrawnSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.RECURRINGS_DRAWN, year, month],
     queryFn: getDrawn,
     retry: false,
-    ...QUERY_OPTIONS,
   });
 
-  return { drawn: data?.drawn, isLoading: isPending, error };
+  return { drawn: data?.drawn, isLoading: isPending };
 };
 
 export default useRecurringsDrawn;

--- a/front/src/components/statistics/services/useStatistics.tsx
+++ b/front/src/components/statistics/services/useStatistics.tsx
@@ -1,5 +1,5 @@
-import { QUERY_OPTIONS } from "@components/spendings/config/constants";
 import useCategories from "@components/spendings/services/useCategories";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { StatisticsResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
@@ -23,18 +23,17 @@ const useStatistics = ({ years }: UseStatisticsOptions) => {
 
   const sortedYears = [...years].sort((a, b) => a - b);
   const yearsParam = sortedYears.join(",");
-  const queryKey = ["statistics", yearsParam, categoryIds.join(",")];
+  const queryKey = [QUERY_KEYS.STATISTICS, yearsParam, categoryIds.join(",")];
 
   const getStatistics = async (): Promise<StatisticsResponse> => {
     const response = await privateRequest(`/statistics?years=${yearsParam}&categories=${categoryIds.join(",")}`);
     return StatisticsResponseSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: queryKey,
     queryFn: getStatistics,
     retry: true,
-    ...QUERY_OPTIONS,
     enabled: categoryIds.length > 0 && sortedYears.length > 0,
   });
 
@@ -43,7 +42,6 @@ const useStatistics = ({ years }: UseStatisticsOptions) => {
     colors: data?.colors ?? {},
     categories: categories ?? [],
     isLoading: isPending,
-    error,
   };
 };
 

--- a/front/src/components/statistics/services/useWeekdayCategories.tsx
+++ b/front/src/components/statistics/services/useWeekdayCategories.tsx
@@ -1,4 +1,4 @@
-import { QUERY_KEYS, QUERY_OPTIONS } from "@components/spendings/config/constants";
+import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { WeekdayCategoriesResponseSchema } from "@src/schemas/stats";
 import { useQuery } from "@tanstack/react-query";
@@ -22,14 +22,13 @@ const useWeekdayCategories = ({ year }: UseWeekdayCategoriesOptions) => {
     return WeekdayCategoriesResponseSchema.parse(response.data);
   };
 
-  const { data, isPending, error } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: [QUERY_KEYS.WEEKDAY_CATEGORIES, year],
     queryFn: getWeekdayCategories,
     retry: false,
-    ...QUERY_OPTIONS,
   });
 
-  return { weekdayCategories: data, isLoading: isPending, error };
+  return { weekdayCategories: data, isLoading: isPending };
 };
 
 export default useWeekdayCategories;

--- a/front/src/lib/query/keys.ts
+++ b/front/src/lib/query/keys.ts
@@ -1,0 +1,29 @@
+// Central registry of React Query cache keys (COS-157). Every query key in the
+// app starts with one of these entries so cross-module invalidation (spendings
+// mutations refreshing dashboard/statistics caches…) never relies on magic
+// strings scattered across hooks.
+export const QUERY_KEYS = {
+  SPENDINGS_BY_MONTH: "spendingsByMonth",
+  RECURRINGS: "recurrings",
+  RECURRINGS_DRAWN: "recurringsDrawn",
+  INITIAL_AMOUNT: "initialAmount",
+  DASHBOARD: "dashboard",
+  DAILY_PROJECTION: "dailyProjection",
+  MONTHLY_INCOME: "monthlyIncome",
+  CATEGORY_TRENDS: "categoryTrends",
+  BUSIEST_WEEK: "busiestWeek",
+  SPENDING_PACE: "spendingPace",
+  WEEKLY_STATS: "weeklyStats",
+  DAILY_STATS: "dailyStats",
+  WEEKDAY_CATEGORIES: "weekdayCategories",
+  BIGGEST_REGULAR_EXPENSE: "biggestRegularExpense",
+  STATISTICS: "statistics",
+  CATEGORIES: "categories",
+  CATEGORY_STATS: "categoryStats",
+  EXCEPTIONALS: "exceptionals",
+  EXCEPTIONAL_YEARS: "exceptionalYears",
+  REGULAR_MONTHLY_AVERAGE: "regularMonthlyAverage",
+  SPENDINGS_SEARCH: "spendingsSearch",
+  SPENDINGS_YEARS: "spendingsYears",
+  LABEL_SUGGESTIONS: "labelSuggestions",
+};


### PR DESCRIPTION
Move QUERY_KEYS out of the spendings module into a shared front/src/lib/query/keys.ts (@lib/query/keys) so statistics, exceptionals and categories no longer depend on spendings. Fold the inline "regularMonthlyAverage" and "statistics" keys into it.

Dissolve QUERY_OPTIONS into the QueryClient defaultOptions.queries (refetchOnWindowFocus, staleTime 1h) and enable throwOnError by default; hooks keep only their own overrides (retry, enabled, gcTime, placeholderData). Drop the manual `if (error) throw error` guards from the components now that queries throw to the boundary on their own.

Search, label suggestions, category stats and spending years opt out of throwOnError locally: their UI degrades gracefully and must not trip the error screen. Expired sessions are unaffected — the 401 is absorbed in useRequestHelper before it ever reaches React Query (COS-26).