### PR TITLE
fix(spendings): label field error line (COS-164)

### DIFF
--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -143,6 +143,7 @@ const SpendingModal = ({
     handleSubmit,
     getValues,
     setValue,
+    clearErrors,
     formState: { errors, isSubmitting },
   } = useForm<SpendingForm>({
     resolver: zodResolver(makeSpendingSchema(spendings.modal.validation)),
@@ -217,7 +218,8 @@ const SpendingModal = ({
 
           <LabelField
             register={register}
-            errors={errors}
+            error={errors.spendingLabel?.message}
+            clearErrors={clearErrors}
             asRecurring={asRecurring}
             labelSuggestions={labelSuggestions}
             applySuggestion={applySuggestion}
@@ -226,7 +228,7 @@ const SpendingModal = ({
 
           <AmountField
             register={register}
-            errors={errors}
+            error={errors.spendingAmount?.message}
           />
 
           {/* Category is hidden for recurrings: the backend/DB have no notion of

--- a/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/AmountField.tsx
@@ -2,21 +2,22 @@ import { FieldShell } from "@components/shared/FieldShell";
 import useTranslations from "@i18n/useTranslations";
 
 import type { SpendingForm } from "@components/spendings/common/spendingModal/schema";
-import type { FieldErrors, UseFormRegister } from "react-hook-form";
+import type { UseFormRegister } from "react-hook-form";
 
 interface AmountFieldProps {
   register: UseFormRegister<SpendingForm>;
-  errors: FieldErrors<SpendingForm>;
+  /** Message string, not RHF's in-place-mutated `errors` object — see LabelField (COS-164). */
+  error: string | undefined;
 }
 
-const AmountField = ({ register, errors }: AmountFieldProps) => {
+const AmountField = ({ register, error }: AmountFieldProps) => {
   const spendings = useTranslations("spendings");
 
   return (
     <FieldShell
       label={spendings.modal.fields.amount}
       htmlFor="spendingAmount"
-      error={errors.spendingAmount?.message}
+      error={error}
     >
       <div className="flex items-baseline gap-2 rounded-md border border-line bg-surface-base px-3 py-2.5 transition-colors focus-within:border-accent-d">
         <input

--- a/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/LabelField.tsx
@@ -5,11 +5,17 @@ import useTranslations from "@i18n/useTranslations";
 import type { SpendingForm } from "@components/spendings/common/spendingModal/schema";
 import type { LabelSuggestion } from "@src/schemas/spendings";
 import type { Dispatch, SetStateAction } from "react";
-import type { FieldErrors, UseFormRegister } from "react-hook-form";
+import type { UseFormClearErrors, UseFormRegister } from "react-hook-form";
 
 interface LabelFieldProps {
   register: UseFormRegister<SpendingForm>;
-  errors: FieldErrors<SpendingForm>;
+  /**
+   * The error message, not RHF's `errors` object: RHF mutates that object in
+   * place, so its reference never changes and the memoized field would skip the
+   * re-render that shows/hides the error (COS-164).
+   */
+  error: string | undefined;
+  clearErrors: UseFormClearErrors<SpendingForm>;
   asRecurring: boolean;
   labelSuggestions: LabelSuggestion[];
   applySuggestion: (suggestion: LabelSuggestion) => void;
@@ -23,7 +29,8 @@ const CHIP_CLASSNAME =
 
 const LabelField = ({
   register,
-  errors,
+  error,
+  clearErrors,
   asRecurring,
   labelSuggestions,
   applySuggestion,
@@ -35,48 +42,72 @@ const LabelField = ({
 
   return (
     <div className="flex flex-col gap-2">
-      <Label
-        htmlFor="spendingLabel"
-        className="text-sm text-ink-2"
-      >
-        {spendings.modal.fields.label}
-      </Label>
-      <TextInput
-        id="spendingLabel"
-        placeholder={spendings.modal.fields.labelPlaceholder}
-        className="dark:bg-surface-base"
-        {...register("spendingLabel", {
-          onChange: (e) => setLabelQuery(e.target.value),
-        })}
-      />
-      {/* Always mounted: an error appearing must not push the rest of the modal down. */}
-      <p className="min-h-4 text-xs text-neg">{errors.spendingLabel?.message}</p>
       {/*
-        Suggestion row: always mounted and always one line high (no wrap, chips
-        truncate), so the dialog keeps a constant height while typing — the list
-        shrinks and grows on every keystroke (COS-159).
+        The error rides on the field's label line — a line that always exists and
+        is taller than the message, so showing it costs no extra height (COS-164).
       */}
-      <div className="flex gap-1.5">
-        {suggestions.length > 0 ? (
-          suggestions.map((s) => (
-            <button
-              key={s.label}
-              type="button"
-              onClick={() => applySuggestion(s)}
-              className={`${CHIP_CLASSNAME} cursor-pointer transition-colors hover:border-ink-4 hover:text-ink`}
-            >
-              {s.label}
-              {s.category && <span className="text-ink-4"> — {s.category}</span>}
-            </button>
-          ))
-        ) : (
-          <span
-            aria-hidden
-            className={`${CHIP_CLASSNAME} invisible`}
+      <div className="flex items-baseline justify-between gap-2">
+        <Label
+          htmlFor="spendingLabel"
+          className="text-sm text-ink-2"
+        >
+          {spendings.modal.fields.label}
+        </Label>
+        {error && (
+          <p
+            id="spendingLabel-error"
+            className="min-w-0 truncate text-xs text-neg"
           >
-            &nbsp;
-          </span>
+            {error}
+          </p>
         )}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <TextInput
+          id="spendingLabel"
+          placeholder={spendings.modal.fields.labelPlaceholder}
+          className="dark:bg-surface-base"
+          aria-invalid={!!error}
+          aria-describedby={error ? "spendingLabel-error" : undefined}
+          {...register("spendingLabel", {
+            onChange: (e) => {
+              const value = e.target.value;
+              setLabelQuery(value);
+              // The zod resolver is async, so waiting for it to clear the error
+              // leaves the message on screen for a keystroke. Any non-empty
+              // value already satisfies the only rule on this field, so drop it
+              // synchronously here (COS-164).
+              if (value) clearErrors("spendingLabel");
+            },
+          })}
+        />
+        {/*
+          Suggestion row: always mounted and always one line high (no wrap, chips
+          truncate), so the dialog keeps a constant height while typing — the list
+          shrinks and grows on every keystroke (COS-159).
+        */}
+        <div className="flex gap-1.5">
+          {suggestions.length > 0 ? (
+            suggestions.map((s) => (
+              <button
+                key={s.label}
+                type="button"
+                onClick={() => applySuggestion(s)}
+                className={`${CHIP_CLASSNAME} cursor-pointer transition-colors hover:border-ink-4 hover:text-ink`}
+              >
+                {s.label}
+                {s.category && <span className="text-ink-4"> — {s.category}</span>}
+              </button>
+            ))
+          ) : (
+            <span
+              aria-hidden
+              className={`${CHIP_CLASSNAME} invisible`}
+            >
+              &nbsp;
+            </span>
+          )}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
L'espace d'erreur reserve sous l'input du libelle laissait un trou permanent entre le champ et la rangee de suggestions. Le message remonte sur la ligne du label du champ, a droite de l'intitule et tronque : cette ligne existe deja, donc la modal ne gagne aucune hauteur quand l'erreur apparait (acquis de COS-159 preserve).

La rangee de suggestions devient le seul emplacement reserve sous l'input, et son espacement est resserre pour que les chips se lisent comme rattachees au champ.

Les champs recoivent desormais le message d'erreur (string) au lieu de l'objet `errors` de react-hook-form : cet objet est mute en place, sa reference ne change jamais, donc les composants memoises ne se re-rendaient qu'au re-render suivant du parent — l'erreur apparaissait et disparaissait en retard, cale sur le debounce des suggestions. Le handler de saisie efface aussi l'erreur de facon synchrone, sans attendre le resolver zod qui est asynchrone.

Accessibilite : `aria-invalid` et `aria-describedby` sur l'input.