### PR TITLE
fix(spendings): steady label suggestions (COS-159)

### DIFF
--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -16,6 +16,11 @@ interface LabelFieldProps {
   setLabelQuery: Dispatch<SetStateAction<string>>;
 }
 
+// Shared by the real chips and the invisible placeholder, so an empty row keeps
+// the exact same height as a filled one (COS-159).
+const CHIP_CLASSNAME =
+  "min-w-0 shrink truncate rounded-md border border-line bg-surface-hi px-2 py-1 text-2xs text-ink-2";
+
 const LabelField = ({
   register,
   errors,
@@ -25,6 +30,8 @@ const LabelField = ({
   setLabelQuery,
 }: LabelFieldProps) => {
   const spendings = useTranslations("spendings");
+  // Suggestions are spending-specific, hidden for recurrings.
+  const suggestions = asRecurring ? [] : labelSuggestions;
 
   return (
     <div className="flex flex-col gap-2">
@@ -42,23 +49,35 @@ const LabelField = ({
           onChange: (e) => setLabelQuery(e.target.value),
         })}
       />
-      {errors.spendingLabel && <p className="text-xs text-neg">{errors.spendingLabel.message}</p>}
-      {/* Suggestions are spending-specific, hidden for recurrings. */}
-      {!asRecurring && labelSuggestions.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {labelSuggestions.map((s) => (
+      {/* Always mounted: an error appearing must not push the rest of the modal down. */}
+      <p className="min-h-4 text-xs text-neg">{errors.spendingLabel?.message}</p>
+      {/*
+        Suggestion row: always mounted and always one line high (no wrap, chips
+        truncate), so the dialog keeps a constant height while typing — the list
+        shrinks and grows on every keystroke (COS-159).
+      */}
+      <div className="flex gap-1.5">
+        {suggestions.length > 0 ? (
+          suggestions.map((s) => (
             <button
               key={s.label}
               type="button"
               onClick={() => applySuggestion(s)}
-              className="rounded-md border border-line bg-surface-hi px-2 py-1 text-2xs text-ink-2 transition-colors hover:border-ink-4 hover:text-ink"
+              className={`${CHIP_CLASSNAME} cursor-pointer transition-colors hover:border-ink-4 hover:text-ink`}
             >
               {s.label}
               {s.category && <span className="text-ink-4"> — {s.category}</span>}
             </button>
-          ))}
-        </div>
-      )}
+          ))
+        ) : (
+          <span
+            aria-hidden
+            className={`${CHIP_CLASSNAME} invisible`}
+          >
+            &nbsp;
+          </span>
+        )}
+      </div>
     </div>
   );
 };

--- a/front/src/components/spendings/services/useLabelSuggestions.ts
+++ b/front/src/components/spendings/services/useLabelSuggestions.ts
@@ -2,7 +2,7 @@ import { useAuth } from "@auth/context/AuthContext";
 import useRequestHelper from "@helpers/useRequestHelper";
 import { QUERY_KEYS } from "@lib/query/keys";
 import { LabelSuggestionListSchema } from "@src/schemas/spendings";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
 import type { LabelSuggestion } from "@src/schemas/spendings";
 
@@ -10,7 +10,8 @@ import type { LabelSuggestion } from "@src/schemas/spendings";
  * Label autocomplete for the spending modal (COS-23): the user's own past
  * spending labels ranked by frequency and filtered by the typed prefix, each
  * with its most-used category so selecting one can pre-fill it. An empty query
- * returns the most frequent labels (shown on open). Hits
+ * — or a prefix matching nothing — returns the most frequent labels, so the row
+ * is never empty as long as the user has history (COS-159). Hits
  * `GET /spendings/label-suggestions`. Debouncing is the caller's job; pass
  * `enabled: false` (recurrings never show suggestions) to skip the request.
  */
@@ -30,6 +31,9 @@ const useLabelSuggestions = (query: string, enabled = true): LabelSuggestion[] =
     queryFn: fetchSuggestions,
     enabled: enabled && !!userID,
     retry: false,
+    // Keep the previous chips on screen while the next query is in flight:
+    // an empty gap between two keystrokes would flicker the row (COS-159).
+    placeholderData: keepPreviousData,
     // Autocomplete is a nice-to-have inside the spending modal — a failure just
     // means no suggestions, never an error screen (opts out of the global
     // throwOnError).

--- a/nest-api/src/spendings/spendings.service.spec.ts
+++ b/nest-api/src/spendings/spendings.service.spec.ts
@@ -266,7 +266,7 @@ describe("SpendingsService.getSpendingYears", () => {
  * Unit tests for SpendingsService.getLabelSuggestions — the label autocomplete
  * backing the spending modal's chip row (COS-23). Prisma is mocked, so these
  * assert the query shape and the JS aggregation (frequency ranking, dominant
- * category, exact-match exclusion, cap) without touching the DB.
+ * category, empty-result fallback, cap) without touching the DB.
  */
 describe("SpendingsService.getLabelSuggestions", () => {
   const makeService = (groupByResult: unknown[], categoriesResult: unknown[] = []) => {
@@ -359,7 +359,7 @@ describe("SpendingsService.getLabelSuggestions", () => {
     expect(result).toEqual([{ label: "Pharmacie", category: "santé" }]);
   });
 
-  it("excludes the exact current input (case-insensitive)", async () => {
+  it("keeps the label equal to the current input (COS-159: the chip row must not empty out)", async () => {
     const { service } = makeService([
       { label: "Monoprix", categoryID: null, _count: 3 },
       { label: "Monoprix Express", categoryID: null, _count: 1 },
@@ -367,7 +367,39 @@ describe("SpendingsService.getLabelSuggestions", () => {
 
     const result = await service.getLabelSuggestions("monoprix", "user-1");
 
-    expect(result).toEqual([{ label: "Monoprix Express", category: null }]);
+    expect(result).toEqual([
+      { label: "Monoprix", category: null },
+      { label: "Monoprix Express", category: null },
+    ]);
+  });
+
+  it("falls back to the global ranking when the prefix matches nothing", async () => {
+    const { service, groupBy } = makeService([]);
+    groupBy.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      { label: "Monoprix", categoryID: null, _count: 3 },
+      { label: "Uber", categoryID: null, _count: 1 },
+    ]);
+
+    const result = await service.getLabelSuggestions("zzz", "user-1");
+
+    expect(groupBy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ where: { userID: "user-1", label: { startsWith: "zzz" } } }),
+    );
+    // Second pass drops the label predicate → most frequent labels overall.
+    expect(groupBy).toHaveBeenNthCalledWith(2, expect.objectContaining({ where: { userID: "user-1" } }));
+    expect(result).toEqual([
+      { label: "Monoprix", category: null },
+      { label: "Uber", category: null },
+    ]);
+  });
+
+  it("does not re-query when the empty query itself yields nothing", async () => {
+    const { service, groupBy } = makeService([]);
+
+    await expect(service.getLabelSuggestions("", "user-1")).resolves.toEqual([]);
+
+    expect(groupBy).toHaveBeenCalledTimes(1);
   });
 
   it("breaks frequency ties alphabetically", async () => {

--- a/nest-api/src/spendings/spendings.service.ts
+++ b/nest-api/src/spendings/spendings.service.ts
@@ -348,21 +348,28 @@ export class SpendingsService {
   // past spending labels ranked by how often they've used each, filtered by the
   // typed prefix, each carrying its most-used category so selecting one can
   // pre-fill the category. An empty query returns the most frequent labels (shown
-  // when the field is empty); the exact current input is excluded so we never
-  // suggest what's already fully typed. Category resolution honors the owned-or-
-  // global rule used across the app; a label only ever used uncategorized yields a
-  // null category.
+  // when the field is empty), and a prefix matching nothing falls back to that
+  // same global ranking: the modal's chip row must never go empty, since an
+  // appearing/disappearing row resizes the dialog mid-typing (COS-159). The label
+  // equal to the current input is kept for the same reason — clicking it still
+  // pre-fills the category. Category resolution honors the owned-or-global rule
+  // used across the app; a label only ever used uncategorized yields a null
+  // category.
   async getLabelSuggestions(query: string, userID: string): Promise<SpendingLabelSuggestion[]> {
     const q = query.trim();
     // Escape LIKE metacharacters so a literal % or _ in the prefix matches
     // literally instead of acting as a wildcard (same guard as searchSpendings).
     const escaped = q.replace(/[\\%_]/g, "\\$&");
 
-    const grouped = await this.prisma.spendings.groupBy({
-      by: ["label", "categoryID"],
-      where: { userID, ...(q ? { label: { startsWith: escaped } } : {}) },
-      _count: true,
-    });
+    const groupLabels = (prefix?: string) =>
+      this.prisma.spendings.groupBy({
+        by: ["label", "categoryID"],
+        where: { userID, ...(prefix ? { label: { startsWith: prefix } } : {}) },
+        _count: true,
+      });
+
+    const matched = await groupLabels(q ? escaped : undefined);
+    const grouped = q && matched.length === 0 ? await groupLabels() : matched;
 
     // Fold the (label, category) groups into one bucket per label: total uses,
     // plus — among the categorized uses only — the tally per category.
@@ -376,11 +383,9 @@ export class SpendingsService {
       buckets.set(group.label, bucket);
     }
 
-    // Rank by total use (then alphabetically), drop the exact current input, and
-    // keep the top few — the modal shows a small chip row.
-    const qLower = q.toLowerCase();
+    // Rank by total use (then alphabetically) and keep the top few — the modal
+    // shows a small chip row.
     const ranked = [...buckets.entries()]
-      .filter(([label]) => label.toLowerCase() !== qLower)
       .sort((a, b) => b[1].total - a[1].total || a[0].localeCompare(b[0]))
       .slice(0, LABEL_SUGGESTIONS_LIMIT);
 


### PR DESCRIPTION
The chip row under the modal's label field appeared, shrank and vanished while typing, resizing the dialog on every keystroke.

Back: getLabelSuggestions no longer drops the label equal to the current input, and falls back to the global frequency ranking when the prefix matches nothing — the row never comes back empty.

Front: the row is always mounted (invisible placeholder chip when there is nothing to show) and always one line high — no wrap, chips truncate. The label error message keeps its space too, and the query keeps the previous data during the debounced refetch.