### PR TITLE
refactor(stats): flatten MonthlyStats (COS-179)

### DIFF
--- a/front/src/components/spendings/services/useDashboard.ts
+++ b/front/src/components/spendings/services/useDashboard.ts
@@ -1,6 +1,6 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
-import useInitialAmount from "@components/spendings/services/useInitialAmount";
+import useMonthlyStats from "@components/spendings/services/useMonthlyStats";
 import { QUERY_KEYS } from "@lib/query/keys";
 import useRequestHelper from "@src/helpers/useRequestHelper";
 import { DashboardResponseSchema } from "@src/schemas/dashboard";
@@ -32,7 +32,7 @@ const useDashboard = (): UseDashboard => {
   const { from } = useDatePickerWrapperStore();
   const monthBeginning = startOfMonth(from!);
   const queryClient = useQueryClient();
-  const { data: initialAmount } = useInitialAmount();
+  const { data: monthlyStats } = useMonthlyStats();
 
   const getDashboard = async () => {
     const response = await privateRequest(`/dashboard?userID=${userID}&start=${startOfMonth(from!)}`);
@@ -68,8 +68,7 @@ const useDashboard = (): UseDashboard => {
     enabled: !!from && !!userID,
   });
 
-  const totalOfMonth =
-    get.data && initialAmount ? initialAmount.spendingsSum.amount + initialAmount.recurringsSum.amount : 0;
+  const totalOfMonth = get.data && monthlyStats ? monthlyStats.spendingsSum + monthlyStats.recurringsSum : 0;
   const monthlyTotal = Number(totalOfMonth.toFixed(2));
   const remaining = get.data ? Number((get.data.initialAmount - totalOfMonth).toFixed(2)) : 0;
 

--- a/front/src/components/spendings/services/useMonthlyStats.ts
+++ b/front/src/components/spendings/services/useMonthlyStats.ts
@@ -6,14 +6,19 @@ import { MonthlyStatsSchema } from "@src/schemas/dashboard";
 import { useQuery } from "@tanstack/react-query";
 import startOfMonth from "date-fns/startOfMonth";
 
-const useInitialAmount = () => {
+/**
+ * The displayed month's spendings and fixed-expenses totals. Named after what it
+ * reads: it used to feed the dashboard's "initial amount" (the month's income),
+ * which comes from `useDashboard` — the name outlived the data (COS-179).
+ */
+const useMonthlyStats = () => {
   const { privateRequest } = useRequestHelper();
   const { user } = useAuth();
   const userID = user?.id;
   const { from } = useDatePickerWrapperStore();
   const monthBeginning = from ? startOfMonth(from) : null;
 
-  const getInitialAmount = async () => {
+  const getMonthlyStats = async () => {
     if (!from || !userID) {
       throw new Error("Missing date range or user for monthlystats query");
     }
@@ -22,17 +27,17 @@ const useInitialAmount = () => {
       const monthlyStats = await privateRequest(`/monthlystats?userID=${userID}&from=${startOfMonth(from)}`);
       return MonthlyStatsSchema.parse(monthlyStats.data);
     } catch (e) {
-      console.log("get initial amount error : ", e);
+      console.log("get monthly stats error : ", e);
       throw e;
     }
   };
 
   return useQuery({
-    queryKey: [QUERY_KEYS.INITIAL_AMOUNT, monthBeginning],
-    queryFn: getInitialAmount,
+    queryKey: [QUERY_KEYS.MONTHLY_STATS, monthBeginning],
+    queryFn: getMonthlyStats,
     retry: false,
     enabled: !!from && !!userID,
   });
 };
 
-export default useInitialAmount;
+export default useMonthlyStats;

--- a/front/src/components/spendings/services/useReccurings.ts
+++ b/front/src/components/spendings/services/useReccurings.ts
@@ -47,7 +47,7 @@ const useReccurings = () => {
       queryKey: [QUERY_KEYS.DASHBOARD, monthBeginning],
     });
     await queryClient.invalidateQueries({
-      queryKey: [QUERY_KEYS.INITIAL_AMOUNT, monthBeginning],
+      queryKey: [QUERY_KEYS.MONTHLY_STATS, monthBeginning],
     });
   };
 

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -93,7 +93,7 @@ const useSpendings = () => {
       queryKey: [QUERY_KEYS.CATEGORY_STATS],
     });
     await queryClient.invalidateQueries({
-      queryKey: [QUERY_KEYS.INITIAL_AMOUNT, monthBeginning],
+      queryKey: [QUERY_KEYS.MONTHLY_STATS, monthBeginning],
     });
     await queryClient.invalidateQueries({
       queryKey: [QUERY_KEYS.CATEGORY_TRENDS, monthBeginning],

--- a/front/src/lib/query/keys.ts
+++ b/front/src/lib/query/keys.ts
@@ -6,7 +6,7 @@ export const QUERY_KEYS = {
   SPENDINGS_BY_MONTH: "spendingsByMonth",
   RECURRINGS: "recurrings",
   RECURRINGS_DRAWN: "recurringsDrawn",
-  INITIAL_AMOUNT: "initialAmount",
+  MONTHLY_STATS: "monthlyStats",
   DASHBOARD: "dashboard",
   DAILY_PROJECTION: "dailyProjection",
   MONTHLY_INCOME: "monthlyIncome",

--- a/front/src/schemas/__tests__/dashboard.test.ts
+++ b/front/src/schemas/__tests__/dashboard.test.ts
@@ -1,0 +1,34 @@
+import { MonthlyStatsSchema } from "@src/schemas/dashboard";
+
+/**
+ * The /monthlystats contract (COS-179). This query is not in `throwOnError:
+ * false`, so a parse failure blanks the Dashboard *and* the Spendings page —
+ * these lock the shape the backend must keep sending.
+ */
+describe("MonthlyStatsSchema", () => {
+  it("parses the two totals as bare numbers", () => {
+    expect(MonthlyStatsSchema.parse({ spendingsSum: 842.17, recurringsSum: 1250 })).toEqual({
+      spendingsSum: 842.17,
+      recurringsSum: 1250,
+    });
+  });
+
+  it("coerces string totals, since Prisma Decimals serialise either way", () => {
+    expect(MonthlyStatsSchema.parse({ spendingsSum: "842.17", recurringsSum: "1250" })).toEqual({
+      spendingsSum: 842.17,
+      recurringsSum: 1250,
+    });
+  });
+
+  it("rejects the pre-COS-179 wrapper shape", () => {
+    expect(() =>
+      MonthlyStatsSchema.parse({ spendingsSum: { amount: 842.17 }, recurringsSum: { amount: 1250 } }),
+    ).toThrow();
+  });
+
+  it("rejects a missing or non-numeric total instead of defaulting it to 0", () => {
+    expect(() => MonthlyStatsSchema.parse({ spendingsSum: 842.17 })).toThrow();
+    expect(() => MonthlyStatsSchema.parse({ spendingsSum: 842.17, recurringsSum: null })).toThrow();
+    expect(() => MonthlyStatsSchema.parse({ spendingsSum: 842.17, recurringsSum: "n/a" })).toThrow();
+  });
+});

--- a/front/src/schemas/dashboard.ts
+++ b/front/src/schemas/dashboard.ts
@@ -41,13 +41,15 @@ export const MonthlyIncomeResponseSchema = z.object({
 
 export type MonthlyIncomeResponse = z.infer<typeof MonthlyIncomeResponseSchema>;
 
+// The two halves of a month's total spend — GET /monthlystats. One-off spendings
+// on one side, the month's fixed expenses on the other; the dashboard adds them
+// up for "spent this month" and for the remaining-budget delta. Both arrive as
+// bare numbers since COS-179 (they were `{ amount }` wrappers carrying nothing).
 export const MonthlyStatsSchema = z.object({
-  spendingsSum: z.object({
-    amount: numberLikeSchema,
-  }),
-  recurringsSum: z.object({
-    amount: numberLikeSchema,
-  }),
+  spendingsSum: numberLikeSchema,
+  recurringsSum: numberLikeSchema,
 });
+
+export type MonthlyStats = z.infer<typeof MonthlyStatsSchema>;
 
 export const WeeklyStatsSchema = z.array(numberLikeSchema);

--- a/nest-api/src/stats/dto/monthly-stats-response.interface.ts
+++ b/nest-api/src/stats/dto/monthly-stats-response.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * The two halves of a month's total spend (GET /monthlystats?from=…): one-off
+ * spendings on one side, that month's fixed expenses (recurrings) on the other.
+ * The front adds them up for the dashboard's "spent this month" figure and for
+ * the remaining-budget delta against `initialAmount`.
+ *
+ * Both sums are rounded to the cent — summing Prisma `Decimal`s through
+ * `Number()` otherwise leaks float noise. They were shipped as `{ amount }`
+ * wrappers until COS-179; the envelopes carried nothing.
+ *
+ * @example { spendingsSum: 842.17, recurringsSum: 1250 }
+ */
+export interface MonthlyStatsResponse {
+  /** Sum of the month's one-off spendings, 0 when there are none. */
+  spendingsSum: number;
+  /** Sum of the month's fixed expenses, 0 when there are none. */
+  recurringsSum: number;
+}

--- a/nest-api/src/stats/stats.service.spec.ts
+++ b/nest-api/src/stats/stats.service.spec.ts
@@ -790,3 +790,74 @@ describe("StatsService.getSearchTimeline", () => {
     );
   });
 });
+
+/**
+ * Unit tests for StatsService.getMonthlyStats — the two halves of a month's
+ * total spend (one-off spendings + that month's fixed expenses), backing the
+ * dashboard's "spent this month" and remaining-budget figures. Prisma is mocked;
+ * these assert the query shape and the flat `{ spendingsSum, recurringsSum }`
+ * contract introduced by COS-179.
+ */
+describe("StatsService.getMonthlyStats", () => {
+  const makeService = (spendingsTotal: unknown, recurringsTotal: unknown) => {
+    const spendingsAggregate = jest.fn().mockResolvedValue({ _sum: { amount: spendingsTotal } });
+    const recurringsAggregate = jest.fn().mockResolvedValue({ _sum: { amount: recurringsTotal } });
+    const prisma = {
+      spendings: { aggregate: spendingsAggregate },
+      recurrings: { aggregate: recurringsAggregate },
+    } as unknown as never;
+    return { service: new StatsService(prisma), spendingsAggregate, recurringsAggregate };
+  };
+
+  it("sums the month's spendings over an inclusive range and its recurrings on their exact bounds", async () => {
+    const { service, spendingsAggregate, recurringsAggregate } = makeService(0, 0);
+
+    await service.getMonthlyStats("2026-06-15", "user-1");
+
+    // Recurrings carry the month bounds as their own columns — matched exactly,
+    // not as a range, since one row spans the whole month.
+    expect(recurringsAggregate).toHaveBeenCalledWith({
+      where: {
+        userID: "user-1",
+        dateFrom: new Date(Date.UTC(2026, 5, 1)),
+        dateTo: new Date(Date.UTC(2026, 5, 30)),
+      },
+      _sum: { amount: true },
+    });
+    expect(spendingsAggregate).toHaveBeenCalledWith({
+      where: {
+        userID: "user-1",
+        date: { gte: new Date(Date.UTC(2026, 5, 1)), lte: new Date(Date.UTC(2026, 5, 30)) },
+      },
+      _sum: { amount: true },
+    });
+  });
+
+  it("returns both totals as bare numbers", async () => {
+    const { service } = makeService(842.17, 1250);
+
+    await expect(service.getMonthlyStats("2026-06-15", "user-1")).resolves.toEqual({
+      spendingsSum: 842.17,
+      recurringsSum: 1250,
+    });
+  });
+
+  it("reports 0 on each side when the month is empty", async () => {
+    const { service } = makeService(null, null);
+
+    await expect(service.getMonthlyStats("2026-06-15", "user-1")).resolves.toEqual({
+      spendingsSum: 0,
+      recurringsSum: 0,
+    });
+  });
+
+  it("coerces Prisma Decimal sums and rounds them to the cent", async () => {
+    const decimal = (value: string) => ({ toString: () => value }) as unknown as number;
+    const { service } = makeService(decimal("120.005"), decimal("99.999"));
+
+    await expect(service.getMonthlyStats("2026-06-15", "user-1")).resolves.toEqual({
+      spendingsSum: 120.01,
+      recurringsSum: 100,
+    });
+  });
+});

--- a/nest-api/src/stats/stats.service.ts
+++ b/nest-api/src/stats/stats.service.ts
@@ -10,6 +10,7 @@ import type { DailyStat, DailyStatsResponse } from "@stats/dto/daily-stats-respo
 import type { BiggestRegularExpenseResponse } from "@stats/dto/biggest-regular-expense-response.interface";
 import type { CategoryTrendPoint, CategoryTrendsResponse } from "@stats/dto/category-trends-response.interface";
 import type { BusiestWeekResponse } from "@stats/dto/busiest-week-response.interface";
+import type { MonthlyStatsResponse } from "@stats/dto/monthly-stats-response.interface";
 import type { SpendingPaceResponse } from "@stats/dto/spending-pace-response.interface";
 import type { WeekdayCategoriesResponse, WeekdayCategory } from "@stats/dto/weekday-categories-response.interface";
 import type { SearchTimelineBucket, SearchTimelineResponse } from "@stats/dto/search-timeline-response.interface";
@@ -223,10 +224,7 @@ export class StatsService {
     return { monthlyAverage: total / monthsElapsed };
   }
 
-  async getMonthlyStats(
-    from: string,
-    userID: string,
-  ): Promise<{ spendingsSum: { amount: string }; recurringsSum: { amount: string } }> {
+  async getMonthlyStats(from: string, userID: string): Promise<MonthlyStatsResponse> {
     const fromDate = new Date(from);
     const start = format(startOfMonth(fromDate), "yyyy-MM-dd");
     const end = format(endOfMonth(fromDate), "yyyy-MM-dd");
@@ -252,14 +250,10 @@ export class StatsService {
       }),
     ]);
 
-    const recurringsSum = {
-      amount: String(recurringsResult._sum.amount ?? 0),
+    return {
+      spendingsSum: round2(Number(spendingsResult._sum.amount ?? 0)),
+      recurringsSum: round2(Number(recurringsResult._sum.amount ?? 0)),
     };
-    const spendingsSum = {
-      amount: String(spendingsResult._sum.amount ?? 0),
-    };
-
-    return { spendingsSum, recurringsSum };
   }
 
   /**


### PR DESCRIPTION
GET /monthlystats shipped its two totals inside single-field wrappers, { spendingsSum: { amount }, recurringsSum: { amount } }. The envelopes carried nothing. Both sides now exchange bare numbers.

Back: adds the missing MonthlyStatsResponse interface (every other stats endpoint has one) and returns round2(Number(...)) instead of String(...), matching the sibling endpoints that kill the float noise of summed Prisma Decimals. The front already coerced those strings through numberLikeSchema, so the arriving type is unchanged — only the wrapper goes.

Front: MonthlyStatsSchema flattened, and the month total in useDashboard reads the two sums directly.

useInitialAmount is renamed useMonthlyStats: it calls /monthlystats and returns the month's spendings + fixed-expenses totals. The actual initial amount (the month's income) comes from useDashboard's own /dashboard query, so the name pointed at data the hook stopped reading long ago. Its cache key INITIAL_AMOUNT is renamed with it — same misnomer, and it is referenced by the useSpendings and useReccurings invalidations.

Both sides had zero coverage. Adds 4 service tests (query shape, flat return, empty month, Decimal coercion + cent rounding) and 4 schema tests, one of which pins the rejection of the old wrapper shape.

Front and back must ship together: the query is not throwOnError: false, so a mismatched contract blanks the Dashboard and the Spendings page.