### PR TITLE
fix(navbar): account block in drawer (COS-163)

### DIFF
--- a/front/src/components/shared/navBar/NavBar.tsx
+++ b/front/src/components/shared/navBar/NavBar.tsx
@@ -9,6 +9,7 @@ import Wordmark from "@components/shared/brand/Wordmark";
 import { ROUTES } from "@components/shared/config/constants";
 import useGlobalStore from "@components/shared/globalStore";
 import { IconButton } from "@components/shared/IconButton";
+import DrawerAccountSection from "@components/shared/navBar/userMenu/DrawerAccountSection";
 import UserMenu from "@components/shared/navBar/userMenu/UserMenu";
 import {
   buildDashboardPath,
@@ -233,17 +234,22 @@ const NavBar = () => {
               </div>
             )
           )}
-          <UserMenu />
+          {/* Below lg the same actions live at the bottom of the drawer (COS-163). */}
+          <div className="hidden lg:block">
+            <UserMenu />
+          </div>
         </div>
 
         {isDashboard ? (
-          <div className="flex w-full items-center gap-2 md:hidden">
+          <div className="flex w-full flex-col gap-2 md:hidden">
+            {/* Stacked like the Dépenses variant below: side by side, the button
+                overflowed the viewport on narrow screens (COS-163). */}
             <MonthSelector />
             <button
               type="button"
               onClick={goToCurrentMonth}
               disabled={currentMonthDisabled}
-              className={currentMonthButtonClass}
+              className={cn(currentMonthButtonClass, "self-start")}
             >
               {text.currentMonth}
             </button>
@@ -310,6 +316,10 @@ const NavBar = () => {
             );
           })}
         </nav>
+        <DrawerAccountSection
+          drawerOpen={drawerOpen}
+          onNavigate={() => setDrawerOpen(false)}
+        />
       </aside>
     </>
   );

--- a/front/src/components/shared/navBar/userMenu/AccountAvatar.tsx
+++ b/front/src/components/shared/navBar/userMenu/AccountAvatar.tsx
@@ -1,0 +1,20 @@
+import { cn } from "@lib/utils";
+
+type AccountAvatarProps = {
+  initials: string;
+  className?: string;
+};
+
+/** Initials chip, shared by the desktop dropdown trigger and the drawer account block. */
+const AccountAvatar = ({ initials, className }: AccountAvatarProps) => (
+  <span
+    className={cn(
+      "grid size-[30px] flex-shrink-0 place-items-center rounded-full border border-line bg-surface-hi text-2xs font-medium text-ink-2",
+      className,
+    )}
+  >
+    {initials}
+  </span>
+);
+
+export default AccountAvatar;

--- a/front/src/components/shared/navBar/userMenu/DrawerAccountSection.tsx
+++ b/front/src/components/shared/navBar/userMenu/DrawerAccountSection.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import AccountAvatar from "@components/shared/navBar/userMenu/AccountAvatar";
+import useAccountActions from "@components/shared/navBar/userMenu/useAccountActions";
+import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@i18n/config";
+import useTranslations from "@i18n/useTranslations";
+import { cn } from "@lib/utils";
+import { Check, ChevronDown, Globe, KeyRound, LogOut } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// Mirrors the drawer nav links so the account rows read as part of the same list.
+const DRAWER_ROW =
+  "flex w-full cursor-pointer items-center gap-2.5 rounded-md px-3 py-2.5 text-sm font-medium text-ink-3 transition-colors hover:bg-white/[0.05] hover:text-ink";
+
+type DrawerAccountSectionProps = {
+  drawerOpen: boolean;
+  onNavigate: () => void;
+};
+
+/**
+ * Mobile-only account block, pinned to the bottom of the drawer (`mt-auto`).
+ * Below `lg` the header dropdown is hidden: its nested "Langue" submenu had no
+ * room to open next to a panel already glued to the screen edge, so it rendered
+ * off-screen (COS-163).
+ *
+ * Standard bottom-of-sidebar pattern: one compact trigger row (avatar + email +
+ * chevron) sitting at the very bottom, collapsed by default; tapping it unfolds
+ * the actions above it, with the locales listed flat — no nested submenu.
+ */
+const DrawerAccountSection = ({ drawerOpen, onNavigate }: DrawerAccountSectionProps) => {
+  const { email, initials, locale, updateLanguage, goToChangePassword, logout } = useAccountActions();
+  const text = useTranslations("navBar");
+  const [expanded, setExpanded] = useState(false);
+
+  // The drawer stays mounted while closed (it slides off-screen), so fold the
+  // menu back when it closes; reopening always starts from the compact row.
+  useEffect(() => {
+    if (!drawerOpen) setExpanded(false);
+  }, [drawerOpen]);
+
+  const handleChangePassword = () => {
+    goToChangePassword();
+    onNavigate();
+  };
+
+  return (
+    <div className="mt-auto flex flex-col gap-0.5 border-t border-white/[0.07] pt-2">
+      {expanded && (
+        <>
+          <button
+            type="button"
+            onClick={handleChangePassword}
+            className={DRAWER_ROW}
+          >
+            <KeyRound className="size-4 text-primary" />
+            {text.userMenu.changePassword}
+          </button>
+
+          <div className="flex items-center gap-2.5 px-3 pt-2 pb-1 text-2xs font-medium uppercase tracking-caps text-ink-4">
+            <Globe className="size-4 text-primary" />
+            {text.userMenu.language}
+          </div>
+          {SUPPORTED_LOCALES.map((availableLocale) => {
+            const isActive = availableLocale === locale;
+            return (
+              <button
+                key={availableLocale}
+                type="button"
+                aria-pressed={isActive}
+                onClick={() => updateLanguage(availableLocale)}
+                className={cn(DRAWER_ROW, "pl-10", isActive && "text-ink")}
+              >
+                {LOCALE_LABELS[availableLocale]}
+                {isActive && <Check className="ml-auto size-4 text-primary" />}
+              </button>
+            );
+          })}
+
+          <button
+            type="button"
+            onClick={logout}
+            className={DRAWER_ROW}
+          >
+            <LogOut className="size-4 text-ink-3" />
+            {text.userMenu.logout}
+          </button>
+        </>
+      )}
+
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((current) => !current)}
+        className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-1.5 py-2 transition-colors hover:bg-white/[0.05]"
+      >
+        <AccountAvatar initials={initials} />
+        <span className="truncate text-sm text-ink-2">{email}</span>
+        <ChevronDown
+          className={cn(
+            "ml-auto size-4 flex-shrink-0 text-ink-4 transition-transform duration-200",
+            // Menu unfolds upward, so the closed chevron points up and flips down once open.
+            expanded ? "rotate-0" : "rotate-180",
+          )}
+        />
+      </button>
+    </div>
+  );
+};
+
+export default DrawerAccountSection;

--- a/front/src/components/shared/navBar/userMenu/UserMenu.tsx
+++ b/front/src/components/shared/navBar/userMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useAuth } from "@auth/context/AuthContext";
-import { ROUTES } from "@components/shared/config/constants";
+import AccountAvatar from "@components/shared/navBar/userMenu/AccountAvatar";
+import useAccountActions from "@components/shared/navBar/userMenu/useAccountActions";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,52 +12,23 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@components/ui/dropdown-menu";
-import useRequestHelper from "@helpers/useRequestHelper";
 import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@i18n/config";
-import { useLocale } from "@i18n/LocaleContext";
 import useTranslations from "@i18n/useTranslations";
-import useUpdateLanguage from "@i18n/useUpdateLanguage";
 import { Check, ChevronDown, Globe, KeyRound, LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
 
-const initialsFromEmail = (email?: string): string => {
-  if (!email) return "?";
-  const local = email.split("@")[0] ?? "";
-  const parts = local.split(/[.\-_]+/).filter(Boolean);
-  const letters = parts.length >= 2 ? `${parts[0][0]}${parts[1][0]}` : local.slice(0, 2);
-  return (letters || "?").toUpperCase();
-};
-
+/**
+ * Desktop-only (≥ lg): below that breakpoint the same actions live at the bottom
+ * of the mobile drawer, where a nested submenu has no room to open (COS-163).
+ */
 const UserMenu = () => {
-  const { user } = useAuth();
-  const { privateRequest } = useRequestHelper();
-  const { locale } = useLocale();
-  const { updateLanguage } = useUpdateLanguage();
+  const { email, initials, locale, updateLanguage, goToChangePassword, logout } = useAccountActions();
   const text = useTranslations("navBar");
-  const router = useRouter();
-
-  const handleLogout = async () => {
-    try {
-      await privateRequest("/users/logout", { method: "POST" });
-    } catch {
-      // Session may already be expired.
-    } finally {
-      // A full-document navigation tears down the React tree, the auth context and the
-      // React Query cache on its own, then re-runs the server `(private)` guard — the same
-      // hard-redirect path as `redirectToLogin`. Clearing that client state here first would
-      // only repaint the current page with emptied data (a flash of the blank dashboard)
-      // before the browser leaves, so we navigate straight away.
-      window.location.replace(ROUTES.login.path);
-    }
-  };
 
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="group flex cursor-pointer items-center gap-2.5 rounded-md outline-hidden">
-        <span className="grid size-[30px] flex-shrink-0 place-items-center rounded-full border border-line bg-surface-hi text-2xs font-medium text-ink-2">
-          {initialsFromEmail(user?.email)}
-        </span>
-        <span className="hidden max-w-[200px] truncate text-sm text-ink-2 xl:inline">{user?.email}</span>
+        <AccountAvatar initials={initials} />
+        <span className="hidden max-w-[200px] truncate text-sm text-ink-2 xl:inline">{email}</span>
         <ChevronDown className="size-4 flex-shrink-0 text-ink-4 transition-transform duration-200 group-data-[state=open]:rotate-180" />
       </DropdownMenuTrigger>
       <DropdownMenuContent
@@ -68,7 +39,7 @@ const UserMenu = () => {
         className="w-64 p-1"
       >
         <DropdownMenuItem
-          onClick={() => router.push(ROUTES.changePassword.path)}
+          onClick={goToChangePassword}
           className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2"
         >
           <KeyRound className="size-4 text-primary" />
@@ -98,7 +69,7 @@ const UserMenu = () => {
         </DropdownMenuSub>
         <DropdownMenuSeparator className="my-1" />
         <DropdownMenuItem
-          onClick={handleLogout}
+          onClick={logout}
           className="cursor-pointer gap-3 px-3 py-2.5 text-sm text-ink-2"
         >
           <LogOut className="size-4 text-ink-3" />

--- a/front/src/components/shared/navBar/userMenu/useAccountActions.ts
+++ b/front/src/components/shared/navBar/userMenu/useAccountActions.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useAuth } from "@auth/context/AuthContext";
+import { ROUTES } from "@components/shared/config/constants";
+import useRequestHelper from "@helpers/useRequestHelper";
+import { useLocale } from "@i18n/LocaleContext";
+import useUpdateLanguage from "@i18n/useUpdateLanguage";
+import { useRouter } from "next/navigation";
+
+const initialsFromEmail = (email?: string): string => {
+  if (!email) return "?";
+  const local = email.split("@")[0] ?? "";
+  const parts = local.split(/[.\-_]+/).filter(Boolean);
+  const letters = parts.length >= 2 ? `${parts[0][0]}${parts[1][0]}` : local.slice(0, 2);
+  return (letters || "?").toUpperCase();
+};
+
+/**
+ * Account identity + actions shared by the two places they are exposed: the
+ * desktop dropdown (`UserMenu`) and the mobile drawer section
+ * (`DrawerAccountSection`). Both must behave identically, so the logout and the
+ * locale switch live here rather than in either component (COS-163).
+ */
+const useAccountActions = () => {
+  const { user } = useAuth();
+  const { privateRequest } = useRequestHelper();
+  const { locale } = useLocale();
+  const { updateLanguage } = useUpdateLanguage();
+  const router = useRouter();
+
+  const logout = async () => {
+    try {
+      await privateRequest("/users/logout", { method: "POST" });
+    } catch {
+      // Session may already be expired.
+    } finally {
+      // A full-document navigation tears down the React tree, the auth context and the
+      // React Query cache on its own, then re-runs the server `(private)` guard — the same
+      // hard-redirect path as `redirectToLogin`. Clearing that client state here first would
+      // only repaint the current page with emptied data (a flash of the blank dashboard)
+      // before the browser leaves, so we navigate straight away.
+      window.location.replace(ROUTES.login.path);
+    }
+  };
+
+  const goToChangePassword = () => router.push(ROUTES.changePassword.path);
+
+  return {
+    email: user?.email,
+    initials: initialsFromEmail(user?.email),
+    locale,
+    updateLanguage,
+    goToChangePassword,
+    logout,
+  };
+};
+
+export default useAccountActions;


### PR DESCRIPTION
The "Langue" entry of the user menu was a Radix submenu. On mobile the w-64 panel is glued to the right edge, leaving room on neither side, so the sub-panel flipped left and rendered off-screen — changing the language was impossible there.

Below lg the header trigger is now hidden and the account lives at the bottom of the drawer, following the usual sidebar pattern: a compact avatar + email + chevron row pinned by `mt-auto`, collapsed by default, unfolding upward. The locales are listed flat, so no nested submenu is involved at all. The block re-collapses when the drawer closes, since the drawer stays mounted and merely slides off-screen.

Logout, the change-password navigation and the locale switch move to a shared `useAccountActions` hook, and the initials chip to `AccountAvatar`, so the desktop dropdown and the drawer cannot drift apart. Desktop is unchanged.

Also stacks the Dashboard's mobile month controls: side by side, the "Mois en cours" button overflowed the viewport on narrow screens. The Dépenses variant was already stacked; this aligns the two.