### PR TITLE
chore(prisma): declare the FK-implicit Spendings index

### DIFF
--- a/nest-api/prisma/schema.prisma
+++ b/nest-api/prisma/schema.prisma
@@ -49,6 +49,10 @@ model Spendings {
   currency   String?     @db.VarChar(3)
   invoicefile String?    @db.VarChar(255)
   category   Categories? @relation(fields: [categoryID], references: [ID])
+
+  // MySQL auto-creates this index with the FK constraint; declaring it (same
+  // name) keeps `migrate diff` clean instead of reporting it as drift forever.
+  @@index([categoryID], map: "Spendings_categoryID_fkey")
 }
 
 model Exceptionals {


### PR DESCRIPTION
MySQL auto-creates an index named after the FK constraint (Spendings_categoryID_fkey); the schema not declaring it made every 'migrate diff' against a live database report it as drift. Declaring it with the same name makes the diff empty. No migration needed — the index already exists everywhere the FK does.