### PR TITLE
refactor(front): types & zod structural cleanup (COS-109)

### DIFF
--- a/front/src/app/(public)/forgotPassword/page.tsx
+++ b/front/src/app/(public)/forgotPassword/page.tsx
@@ -16,7 +16,7 @@ export default function ForgotPassword() {
   const { forgotPassword: t } = login;
 
   const onSubmit = async (values: LoginValues) => {
-    await resetPasswordService(values.email!);
+    await resetPasswordService(values.email);
   };
 
   return (

--- a/front/src/auth/server/getServerSession.ts
+++ b/front/src/auth/server/getServerSession.ts
@@ -1,3 +1,4 @@
+import { AuthResponseSchema } from "@src/schemas/auth";
 import { cookies, headers } from "next/headers";
 
 import type { AuthResponse } from "@auth/types";
@@ -50,5 +51,5 @@ export const getServerSession = async (): Promise<AuthResponse | null> => {
     throw new Error(`users/me failed with status ${response.status}`);
   }
 
-  return (await response.json()) as AuthResponse;
+  return AuthResponseSchema.parse(await response.json());
 };

--- a/front/src/auth/types.ts
+++ b/front/src/auth/types.ts
@@ -1,12 +1,8 @@
-export interface AuthUser {
-  id: string;
-  name: string;
-  email: string;
-  baseCurrency: string;
-  language: string | null;
-}
+import type { AuthResponseSchema, AuthUserSchema } from "@src/schemas/auth";
+import type { z } from "zod";
 
-export interface AuthResponse {
-  user: AuthUser;
-  csrfToken: string;
-}
+// Inferred from the zod schemas so the runtime contract and the compile-time one
+// can never drift apart. This stays the import site for the rest of the app
+// (@auth/types); the schemas themselves live with the other API schemas.
+export type AuthUser = z.infer<typeof AuthUserSchema>;
+export type AuthResponse = z.infer<typeof AuthResponseSchema>;

--- a/front/src/auth/useLoginService.ts
+++ b/front/src/auth/useLoginService.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import useRequestHelper from "@helpers/useRequestHelper";
+import { AuthResponseSchema } from "@src/schemas/auth";
 
 import type { AuthResponse } from "@auth/types";
 
@@ -17,7 +18,7 @@ const useLoginService = () => {
         password,
       },
     });
-    return result.data as AuthResponse;
+    return AuthResponseSchema.parse(result.data);
   };
 
   return {

--- a/front/src/auth/useSignupService.ts
+++ b/front/src/auth/useSignupService.ts
@@ -3,6 +3,7 @@
 import useRequestHelper from "@helpers/useRequestHelper";
 import { pickSupportedLocale } from "@i18n/pickSupportedLocale";
 import useTranslations from "@i18n/useTranslations";
+import { AuthResponseSchema } from "@src/schemas/auth";
 import { toast } from "sonner";
 
 import type { AuthResponse } from "@auth/types";
@@ -19,7 +20,7 @@ const useSignupService = () => {
       const res = await request("/users/add", {
         method: "POST",
         data: {
-          name: email!.split("@")[0],
+          name: email.split("@")[0],
           email,
           password,
           registerDate: new Date(),
@@ -27,7 +28,7 @@ const useSignupService = () => {
           language: pickSupportedLocale(navigator.languages ?? []),
         },
       });
-      return res.data as AuthResponse;
+      return AuthResponseSchema.parse(res.data);
     } catch (e) {
       const status = (e as AxiosError)?.response?.status;
       toast.error(status === 409 ? t.emailAlreadyExists : t.error);

--- a/front/src/components/dashboard/sections/WeeklyCeiling.tsx
+++ b/front/src/components/dashboard/sections/WeeklyCeiling.tsx
@@ -23,11 +23,15 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 
+import type { WeekSlice } from "@components/spendings/interfaces/weeklyStatsTypes";
 import type { FocusEvent, KeyboardEvent } from "react";
 
 interface CeilingForm {
   initialCeiling: string;
 }
+
+/** "5 - 11" for a range, "5" for a slice the month edges cut down to a single day. */
+const formatWeekSlice = ({ start, end }: WeekSlice): string => (start === end ? String(start) : `${start} - ${end}`);
 
 /** Weekly spend vs a fixed ceiling, per week of the month + inline ceiling edit. */
 const WeeklyCeiling = () => {
@@ -60,11 +64,10 @@ const WeeklyCeiling = () => {
   const monthIsFuture = from ? isAfter(startOfMonth(from), startOfMonth(now)) : false;
   const monthIsPast = from ? isBefore(startOfMonth(from), startOfMonth(now)) : false;
 
-  const isFutureWeek = (slice: string | number): boolean => {
+  const isFutureWeek = (slice: WeekSlice | undefined): boolean => {
     if (monthIsFuture) return true;
     if (monthIsPast) return false;
-    const startDay = typeof slice === "number" ? slice : parseInt(String(slice), 10);
-    return Number.isFinite(startDay) && startDay > getDate(now);
+    return slice != null && slice.start > getDate(now);
   };
 
   const onSubmit = (v: CeilingForm) => {
@@ -125,18 +128,18 @@ const WeeklyCeiling = () => {
 
       <div className="flex flex-col">
         {stats.map((weekTotal, i) => {
-          const weekLabel = slices[i] ?? `S${i + 1}`;
-          const current = from ? isCurrentWeek(slices[i], from) : false;
+          const slice = slices[i];
+          const weekLabel = slice ? formatWeekSlice(slice) : `S${i + 1}`;
+          const current = from ? isCurrentWeek(slice, from) : false;
           const over = ceiling > 0 && weekTotal > ceiling;
-          const future = isFutureWeek(slices[i]);
+          const future = isFutureWeek(slice);
           const delta = weekTotal - ceiling;
           // Past/current weeks drill into that week on the Spendings page; future
           // weeks have nothing to open, so they stay inert — no link, no hover,
           // default cursor (COS-151). Start day of the range doubles as the ?date=.
-          const startDay = typeof weekLabel === "number" ? weekLabel : parseInt(String(weekLabel), 10);
           const href =
-            !future && from != null && Number.isFinite(startDay)
-              ? buildSpendingsPath(formatIsoDate(new Date(from.getFullYear(), from.getMonth(), startDay)))
+            !future && from != null && slice != null
+              ? buildSpendingsPath(formatIsoDate(new Date(from.getFullYear(), from.getMonth(), slice.start)))
               : null;
           const rowClass = cn(
             "grid grid-cols-[52px_1fr_74px] items-center gap-3 border-b border-line-soft py-3 text-sm last:border-b-0",
@@ -144,7 +147,7 @@ const WeeklyCeiling = () => {
           );
           const cells = (
             <>
-              <span className="num text-xs text-ink-2">{slices[i] ?? `S${i + 1}`}</span>
+              <span className="num text-xs text-ink-2">{weekLabel}</span>
               <ProgressTrack
                 key={`${monthKey}-${weekLabel}-${weekTotal > 0 ? "d" : "e"}`}
                 value={weekTotal}

--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -25,6 +25,8 @@ import type { Dictionary } from "@text/index";
 const makeFormSchema = (errors: Dictionary["exceptionals"]["modal"]["errors"]) =>
   z.object({
     label: z.string().min(1, errors.labelRequired),
+    // As in the spending modal, a string on purpose: it holds a Mexp expression,
+    // evaluated on submit by @lib/amountExpression (COS-109).
     amount: z.string().min(1, errors.amountRequired),
     date: z.string().min(1, errors.dateRequired),
     description: z.string().optional(),
@@ -179,7 +181,12 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
               />
             </FieldShell>
           </div>
-          {errors.amount && <p className="-mt-3 text-xs text-neg">{errors.amount.message}</p>}
+          {/* Date and amount share a 2-column grid row, so their error line sits
+              below the row rather than inside either FieldShell — otherwise the
+              two columns stop lining up (same pattern as COS-164). */}
+          {(errors.date || errors.amount) && (
+            <p className="-mt-3 text-xs text-neg">{errors.date?.message ?? errors.amount?.message}</p>
+          )}
 
           <FieldShell
             label={modal.fields.label}

--- a/front/src/components/login/LoginFormClient.tsx
+++ b/front/src/components/login/LoginFormClient.tsx
@@ -21,7 +21,7 @@ export default function LoginFormClient() {
 
   const onSubmit = async (values: LoginValues) => {
     try {
-      const result = await loginService(values.email!, values.password!);
+      const result = await loginService(values.email, values.password);
       if (result?.user && result.csrfToken) {
         setServerError(null);
         await setCredentials(result);

--- a/front/src/components/shared/sharedLoginForm/interfaces.ts
+++ b/front/src/components/shared/sharedLoginForm/interfaces.ts
@@ -1,7 +1,10 @@
+// What `SharedLoginForm` hands to its `onSubmit`. Every field is present: the
+// form renders a subset of the inputs depending on the mode, but the hidden ones
+// still carry their "" default, so callers never have to assert (COS-109).
 export interface LoginValues {
-  currency?: string;
-  email?: string;
-  password?: string;
+  currency: string;
+  email: string;
+  password: string;
 }
 
 export interface SharedLoginFormProps {

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -25,12 +25,15 @@ const buildSchema = (
 ) =>
   z
     .object({
-      email: needEmail
-        ? z.string().min(1, validation.emailRequired).email(validation.emailInvalid)
-        : z.string().optional(),
-      password: needPassword ? z.string().min(1, validation.passwordRequired) : z.string().optional(),
-      confirmPassword: needConfirm ? z.string().min(1, validation.confirmRequired) : z.string().optional(),
-      currency: needCurrency ? z.string().min(1) : z.string().optional(),
+      // A hidden field validates as a plain `z.string()`, never `.optional()`:
+      // `defaultValues` below always supplies "" for it, so the value is present
+      // either way. Keeping it required is what makes `z.infer` resolve to all
+      // required strings instead of collapsing every field to `string | undefined`
+      // — the root cause of the `values.email!` assertions in the callers (COS-109).
+      email: needEmail ? z.string().min(1, validation.emailRequired).email(validation.emailInvalid) : z.string(),
+      password: needPassword ? z.string().min(1, validation.passwordRequired) : z.string(),
+      confirmPassword: needConfirm ? z.string().min(1, validation.confirmRequired) : z.string(),
+      currency: needCurrency ? z.string().min(1) : z.string(),
     })
     .refine((d) => !needConfirm || d.password === d.confirmPassword, {
       message: validation.passwordMismatch,

--- a/front/src/components/spendings/common/spendingModal/schema.ts
+++ b/front/src/components/spendings/common/spendingModal/schema.ts
@@ -6,9 +6,10 @@ import type { Dictionary } from "@text/index";
 export const makeSpendingSchema = (validation: Dictionary["spendings"]["modal"]["validation"]) =>
   z.object({
     spendingLabel: z.string().min(1, validation.labelRequired),
+    // Deliberately a string, not a number (COS-109): the field accepts an
+    // arithmetic expression ("12+3"), evaluated on submit by @lib/amountExpression.
     spendingAmount: z.string().min(1, validation.amountRequired),
     spendingDate: z.string().optional(),
-    categoryName: z.string().optional(),
   });
 
 export type SpendingForm = z.infer<ReturnType<typeof makeSpendingSchema>>;

--- a/front/src/components/spendings/helpers/useWeeklyStatsHelper.ts
+++ b/front/src/components/spendings/helpers/useWeeklyStatsHelper.ts
@@ -3,6 +3,8 @@ import getDay from "date-fns/getDay";
 import getDaysInMonth from "date-fns/getDaysInMonth";
 import startOfMonth from "date-fns/startOfMonth";
 
+import type { WeekSlice } from "@components/spendings/interfaces/weeklyStatsTypes";
+
 const useWeeklyStatsHelper = () => {
   const makeRange = (from: Date) => {
     const ranges: number[] = [];
@@ -21,26 +23,18 @@ const useWeeklyStatsHelper = () => {
     return ranges;
   };
 
-  const getSliceDates = (idx: number, ranges: number[]) => {
+  const getSliceDates = (idx: number, ranges: number[]): WeekSlice => {
     const getSumDays = (i: number) => ranges.slice(0, i + 1).reduce((acc, curr) => acc + curr, 0);
-    const sliceStart = idx === 0 ? 1 : getSumDays(idx - 1) + 1;
-    const sliceEnd = getSumDays(idx);
 
-    return sliceStart === sliceEnd ? sliceStart : `${sliceStart} - ${sliceEnd}`;
+    return {
+      start: idx === 0 ? 1 : getSumDays(idx - 1) + 1,
+      end: getSumDays(idx),
+    };
   };
 
-  const makeSlices = (ranges: number[]) =>
-    ranges.reduce(
-      (acc: Array<string | number>, _curr, idx, arr) => {
-        acc.push(getSliceDates(idx, arr));
-        return acc;
-      },
-      [] as Array<string | number>,
-    );
+  const makeSlices = (ranges: number[]): WeekSlice[] => ranges.map((_curr, idx, arr) => getSliceDates(idx, arr));
 
-  const isCurrentWeek = (slice: string | number, from: Date) => {
-    return typeof slice === "string" ? +slice.split(" - ")[0] === getDate(from) : +slice === getDate(from);
-  };
+  const isCurrentWeek = (slice: WeekSlice | undefined, from: Date) => slice?.start === getDate(from);
 
   return {
     makeRange,

--- a/front/src/components/spendings/interfaces/weeklyStatsTypes.ts
+++ b/front/src/components/spendings/interfaces/weeklyStatsTypes.ts
@@ -1,0 +1,13 @@
+/**
+ * One calendar week-slice of a month, as day-of-month bounds (inclusive).
+ *
+ * Weeks are Sunday→Saturday, truncated at the month edges — so a month can open
+ * with a 1–3 slice and close with a 29–31 one. A single-day slice has
+ * `start === end`. Formatting is the view's job (COS-109): this used to be an
+ * `Array<string | number>` where a range was the string "5 - 11" and a lone day a
+ * bare number, which every consumer then re-parsed to get the start day back.
+ */
+export interface WeekSlice {
+  start: number;
+  end: number;
+}

--- a/front/src/components/spendings/types.ts
+++ b/front/src/components/spendings/types.ts
@@ -1,7 +1,4 @@
-import type { User } from "@src/interfaces/user";
 import type { RecurringItem, SpendingItem } from "@src/schemas/spendings";
-
-export type Month = { start: Date; end: Date } | null;
 
 export type SpendingListItem = SpendingItem | RecurringItem;
 export type { RecurringItem, SpendingItem };
@@ -12,19 +9,10 @@ export interface SpendingDayGroup {
   items: SpendingItem[];
 }
 
-export type SpendingsType = Array<SpendingDayGroup>;
-
 interface SpendingsPartial {
   spendingsByDaySorted: SpendingListItem[];
   isLoading: boolean;
   recurringType?: boolean;
-}
-
-export interface SpendingDayItemType extends SpendingsPartial {
-  user: User;
-  month?: string | null;
-  date?: Date;
-  total?: number;
 }
 
 export interface SpendingsListContainerType extends SpendingsPartial {

--- a/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/statisticsData.test.ts
@@ -1,11 +1,17 @@
-import { filledMonthlyIncome, monthlyPresence, monthlyTotals } from "@components/statistics/helpers/statisticsData";
+import {
+  categoryMonthly,
+  filledMonthlyIncome,
+  monthlyPresence,
+  monthlyTotals,
+  perCategoryTotals,
+} from "@components/statistics/helpers/statisticsData";
 
 import type { StatisticsResponse } from "@src/schemas/stats";
 
 const data: StatisticsResponse["data"] = {
   "2026": [
-    { month: "janv.", food: 10, rent: 5 },
-    { month: "mars", food: 0 }, // present, but a genuine zero total
+    { month: "janv.", totals: { food: 10, rent: 5 } },
+    { month: "mars", totals: { food: 0 } }, // present, but a genuine zero total
   ],
 };
 
@@ -28,6 +34,52 @@ describe("monthlyPresence", () => {
 
   it("returns an all-false mask for a year with no data", () => {
     expect(monthlyPresence(data, 2020)).toEqual(Array(12).fill(false));
+  });
+});
+
+// These two read every per-category total on a row. They had no coverage while
+// the row was still a flat map keyed by category name with the month label mixed
+// in, so the split into { month, totals } (COS-109) is pinned down here.
+describe("perCategoryTotals", () => {
+  const colors = { food: "#111", rent: "#222" };
+
+  it("sums each category across the year's months, sorted descending", () => {
+    expect(perCategoryTotals(data, colors, 2026)).toEqual([
+      { name: "food", value: 10, color: "#111" },
+      { name: "rent", value: 5, color: "#222" },
+    ]);
+  });
+
+  it("never counts the month label as a category", () => {
+    expect(perCategoryTotals(data, colors, 2026).map((c) => c.name)).not.toContain("month");
+  });
+
+  it("falls back to the placeholder colour for an unknown category", () => {
+    const [food] = perCategoryTotals(data, {}, 2026);
+    expect(food.color).toBeTruthy();
+    expect(food.color).not.toBe("#111");
+  });
+
+  it("returns nothing for a year with no data", () => {
+    expect(perCategoryTotals(data, colors, 2020)).toEqual([]);
+  });
+});
+
+describe("categoryMonthly", () => {
+  it("places each month's value at its calendar index", () => {
+    const series = categoryMonthly(data, 2026, "food");
+    expect(series[0]).toBe(10); // janv.
+    expect(series[2]).toBe(0); // mars — a real zero
+    expect(series).toHaveLength(12);
+  });
+
+  it("yields 0 for a month where the category is absent", () => {
+    // "rent" only appears in janv., so mars must read 0 rather than undefined.
+    expect(categoryMonthly(data, 2026, "rent")[2]).toBe(0);
+  });
+
+  it("yields an all-zero series for an unknown category", () => {
+    expect(categoryMonthly(data, 2026, "nope")).toEqual(Array(12).fill(0));
   });
 });
 

--- a/front/src/components/statistics/helpers/statisticsData.ts
+++ b/front/src/components/statistics/helpers/statisticsData.ts
@@ -32,14 +32,7 @@ export const monthShortLabels = (locale: Locale): string[] =>
 type StatData = StatisticsResponse["data"];
 type Row = StatData[string][number];
 
-const toNumber = (value: string | number | undefined): number =>
-  typeof value === "number" ? value : Number(value) || 0;
-
-const rowTotal = (row: Row): number =>
-  Object.entries(row).reduce(
-    (sum, [key, value]) => (key === "month" ? sum : sum + toNumber(value as string | number)),
-    0,
-  );
+const rowTotal = (row: Row): number => Object.values(row.totals).reduce((sum, value) => sum + value, 0);
 
 const rowsForYear = (data: StatData | undefined, year: number): Row[] => data?.[String(year)] ?? [];
 
@@ -47,7 +40,7 @@ const rowsForYear = (data: StatData | undefined, year: number): Row[] => data?.[
 export const monthlyTotals = (data: StatData | undefined, year: number): number[] => {
   const totals = Array<number>(12).fill(0);
   rowsForYear(data, year).forEach((row, i) => {
-    const idx = MONTHS_FR.indexOf(String(row.month));
+    const idx = MONTHS_FR.indexOf(row.month);
     totals[idx >= 0 ? idx : i] = rowTotal(row);
   });
   return totals;
@@ -65,7 +58,7 @@ export const yearTotal = (data: StatData | undefined, year: number): number =>
 export const monthlyPresence = (data: StatData | undefined, year: number): boolean[] => {
   const present = Array<boolean>(12).fill(false);
   rowsForYear(data, year).forEach((row, i) => {
-    const idx = MONTHS_FR.indexOf(String(row.month));
+    const idx = MONTHS_FR.indexOf(row.month);
     present[idx >= 0 ? idx : i] = true;
   });
   return present;
@@ -136,9 +129,8 @@ export const perCategoryTotals = (
 ): CategoryTotal[] => {
   const totals = new Map<string, number>();
   rowsForYear(data, year).forEach((row) => {
-    Object.entries(row).forEach(([key, value]) => {
-      if (key === "month") return;
-      totals.set(key, (totals.get(key) ?? 0) + toNumber(value as string | number));
+    Object.entries(row.totals).forEach(([key, value]) => {
+      totals.set(key, (totals.get(key) ?? 0) + value);
     });
   });
   return Array.from(totals.entries())
@@ -150,8 +142,8 @@ export const perCategoryTotals = (
 export const categoryMonthly = (data: StatData | undefined, year: number, name: string): number[] => {
   const out = Array<number>(12).fill(0);
   rowsForYear(data, year).forEach((row, i) => {
-    const idx = MONTHS_FR.indexOf(String(row.month));
-    out[idx >= 0 ? idx : i] = toNumber(row[name] as string | number);
+    const idx = MONTHS_FR.indexOf(row.month);
+    out[idx >= 0 ? idx : i] = row.totals[name] ?? 0;
   });
   return out;
 };

--- a/front/src/interfaces/locales.ts
+++ b/front/src/interfaces/locales.ts
@@ -1,12 +1,3 @@
 import type localesDates from "@src/i18n/locales-dates";
 
 export type LangKeys = keyof typeof localesDates;
-
-// Locale from date-fns caused typing conflicts in this codebase.
-// Keep this object flexible but strongly avoid `any`.
-export interface LocaleObject {
-  [k: string]: unknown;
-  formatString: string;
-}
-
-export type LocalesObject = { [k: string]: LocaleObject };

--- a/front/src/interfaces/user.ts
+++ b/front/src/interfaces/user.ts
@@ -1,9 +1,0 @@
-import type { LangKeys } from "@src/interfaces/locales";
-
-export interface User {
-  baseCurrency: string;
-  email: string;
-  id: string;
-  language: LangKeys;
-  name: string;
-}

--- a/front/src/lib/dataviz/CategoryBarTooltip.tsx
+++ b/front/src/lib/dataviz/CategoryBarTooltip.tsx
@@ -6,7 +6,7 @@ import CategoryTrend from "@lib/dataviz/CategoryTrend";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import type { CategoryTooltipDatum } from "@lib/dataviz/dataVizTypes";
+import type { CategoryTooltipDatum, CursorPoint } from "@lib/dataviz/dataVizTypes";
 
 // Measure-then-position must run before paint to clamp the tooltip at the
 // viewport edge without a flash; fall back to useEffect on the server, where
@@ -15,7 +15,7 @@ const useIsomorphicLayoutEffect = typeof window === "undefined" ? useEffect : us
 
 interface CategoryBarTooltipProps {
   /** Cursor position in viewport coords, or null when the tooltip is hidden. */
-  point: { x: number; y: number } | null;
+  point: CursorPoint | null;
   datum: CategoryTooltipDatum;
 }
 

--- a/front/src/schemas/auth.ts
+++ b/front/src/schemas/auth.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+
+// Auth was the last API boundary still crossing into the app on a bare `as`
+// cast instead of a parse (COS-109). Shape mirrors the backend's
+// `SignInResponse & { csrfToken }` — returned identically by POST /users
+// (login), POST /users/add (signup) and GET /users/me (session bootstrap).
+//
+// Deliberately a plain `z.object`, never `.strict()`: zod strips unknown keys by
+// default, so a field added server-side stays backward-compatible. A strict
+// schema would turn any such addition into a hard login failure.
+
+export const AuthUserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  // Nullable in DB (`Users.language`, defaulted to "en" but never NOT NULL).
+  baseCurrency: z.string(),
+  language: z.string().nullable(),
+});
+
+export const AuthResponseSchema = z.object({
+  user: AuthUserSchema,
+  csrfToken: z.string(),
+});

--- a/front/src/schemas/primitives.ts
+++ b/front/src/schemas/primitives.ts
@@ -36,3 +36,17 @@ export const numberLikeWithZeroFallbackSchema = z.preprocess((value) => {
  * API before it) emits one of these three, and no read path rewrites the value.
  */
 export const itemTypeSchema = z.enum(["spending", "exceptional", "recurring"]);
+
+// ---------------------------------------------------------------------------
+// Deliberate choices in these schemas — please don't "fix" them (COS-109).
+//
+// * `currency: z.string()` stays a free string, never an enum. It is a per-user
+//   `baseCurrency`, and multi-currency support is a deferred decision; hardcoding
+//   EUR here would have to be undone. `z.string().length(3)` is the most that
+//   would ever be justified.
+//
+// * `ID` / `userID` / `categoryID` keep their capitalisation. It comes straight
+//   from the Prisma/MySQL column names and Nest ships the rows unmapped (no DTO,
+//   no serializer), so renaming them front-side would just paper over the wire
+//   format. If it is ever changed, it starts from a Prisma `@map`, not from here.
+// ---------------------------------------------------------------------------

--- a/front/src/schemas/stats.ts
+++ b/front/src/schemas/stats.ts
@@ -1,8 +1,28 @@
 import { numberLikeSchema } from "@src/schemas/primitives";
 import { z } from "zod";
 
-const statisticsMonthEntrySchema = z.record(z.string(), z.union([z.string(), z.number()]));
+// A statistics row arrives flat from the backend — the month label sits among the
+// per-category totals: { month: "janv.", food: 10, rent: 5 }. Splitting it at the
+// parse boundary is what lets every consumer read `totals` as plain numbers,
+// instead of walking the row re-discriminating the "month" key and casting the
+// rest to `string | number` (COS-109).
+//
+// The coercion stays lenient — a malformed cell becomes 0 rather than throwing.
+// The entire Statistics page (KPIs, forecast, charts) renders off this single
+// parse, so one bad value must degrade a cell, not blank the page.
+const statisticsMonthEntrySchema = z.record(z.string(), z.union([z.string(), z.number()])).transform((row) => {
+  const { month, ...categories } = row;
+  const totals: Record<string, number> = {};
+  for (const [name, value] of Object.entries(categories)) {
+    totals[name] = typeof value === "number" ? value : Number(value) || 0;
+  }
+  return { month: String(month ?? ""), totals };
+});
 
+// The two outer `z.record`s stay dynamically keyed on purpose (COS-109): the keys
+// are the user's own category names and the years they have data for, both only
+// known at runtime. Typing them further is impossible without changing the
+// backend contract, which is out of scope here.
 export const StatisticsResponseSchema = z.object({
   colors: z.record(z.string(), z.string()),
   data: z.record(z.string(), z.array(statisticsMonthEntrySchema)),


### PR DESCRIPTION
Bloc 2/2 de l'audit types/Zod du front. Les 6 chantiers front-only ; le reste est sorti en tickets (COS-175/176/177/179/180).

- Matrice stats : .transform() au parse, la ligne devient { month, totals }. Retire 3 casts string|number et 2 gardes key === "month". Coercion volontairement tolérante (valeur invalide -> 0) : toute la page dépend de ce seul parse. perCategoryTotals et categoryMonthly, réécrits ici et sans aucun test jusqu'ici, sont désormais couverts.
- Auth sous zod : AuthResponseSchema, les 3 `as AuthResponse` deviennent des .parse(). z.object simple, jamais .strict() : zod retire les clés inconnues, donc un champ ajouté côté back n'est pas une panne de connexion.
- Formulaire d'auth : la branche non validante de buildSchema passe de .optional() à z.string(), ce qui fait résoudre z.infer en chaînes requises et supprime les 4 `!` des appelants. Renommer le type sans toucher aux ternaires ne compile pas — le resolver porte encore l'élargissement.
- Doublons de types : Month et User n'étaient atteignables que via des types morts, AuthUser devient le type utilisateur unique ; CategoryBarTooltip utilise CursorPoint au lieu de le redéclarer.
- LocaleObject/LocalesObject : sans consommateur, supprimés — avec eux l'index-signature et son caveat date-fns caduc.
- Slices hebdo : { start, end } au lieu de Array<string|number>, formatage dans la vue. Retire 3 re-parsings de chaîne, à comportement identique.
- Modale des exceptionnels : le message d'erreur de date existait mais aucun emplacement ne l'affichait.

Points « à ne pas toucher » documentés en commentaire : devise en chaîne libre, casse des ID imposée par Prisma, records dynamiques des stats, amount de formulaire = expression Mexp.