### PR TITLE
refactor(front): types & zod quick-wins (COS-107)

### DIFF
--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -12,9 +12,9 @@ import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "
 import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover";
 import { zodResolver } from "@hookform/resolvers/zod";
 import useTranslations from "@i18n/useTranslations";
+import evaluateAmountExpression from "@lib/amountExpression";
 import format from "date-fns/format";
 import { Check, ChevronsUpDown } from "lucide-react";
-import Mexp from "math-expression-evaluator";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -107,18 +107,8 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
       return;
     }
 
-    let amountEvaluated: number;
-    try {
-      const mexp = new Mexp();
-      const lexed = mexp.lex(values.amount.trim());
-      const postfixed = mexp.toPostfix(lexed);
-      amountEvaluated = mexp.postfixEval(postfixed);
-    } catch (error) {
-      console.error("Invalid amount expression", error);
-      return;
-    }
-
-    if (Number.isNaN(amountEvaluated)) {
+    const amountEvaluated = evaluateAmountExpression(values.amount);
+    if (amountEvaluated === null) {
       return;
     }
 

--- a/front/src/components/exceptionals/helpers/__tests__/exceptionalStats.test.ts
+++ b/front/src/components/exceptionals/helpers/__tests__/exceptionalStats.test.ts
@@ -14,6 +14,11 @@ const item = (date: string, amount: number, label = "Achat"): ExceptionalItem =>
   itemType: "exceptional",
   label,
   amount,
+  description: null,
+  currency: null,
+  categoryName: null,
+  categoryColor: null,
+  invoicefile: null,
 });
 
 describe("computeExceptionalStats — monthly average (COS-51)", () => {

--- a/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
+++ b/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
@@ -1,8 +1,8 @@
 import { getRandomHexColor } from "@components/spendings/common/spendingModal/helpers";
+import evaluateAmountExpression from "@lib/amountExpression";
 import endOfMonth from "date-fns/endOfMonth";
 import format from "date-fns/format";
 import startOfMonth from "date-fns/startOfMonth";
-import Mexp from "math-expression-evaluator";
 
 import type { AuthUser } from "@auth/types";
 import type { CategoryOption, SpendingForm } from "@components/spendings/common/spendingModal/schema";
@@ -57,18 +57,8 @@ const useSpendingSubmit = ({
       return;
     }
 
-    let amountEvaluatedExpr: number;
-    try {
-      const mexp = new Mexp();
-      const lexed = mexp.lex(values.spendingAmount.trim());
-      const postfixed = mexp.toPostfix(lexed);
-      amountEvaluatedExpr = mexp.postfixEval(postfixed);
-    } catch (error) {
-      console.error("Invalid amount expression", error);
-      return;
-    }
-
-    if (Number.isNaN(amountEvaluatedExpr)) {
+    const amountEvaluatedExpr = evaluateAmountExpression(values.spendingAmount);
+    if (amountEvaluatedExpr === null) {
       return;
     }
 

--- a/front/src/components/spendings/config/constants.ts
+++ b/front/src/components/spendings/config/constants.ts
@@ -11,3 +11,8 @@ export const DATE_FORMAT = "yyyy-MM-dd";
 // Period-type discriminators (formerly in the removed spendingDashboard tree).
 export const MONTHLY = "PERIOD_TYPE_MONTHLY";
 export const WEEKLY = "PERIOD_TYPE_WEEKLY";
+
+// Anything holding one of the two discriminators is typed with this rather than
+// a bare `string`, so a typo can no longer silently fall through to the weekly
+// branch (COS-107).
+export type PeriodType = typeof MONTHLY | typeof WEEKLY;

--- a/front/src/components/spendings/interfaces/spendingDashboardTypes.ts
+++ b/front/src/components/spendings/interfaces/spendingDashboardTypes.ts
@@ -1,17 +1,3 @@
-export interface Spending {
-  ID: string;
-  amount: number;
-  category: string | null;
-  categoryColor: string | null;
-  categoryID: string | null;
-  currency: string | null;
-  date: string;
-  invoicefile: null | string;
-  itemType: string;
-  label: string;
-  userID: string;
-}
-
 export interface MonthRange {
   start: Date;
   end: Date;

--- a/front/src/components/spendings/services/useCategoryTrends.tsx
+++ b/front/src/components/spendings/services/useCategoryTrends.tsx
@@ -11,6 +11,7 @@ import startOfMonth from "date-fns/startOfMonth";
 import subDays from "date-fns/subDays";
 import subMonths from "date-fns/subMonths";
 
+import type { PeriodType } from "@components/spendings/config/constants";
 import type { CategoryTrendPoint } from "@src/schemas/stats";
 
 // A user category and a global one can share a name; merge those rows by name —
@@ -38,7 +39,7 @@ const aggregateByCategory = (items: CategoryTrendPoint[]): CategoryTrendPoint[] 
 // front owns this math (server-timezone-agnostic): monthly = the selected month
 // vs the one before it (dashboard, COS-41); weekly = the picked range vs the 7
 // days before it (Spendings, COS-35).
-const windows = (periodType: string, from?: Date | null, to?: Date | null) => {
+const windows = (periodType: PeriodType, from?: Date | null, to?: Date | null) => {
   if (periodType === MONTHLY) {
     if (!from) return null;
     const previousMonth = subMonths(from, 1);
@@ -63,7 +64,7 @@ const windows = (periodType: string, from?: Date | null, to?: Date | null) => {
  * Backs the dashboard's monthly breakdown trend column + "Rising category"
  * insight (COS-41), and the Spendings weekly breakdown (COS-35).
  */
-const useCategoryTrends = (periodType: string) => {
+const useCategoryTrends = (periodType: PeriodType) => {
   const { privateRequest } = useRequestHelper();
   const { from, to } = useDatePickerWrapperStore();
   const { user } = useAuth();

--- a/front/src/components/spendings/services/useDashboard.ts
+++ b/front/src/components/spendings/services/useDashboard.ts
@@ -69,11 +69,9 @@ const useDashboard = (): UseDashboard => {
   });
 
   const totalOfMonth =
-    get.data && initialAmount
-      ? Number(initialAmount.spendingsSum.amount) + Number(initialAmount.recurringsSum.amount)
-      : 0;
+    get.data && initialAmount ? initialAmount.spendingsSum.amount + initialAmount.recurringsSum.amount : 0;
   const monthlyTotal = Number(totalOfMonth.toFixed(2));
-  const remaining = get.data ? Number((Number(get.data.initialAmount) - totalOfMonth).toFixed(2)) : 0;
+  const remaining = get.data ? Number((get.data.initialAmount - totalOfMonth).toFixed(2)) : 0;
 
   const mutation = useMutation<unknown, AxiosError, DashboardMutationVariables>({
     mutationFn: ({ dashboardID, initialAmount }) => {

--- a/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
+++ b/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
@@ -15,12 +15,13 @@ import { ChevronRight, Search, X } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
 
+import type { PeriodType } from "@components/spendings/config/constants";
 import type { SpendingItem } from "@components/spendings/types";
 import type { CategoryProps } from "@src/interfaces/category";
 
 interface SpendingsListModalProps {
   handleClickOutside: () => void;
-  periodType: string;
+  periodType: PeriodType;
   categoryInfos: CategoryProps;
   total: number;
 }

--- a/front/src/lib/amountExpression.ts
+++ b/front/src/lib/amountExpression.ts
@@ -1,0 +1,28 @@
+import Mexp from "math-expression-evaluator";
+
+// The amount fields of the spending and exceptional modals accept an arithmetic
+// expression, not just a number ("12.50 + 3*2"), so the user can add up a
+// receipt in place. Both modals used to carry their own copy of the same
+// lex → toPostfix → postfixEval dance (COS-107).
+
+/**
+ * Evaluates a user-typed amount expression, returning `null` when it is not a
+ * usable number — either the expression failed to parse or it evaluated to NaN.
+ * Callers treat `null` as "abort the submit".
+ */
+const evaluateAmountExpression = (input: string): number | null => {
+  let result: number;
+  try {
+    const mexp = new Mexp();
+    const lexed = mexp.lex(input.trim());
+    const postfixed = mexp.toPostfix(lexed);
+    result = mexp.postfixEval(postfixed);
+  } catch (error) {
+    console.error("Invalid amount expression", error);
+    return null;
+  }
+
+  return Number.isNaN(result) ? null : result;
+};
+
+export default evaluateAmountExpression;

--- a/front/src/lib/query/keys.ts
+++ b/front/src/lib/query/keys.ts
@@ -27,4 +27,4 @@ export const QUERY_KEYS = {
   SEARCH_TIMELINE: "searchTimeline",
   SPENDINGS_YEARS: "spendingsYears",
   LABEL_SUGGESTIONS: "labelSuggestions",
-};
+} as const;

--- a/front/src/schemas/categoryStats.ts
+++ b/front/src/schemas/categoryStats.ts
@@ -1,10 +1,5 @@
+import { numberLikeSchema } from "@src/schemas/primitives";
 import { z } from "zod";
-
-/** Coerces a string-or-number backend field (Prisma Decimal serialises as either) into a finite number. */
-const numberLikeSchema = z.preprocess(
-  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-  z.coerce.number().finite(),
-);
 
 export const CategoryStatSchema = z.object({
   categoryID: z.string(),
@@ -18,5 +13,3 @@ export const CategoryStatsResponseSchema = z.object({
   totalSpent: numberLikeSchema,
   byCategory: z.array(CategoryStatSchema),
 });
-
-export type CategoryStatsResponse = z.infer<typeof CategoryStatsResponseSchema>;

--- a/front/src/schemas/dashboard.ts
+++ b/front/src/schemas/dashboard.ts
@@ -1,19 +1,5 @@
+import { numberLikeSchema, numberLikeWithZeroFallbackSchema } from "@src/schemas/primitives";
 import { z } from "zod";
-
-const numberLikeSchema = z.preprocess(
-  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-  z.coerce.number().finite(),
-);
-
-const numberLikeWithZeroFallbackSchema = z.preprocess((value) => {
-  if (value === null || value === undefined) {
-    return 0;
-  }
-  if (typeof value === "string" && value.trim() === "") {
-    return 0;
-  }
-  return value;
-}, z.coerce.number().finite());
 
 export const DashboardSchema = z.object({
   ID: z.string(),
@@ -64,7 +50,4 @@ export const MonthlyStatsSchema = z.object({
   }),
 });
 
-export type MonthlyStats = z.infer<typeof MonthlyStatsSchema>;
-
 export const WeeklyStatsSchema = z.array(numberLikeSchema);
-export type WeeklyStats = z.infer<typeof WeeklyStatsSchema>;

--- a/front/src/schemas/exceptionals.ts
+++ b/front/src/schemas/exceptionals.ts
@@ -1,22 +1,18 @@
+import { itemTypeSchema, numberLikeSchema } from "@src/schemas/primitives";
 import { z } from "zod";
-
-const numberLikeSchema = z.preprocess(
-  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-  z.coerce.number().finite(),
-);
 
 export const ExceptionalItemSchema = z.object({
   ID: z.string(),
   userID: z.string(),
   date: z.string(),
-  itemType: z.string(),
+  itemType: itemTypeSchema,
   label: z.string(),
-  description: z.string().nullable().optional(),
+  description: z.string().nullable(),
   amount: numberLikeSchema,
-  currency: z.string().nullable().optional(),
-  categoryName: z.string().nullable().optional(),
-  categoryColor: z.string().nullable().optional(),
-  invoicefile: z.string().nullable().optional(),
+  currency: z.string().nullable(),
+  categoryName: z.string().nullable(),
+  categoryColor: z.string().nullable(),
+  invoicefile: z.string().nullable(),
 });
 
 export const ExceptionalListSchema = z.array(ExceptionalItemSchema);
@@ -26,11 +22,11 @@ export const ExceptionalMutationPayloadSchema = z.object({
   id: z.string().optional(),
   date: z.string(),
   label: z.string().min(1),
-  description: z.string().optional().nullable(),
+  description: z.string().nullable().optional(),
   amount: numberLikeSchema,
   currency: z.string().optional(),
-  categoryName: z.string().optional().nullable(),
-  categoryColor: z.string().optional().nullable(),
+  categoryName: z.string().nullable().optional(),
+  categoryColor: z.string().nullable().optional(),
 });
 
 export type ExceptionalMutationPayload = z.infer<typeof ExceptionalMutationPayloadSchema>;

--- a/front/src/schemas/primitives.ts
+++ b/front/src/schemas/primitives.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+// Shared zod primitives for API response parsing (COS-107).
+//
+// Money fields come off Prisma as `Decimal`, which NestJS serialises three
+// different ways depending on the endpoint (raw Decimal → string, `String()`,
+// or `Number()`). Rather than guess per endpoint, every amount-ish field is
+// parsed through `numberLikeSchema`, which accepts either shape and always
+// yields a finite number.
+
+/** Coerces a string-or-number backend field (Prisma Decimal serialises as either) into a finite number. */
+export const numberLikeSchema = z.preprocess(
+  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
+  z.coerce.number().finite(),
+);
+
+/**
+ * Same coercion, but treats a missing value (null/undefined) or an empty string
+ * as 0 instead of failing — for fields the user may never have filled in
+ * (dashboard `initialAmount` / `initialCeiling`).
+ */
+export const numberLikeWithZeroFallbackSchema = z.preprocess((value) => {
+  if (value === null || value === undefined) {
+    return 0;
+  }
+  if (typeof value === "string" && value.trim() === "") {
+    return 0;
+  }
+  return value;
+}, z.coerce.number().finite());
+
+/**
+ * Discriminator carried by every spending-like row. The column is a plain
+ * `VARCHAR(11)` with no DB constraint, but each table only ever stores its own
+ * lowercase literal — every write in the backend (and in the retired Express
+ * API before it) emits one of these three, and no read path rewrites the value.
+ */
+export const itemTypeSchema = z.enum(["spending", "exceptional", "recurring"]);

--- a/front/src/schemas/spendings.ts
+++ b/front/src/schemas/spendings.ts
@@ -1,9 +1,5 @@
+import { itemTypeSchema, numberLikeSchema } from "@src/schemas/primitives";
 import { z } from "zod";
-
-const numberLikeSchema = z.preprocess(
-  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-  z.coerce.number().finite(),
-);
 
 export const SpendingCategoryInputSchema = z.object({
   ID: z.string().nullable(),
@@ -12,18 +8,20 @@ export const SpendingCategoryInputSchema = z.object({
   color: z.string().nullable(),
 });
 
-export type SpendingCategoryInput = z.infer<typeof SpendingCategoryInputSchema>;
-
+// Response shape of GET /spendings and the search page. Every field below is a
+// real column returned by an unprojected Prisma `findMany`, so nullable fields
+// arrive as `null`, never absent — hence `.nullable()` without `.optional()`
+// (COS-107).
 export const SpendingItemSchema = z.object({
   ID: z.string(),
   amount: numberLikeSchema,
-  category: z.string().nullable().optional(),
-  categoryColor: z.string().nullable().optional(),
-  categoryID: z.string().nullable().optional(),
-  currency: z.string().nullable().optional(),
+  category: z.string().nullable(),
+  categoryColor: z.string().nullable(),
+  categoryID: z.string().nullable(),
+  currency: z.string().nullable(),
   date: z.string(),
-  invoicefile: z.string().nullable().optional(),
-  itemType: z.string(),
+  invoicefile: z.string().nullable(),
+  itemType: itemTypeSchema,
   label: z.string(),
   userID: z.string(),
 });
@@ -39,7 +37,6 @@ export const SpendingSearchPageSchema = z.object({
   nextCursor: z.string().nullable(),
   total: z.number().optional(),
 });
-export type SpendingSearchPage = z.infer<typeof SpendingSearchPageSchema>;
 
 // Years the user has spendings in (newest first) — the search modal's year filter.
 export const SpendingYearsSchema = z.array(z.number());
@@ -58,10 +55,10 @@ export type LabelSuggestion = z.infer<typeof LabelSuggestionSchema>;
 export const RecurringItemSchema = z.object({
   ID: z.string(),
   amount: numberLikeSchema,
-  currency: z.string().nullable().optional(),
+  currency: z.string().nullable(),
   dateFrom: z.string(),
   dateTo: z.string(),
-  itemType: z.string(),
+  itemType: itemTypeSchema,
   label: z.string(),
   userID: z.string(),
 });
@@ -72,7 +69,6 @@ export type RecurringItem = z.infer<typeof RecurringItemSchema>;
 // Real year-to-date "Already debited" (COS-49) — GET /recurrings/drawn. The server
 // sums the actual per-month recurring rows from January through the current month.
 export const RecurringsDrawnSchema = z.object({ drawn: numberLikeSchema });
-export type RecurringsDrawn = z.infer<typeof RecurringsDrawnSchema>;
 
 export const SpendingMutationPayloadSchema = z.object({
   date: z.string().nullable().optional(),
@@ -91,5 +87,3 @@ export const RecurringMutationPayloadSchema = z.object({
   amount: numberLikeSchema,
   id: z.string().optional(),
 });
-
-export type RecurringMutationPayload = z.infer<typeof RecurringMutationPayloadSchema>;

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -1,9 +1,5 @@
+import { numberLikeSchema } from "@src/schemas/primitives";
 import { z } from "zod";
-
-const numberLikeSchema = z.preprocess(
-  (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-  z.coerce.number().finite(),
-);
 
 const statisticsMonthEntrySchema = z.record(z.string(), z.union([z.string(), z.number()]));
 
@@ -17,10 +13,7 @@ export type StatisticsResponse = z.infer<typeof StatisticsResponseSchema>;
 export const ChartsCategorySchema = z.object({
   category: z.string().nullable(),
   categoryColor: z.string().nullable(),
-  value: z.preprocess(
-    (value) => (typeof value === "number" || typeof value === "string" ? value : NaN),
-    z.coerce.number().finite(),
-  ),
+  value: numberLikeSchema,
 });
 
 export type ChartsCategory = z.infer<typeof ChartsCategorySchema>;
@@ -46,8 +39,6 @@ export const CategoryTrendsResponseSchema = z.object({
   // week" delta (COS-35); unused by the dashboard monthly breakdown.
   previousTotal: numberLikeSchema,
 });
-
-export type CategoryTrendsResponse = z.infer<typeof CategoryTrendsResponseSchema>;
 
 // Per-day spending totals for a year (COS-45) — GET /daily-stats. Sparse: one
 // entry per day that has at least one spending. Feeds the daily heatmap and the


### PR DESCRIPTION
Bloc 1/2 de l'audit types/Zod du front (COS-109 suit).

- schemas/primitives.ts : numberLike / numberLikeWithZeroFallback extraits des 5 copies + de la copie inline de ChartsCategory.
- itemType typé en z.enum(["spending","exceptional","recurring"]) : les 3 tables ne stockent que ces littéraux minuscules, et aucun endpoint ne réécrit la valeur en lecture.
- Champs de réponse : .optional() retiré (les 4 reads front sont des findMany sans select, donc le champ est toujours présent, au pire null) ; ordre .nullable().optional() uniformisé sur les payloads.
- Types morts supprimés : CategoryStatsResponse, SpendingCategoryInput, RecurringMutationPayload, MonthlyStats, WeeklyStats, l'interface Spending, + CategoryTrendsResponse, RecurringsDrawn et SpendingSearchPage que l'inventaire du ticket avait manqués. CategoryStat est conservé : il est utilisé par rankFrequentCategories.
- PeriodType = typeof MONTHLY | typeof WEEKLY, en place des periodType: string (3 sites).
- QUERY_KEYS en as const.
- Number() redondants retirés dans useDashboard (valeurs déjà coercées).
- Évaluateur Mexp dupliqué → lib/amountExpression.ts.

Le point 4 du ticket est sans objet : mockSpending.ts et useCharts.tsx n'existent plus, TrendDirection n'est déclaré que dans dataVizTypes.ts.