### PR TITLE
fix: bound text fields on their columns (COS-180)

### DIFF
--- a/front/src/auth/useSignupService.ts
+++ b/front/src/auth/useSignupService.ts
@@ -4,6 +4,7 @@ import useRequestHelper from "@helpers/useRequestHelper";
 import { pickSupportedLocale } from "@i18n/pickSupportedLocale";
 import useTranslations from "@i18n/useTranslations";
 import { AuthResponseSchema } from "@src/schemas/auth";
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
 import { toast } from "sonner";
 
 import type { AuthResponse } from "@auth/interfaces/authTypes";
@@ -20,7 +21,10 @@ const useSignupService = () => {
       const res = await request("/users/add", {
         method: "POST",
         data: {
-          name: email.split("@")[0],
+          // Users.name is a VarChar(20) and the signup form has no name field:
+          // a long email local part used to reach the insert and fail as a raw
+          // SQL error, with nothing the user could fix (COS-180).
+          name: email.split("@")[0].slice(0, FIELD_LIMITS.userName),
           email,
           password,
           registerDate: new Date(),

--- a/front/src/components/categories/CategoryFormModal.tsx
+++ b/front/src/components/categories/CategoryFormModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "@components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@components/ui/dialog";
 import useTranslations from "@i18n/useTranslations";
 import { cn } from "@lib/utils";
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
 import { useMemo, useState } from "react";
 
 const LABEL = overlineClass;
@@ -39,6 +40,7 @@ const CategoryFormBody = ({
   onCancel: () => void;
 }) => {
   const categories = useTranslations("categories");
+  const common = useTranslations("common");
   const { form } = categories;
   const swatches = useMemo(() => paletteHex(), []);
   const [name, setName] = useState(initialName);
@@ -49,6 +51,10 @@ const CategoryFormBody = ({
     const trimmed = name.trim().toLowerCase();
     if (!trimmed) {
       setError(form.errorNameRequired);
+      return;
+    }
+    if (trimmed.length > FIELD_LIMITS.categoryName) {
+      setError(common.validation.tooLong(FIELD_LIMITS.categoryName));
       return;
     }
     if (takenNames.includes(trimmed)) {

--- a/front/src/components/exceptionals/ExceptionalModal.tsx
+++ b/front/src/components/exceptionals/ExceptionalModal.tsx
@@ -2,6 +2,7 @@
 
 import { useAuth } from "@auth/context/AuthContext";
 import { CATEGORY_FALLBACK } from "@components/categories/helpers/categoryColors";
+import { makeExceptionalSchema } from "@components/exceptionals/schema";
 import useExceptionals from "@components/exceptionals/services/useExceptionals";
 import { comboboxTriggerClass } from "@components/shared/comboboxTriggerClass";
 import { FieldShell } from "@components/shared/FieldShell";
@@ -13,26 +14,14 @@ import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover"
 import { zodResolver } from "@hookform/resolvers/zod";
 import useTranslations from "@i18n/useTranslations";
 import evaluateAmountExpression from "@lib/amountExpression";
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
 import format from "date-fns/format";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 
+import type { ExceptionalForm } from "@components/exceptionals/schema";
 import type { ExceptionalItem } from "@src/schemas/exceptionals";
-import type { Dictionary } from "@text/index";
-
-const makeFormSchema = (errors: Dictionary["exceptionals"]["modal"]["errors"]) =>
-  z.object({
-    label: z.string().min(1, errors.labelRequired),
-    // As in the spending modal, a string on purpose: it holds a Mexp expression,
-    // evaluated on submit by @lib/amountExpression (COS-109).
-    amount: z.string().min(1, errors.amountRequired),
-    date: z.string().min(1, errors.dateRequired),
-    description: z.string().optional(),
-  });
-
-type FormValues = z.infer<ReturnType<typeof makeFormSchema>>;
 
 interface CategoryOption {
   name: string;
@@ -62,8 +51,9 @@ const getRandomHexColor = () => {
 
 const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories }: ExceptionalModalProps) => {
   const exceptionals = useTranslations("exceptionals");
+  const common = useTranslations("common");
   const { modal, actions } = exceptionals;
-  const formSchema = makeFormSchema(modal.errors);
+  const formSchema = makeExceptionalSchema(modal.errors, common.validation);
   const [open, setOpen] = useState(true);
   const closeModal = () => {
     setOpen(false);
@@ -88,7 +78,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
     register,
     handleSubmit,
     formState: { errors, isSubmitting, isValid },
-  } = useForm<FormValues>({
+  } = useForm<ExceptionalForm>({
     resolver: zodResolver(formSchema),
     mode: "onChange",
     defaultValues: {
@@ -103,7 +93,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
 
   const exactMatch = categoryOptions.find((c) => c.name.toLowerCase() === comboboxQuery.trim().toLowerCase());
 
-  const onSubmit = (values: FormValues) => {
+  const onSubmit = (values: ExceptionalForm) => {
     if (!user) {
       console.error("User is not available");
       return;
@@ -207,6 +197,7 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
               </>
             }
             htmlFor="exceptional-description"
+            error={errors.description?.message}
           >
             <TextInput
               id="exceptional-description"
@@ -251,6 +242,10 @@ const ExceptionalModal = ({ closeModal: closeModalProp, item, existingCategories
                     placeholder={modal.category.searchPlaceholder}
                     value={comboboxQuery}
                     onValueChange={setComboboxQuery}
+                    // The typed name is committed as-is, and this combobox has no
+                    // error slot — so the bound is enforced at the keystroke
+                    // rather than reported after the fact (COS-180).
+                    maxLength={FIELD_LIMITS.exceptionalCategoryName}
                     className="text-ink"
                   />
                   <CommandList>

--- a/front/src/components/exceptionals/schema.ts
+++ b/front/src/components/exceptionals/schema.ts
@@ -1,0 +1,19 @@
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
+import { z } from "zod";
+
+import type { Dictionary } from "@text/index";
+
+export const makeExceptionalSchema = (
+  errors: Dictionary["exceptionals"]["modal"]["errors"],
+  common: Dictionary["common"]["validation"],
+) =>
+  z.object({
+    label: z.string().min(1, errors.labelRequired).max(FIELD_LIMITS.label, common.tooLong(FIELD_LIMITS.label)),
+    // As in the spending modal, a string on purpose: it holds a Mexp expression,
+    // evaluated on submit by @lib/amountExpression (COS-109).
+    amount: z.string().min(1, errors.amountRequired),
+    date: z.string().min(1, errors.dateRequired),
+    description: z.string().max(FIELD_LIMITS.description, common.tooLong(FIELD_LIMITS.description)).optional(),
+  });
+
+export type ExceptionalForm = z.infer<ReturnType<typeof makeExceptionalSchema>>;

--- a/front/src/components/shared/sharedLoginForm/schema.ts
+++ b/front/src/components/shared/sharedLoginForm/schema.ts
@@ -1,0 +1,38 @@
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
+import { z } from "zod";
+
+import type { Dictionary } from "@text/index";
+
+export const makeLoginSchema = (
+  needEmail: boolean,
+  needPassword: boolean,
+  needConfirm: boolean,
+  needCurrency: boolean,
+  validation: Dictionary["login"]["validation"],
+  common: Dictionary["common"]["validation"],
+) =>
+  z
+    .object({
+      // A hidden field validates as a plain `z.string()`, never `.optional()`:
+      // the form's `defaultValues` always supplies "" for it, so the value is
+      // present either way. Keeping it required is what makes `z.infer` resolve
+      // to all required strings instead of collapsing every field to
+      // `string | undefined` — the root cause of the `values.email!` assertions
+      // in the callers (COS-109).
+      email: needEmail
+        ? z
+            .string()
+            .min(1, validation.emailRequired)
+            .email(validation.emailInvalid)
+            .max(FIELD_LIMITS.email, common.tooLong(FIELD_LIMITS.email))
+        : z.string(),
+      password: needPassword ? z.string().min(1, validation.passwordRequired) : z.string(),
+      confirmPassword: needConfirm ? z.string().min(1, validation.confirmRequired) : z.string(),
+      currency: needCurrency ? z.string().min(1) : z.string(),
+    })
+    .refine((d) => !needConfirm || d.password === d.confirmPassword, {
+      message: validation.passwordMismatch,
+      path: ["confirmPassword"],
+    });
+
+export type LoginForm = z.infer<ReturnType<typeof makeLoginSchema>>;

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -3,6 +3,7 @@
 import { overlineClass } from "@components/shared/Overline";
 import { authInputClass } from "@components/shared/sharedLoginForm/authInputClass";
 import { PasswordField } from "@components/shared/sharedLoginForm/PasswordField";
+import { makeLoginSchema } from "@components/shared/sharedLoginForm/schema";
 import { Button } from "@components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@components/ui/select";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -11,34 +12,9 @@ import currencyCodes from "@src/currency-codes.json";
 import getSymbolFromCurrency from "currency-symbol-map";
 import { ArrowRight } from "lucide-react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 
 import type { SharedLoginFormProps } from "@components/shared/interfaces/sharedLoginFormTypes";
-import type { Dictionary } from "@text/index";
-
-const buildSchema = (
-  needEmail: boolean,
-  needPassword: boolean,
-  needConfirm: boolean,
-  needCurrency: boolean,
-  validation: Dictionary["login"]["validation"],
-) =>
-  z
-    .object({
-      // A hidden field validates as a plain `z.string()`, never `.optional()`:
-      // `defaultValues` below always supplies "" for it, so the value is present
-      // either way. Keeping it required is what makes `z.infer` resolve to all
-      // required strings instead of collapsing every field to `string | undefined`
-      // — the root cause of the `values.email!` assertions in the callers (COS-109).
-      email: needEmail ? z.string().min(1, validation.emailRequired).email(validation.emailInvalid) : z.string(),
-      password: needPassword ? z.string().min(1, validation.passwordRequired) : z.string(),
-      confirmPassword: needConfirm ? z.string().min(1, validation.confirmRequired) : z.string(),
-      currency: needCurrency ? z.string().min(1) : z.string(),
-    })
-    .refine((d) => !needConfirm || d.password === d.confirmPassword, {
-      message: validation.passwordMismatch,
-      path: ["confirmPassword"],
-    });
+import type { LoginForm } from "@components/shared/sharedLoginForm/schema";
 
 const LABEL = overlineClass;
 
@@ -69,15 +45,15 @@ const SharedLoginForm = ({
   onDismissError,
 }: SharedLoginFormProps) => {
   const login = useTranslations("login");
-  const schema = buildSchema(
+  const common = useTranslations("common");
+  const schema = makeLoginSchema(
     !!displayEmailField,
     !!displayPasswordField,
     !!displayConfirmPasswordField,
     !!displayCurrencyField,
     login.validation,
+    common.validation,
   );
-
-  type FormValues = z.infer<typeof schema>;
 
   const {
     register,
@@ -86,7 +62,7 @@ const SharedLoginForm = ({
     watch,
     clearErrors,
     formState: { errors, isSubmitting },
-  } = useForm<FormValues>({
+  } = useForm<LoginForm>({
     resolver: zodResolver(schema),
     defaultValues: {
       email: "",
@@ -106,7 +82,7 @@ const SharedLoginForm = ({
     errors.email?.message || errors.password?.message || errors.confirmPassword?.message || errors.currency?.message;
   const formMessage = serverError || (fieldError ? String(fieldError) : null);
 
-  const clearFieldError = (field: keyof FormValues) => () => {
+  const clearFieldError = (field: keyof LoginForm) => () => {
     clearErrors(field);
     onDismissError?.();
   };

--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -58,6 +58,7 @@ const SpendingModal = ({
   month = null,
 }: SpendingModalProps) => {
   const spendings = useTranslations("spendings");
+  const common = useTranslations("common");
   const [open, setOpen] = useState(true);
   const closeModal = () => {
     setOpen(false);
@@ -146,7 +147,7 @@ const SpendingModal = ({
     clearErrors,
     formState: { errors, isSubmitting },
   } = useForm<SpendingForm>({
-    resolver: zodResolver(makeSpendingSchema(spendings.modal.validation)),
+    resolver: zodResolver(makeSpendingSchema(spendings.modal.validation, common.validation)),
     mode: "onChange",
     defaultValues: {
       spendingLabel: spending?.label ?? "",

--- a/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
+++ b/front/src/components/spendings/common/spendingModal/fields/CategoryField.tsx
@@ -6,6 +6,7 @@ import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, Command
 import { Popover, PopoverContent, PopoverTrigger } from "@components/ui/popover";
 import useTranslations from "@i18n/useTranslations";
 import { cn } from "@lib/utils";
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
 import { Check, ChevronsUpDown } from "lucide-react";
 
 import type { CategoryOption } from "@components/spendings/common/spendingModal/schema";
@@ -117,6 +118,11 @@ const CategoryField = ({
               placeholder={t.category.searchPlaceholder}
               value={comboboxQuery}
               onValueChange={setComboboxQuery}
+              // Whatever is typed is committed as a category name — on selection
+              // or simply on close — and this combobox has no error slot, so the
+              // bound is enforced at the keystroke rather than reported after the
+              // fact (COS-180).
+              maxLength={FIELD_LIMITS.categoryName}
               className="text-ink"
             />
             <CommandList>

--- a/front/src/components/spendings/common/spendingModal/schema.ts
+++ b/front/src/components/spendings/common/spendingModal/schema.ts
@@ -1,11 +1,18 @@
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
 import { z } from "zod";
 
 import type { SpendingCategoryInputSchema } from "@src/schemas/spendings";
 import type { Dictionary } from "@text/index";
 
-export const makeSpendingSchema = (validation: Dictionary["spendings"]["modal"]["validation"]) =>
+export const makeSpendingSchema = (
+  validation: Dictionary["spendings"]["modal"]["validation"],
+  common: Dictionary["common"]["validation"],
+) =>
   z.object({
-    spendingLabel: z.string().min(1, validation.labelRequired),
+    spendingLabel: z
+      .string()
+      .min(1, validation.labelRequired)
+      .max(FIELD_LIMITS.label, common.tooLong(FIELD_LIMITS.label)),
     // Deliberately a string, not a number (COS-109): the field accepts an
     // arithmetic expression ("12+3"), evaluated on submit by @lib/amountExpression.
     spendingAmount: z.string().min(1, validation.amountRequired),

--- a/front/src/schemas/__tests__/fieldLimits.test.ts
+++ b/front/src/schemas/__tests__/fieldLimits.test.ts
@@ -1,0 +1,90 @@
+import { makeExceptionalSchema } from "@components/exceptionals/schema";
+import { makeLoginSchema } from "@components/shared/sharedLoginForm/schema";
+import { makeSpendingSchema } from "@components/spendings/common/spendingModal/schema";
+import { FIELD_LIMITS } from "@src/schemas/fieldLimits";
+import { dictionaries } from "@text/index";
+
+import type { ZodSafeParseResult } from "zod";
+
+/**
+ * COS-180 — every bounded form field refuses one character over its column width
+ * and says so with the shared `common.validation.tooLong` message, instead of
+ * letting the value reach MySQL and come back as a raw SQL error.
+ *
+ * The real FR dictionary is used on purpose: it checks the message the user
+ * actually reads, not a stub.
+ */
+const { common, exceptionals, login, spendings } = dictionaries.fr;
+
+const spendingSchema = makeSpendingSchema(spendings.modal.validation, common.validation);
+const exceptionalSchema = makeExceptionalSchema(exceptionals.modal.errors, common.validation);
+const loginSchema = makeLoginSchema(true, true, true, true, login.validation, common.validation);
+
+const validSpending = { spendingLabel: "Courses", spendingAmount: "12", spendingDate: "2026-07-01" };
+const validExceptional = { label: "Réparation", amount: "320", date: "2026-07-01", description: "Garage" };
+const validLogin = { email: "someone@example.com", password: "hunter2", confirmPassword: "hunter2", currency: "EUR" };
+
+const filler = (length: number) => "x".repeat(length);
+
+/** A syntactically valid email of exactly `length` chars (long domain, short local part). */
+const email = (length: number) => {
+  const local = "a".repeat(60);
+  const labels: string[] = [];
+  let remaining = length - local.length - 1;
+  while (remaining > 0) {
+    const take = Math.min(60, remaining);
+    labels.push("b".repeat(take));
+    remaining -= take + 1;
+  }
+  return `${local}@${labels.join(".")}`;
+};
+
+const outcome = (result: ZodSafeParseResult<unknown>) => ({
+  success: result.success,
+  messages: result.success ? [] : result.error.issues.map((issue) => issue.message),
+});
+
+interface Case {
+  name: string;
+  max: number;
+  build: (length: number) => string;
+  check: (value: string) => { success: boolean; messages: string[] };
+}
+
+const cases: Case[] = [
+  {
+    name: "spending label",
+    max: FIELD_LIMITS.label,
+    build: filler,
+    check: (value) => outcome(spendingSchema.safeParse({ ...validSpending, spendingLabel: value })),
+  },
+  {
+    name: "exceptional label",
+    max: FIELD_LIMITS.label,
+    build: filler,
+    check: (value) => outcome(exceptionalSchema.safeParse({ ...validExceptional, label: value })),
+  },
+  {
+    name: "exceptional description",
+    max: FIELD_LIMITS.description,
+    build: filler,
+    check: (value) => outcome(exceptionalSchema.safeParse({ ...validExceptional, description: value })),
+  },
+  {
+    name: "signup email",
+    max: FIELD_LIMITS.email,
+    build: email,
+    check: (value) => outcome(loginSchema.safeParse({ ...validLogin, email: value })),
+  },
+];
+
+it.each(cases)("$name accepts exactly $max characters", ({ max, build, check }) => {
+  expect(check(build(max))).toEqual({ success: true, messages: [] });
+});
+
+it.each(cases)("$name rejects one character over $max", ({ max, build, check }) => {
+  const result = check(build(max + 1));
+
+  expect(result.success).toBe(false);
+  expect(result.messages).toContain(common.validation.tooLong(max));
+});

--- a/front/src/schemas/fieldLimits.ts
+++ b/front/src/schemas/fieldLimits.ts
@@ -1,0 +1,28 @@
+/**
+ * Maximum lengths of the user-writable text fields, mirroring the `VarChar`
+ * columns they land in (COS-180). Nothing validated a length before: an
+ * oversized input travelled all the way to MySQL and came back as a raw SQL
+ * error instead of a form message.
+ *
+ * The backend mirrors this table in `nest-api/src/config/field-limits.ts`, where
+ * a spec asserts it against `schema.prisma` — the two must move together, and
+ * both only ever move with the column.
+ */
+export const FIELD_LIMITS = {
+  /** `Spendings.label` and `Recurrings.label` — the spending modal's label. */
+  label: 100,
+  /** `Exceptionals.description`. */
+  description: 255,
+  /** `Categories.name` — the categories the spendings reference. */
+  categoryName: 20,
+  /**
+   * `Exceptionals.categoryName` — exceptionals keep their category inline
+   * instead of referencing `Categories`, and the column is wider. Each field is
+   * bounded on its own column; the divergence predates COS-180.
+   */
+  exceptionalCategoryName: 50,
+  /** `Users.name` — derived from the email's local part at signup. */
+  userName: 20,
+  /** `Users.email`. */
+  email: 250,
+} as const;

--- a/front/src/text/en/common.ts
+++ b/front/src/text/en/common.ts
@@ -30,6 +30,9 @@ const common: typeof frCommon = {
   category: {
     uncategorized: "uncategorized",
   },
+  validation: {
+    tooLong: (max: number) => `${max} characters max`,
+  },
   loading: "Loading…",
   searchPlaceholder: "Search…",
   optional: "(optional)",

--- a/front/src/text/fr/common.ts
+++ b/front/src/text/fr/common.ts
@@ -28,6 +28,10 @@ const common = {
   category: {
     uncategorized: "sans catégorie",
   },
+  validation: {
+    /** Shared by every bounded text field — the bound comes from its DB column (COS-180). */
+    tooLong: (max: number) => `${max} caractères maximum`,
+  },
   loading: "Chargement…",
   searchPlaceholder: "Rechercher…",
   optional: "(optionnel)",

--- a/nest-api/src/categories/dto/update-category.dto.ts
+++ b/nest-api/src/categories/dto/update-category.dto.ts
@@ -1,11 +1,14 @@
-import { IsNotEmpty, IsString } from "class-validator";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class UpdateCategoryDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.categoryName)
   name: string;
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.color)
   color: string;
 }

--- a/nest-api/src/config/field-limits.spec.ts
+++ b/nest-api/src/config/field-limits.spec.ts
@@ -1,0 +1,155 @@
+// The DTO decorators write their metadata through Reflect — Nest loads this in
+// main.ts, a bare unit spec has to do it itself.
+import "reflect-metadata";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { FIELD_LIMITS } from "@config/field-limits";
+import { CreateSpendingDto } from "../spendings/dto/create-spending.dto";
+import { UpdateSpendingDto } from "../spendings/dto/update-spending.dto";
+import { CreateSpendingCategoryDto } from "../spendings/dto/create-spending-category.dto";
+import { UpdateCategoryDto } from "../categories/dto/update-category.dto";
+import { CreateRecurringDto } from "../recurrings/dto/create-recurring.dto";
+import { UpdateRecurringDto } from "../recurrings/dto/update-recurring.dto";
+import { CreateExceptionalDto } from "../exceptionals/dto/create-exceptional.dto";
+import { UpdateExceptionalDto } from "../exceptionals/dto/update-exceptional.dto";
+import { AddUserDto } from "../users/dto/add-user.dto";
+import { SignInDto } from "../users/dto/sign-in.dto";
+
+/**
+ * COS-180 — every user-writable text field is bounded on the width of the column
+ * it lands in, so an oversized input is refused by validation instead of blowing
+ * up as a raw SQL error at insert time.
+ *
+ * Two guards: the constants still match `schema.prisma`, and each DTO field
+ * actually carries the bound.
+ */
+describe("FIELD_LIMITS", () => {
+  const schema = readFileSync(join(__dirname, "..", "..", "prisma", "schema.prisma"), "utf8");
+
+  /** Width of a model's `@db.VarChar(n)` column, read straight from the schema. */
+  const columnWidth = (model: string, column: string): number | null => {
+    const block = new RegExp(`model ${model} \\{([\\s\\S]*?)\\n\\}`).exec(schema)?.[1];
+    if (!block) return null;
+    const line = new RegExp(`^\\s*${column}\\s+\\S+\\s.*@db\\.VarChar\\((\\d+)\\)`, "m").exec(block);
+    return line ? Number(line[1]) : null;
+  };
+
+  it.each([
+    ["label", "Spendings", "label"],
+    ["label", "Recurrings", "label"],
+    ["description", "Exceptionals", "description"],
+    ["categoryName", "Categories", "name"],
+    ["exceptionalCategoryName", "Exceptionals", "categoryName"],
+    ["color", "Categories", "color"],
+    ["color", "Exceptionals", "categoryColor"],
+    ["userName", "Users", "name"],
+    ["email", "Users", "email"],
+    ["currency", "Spendings", "currency"],
+    ["currency", "Users", "baseCurrency"],
+    ["language", "Users", "language"],
+  ])("%s mirrors %s.%s in schema.prisma", (limit, model, column) => {
+    expect(columnWidth(model, column)).toBe(FIELD_LIMITS[limit as keyof typeof FIELD_LIMITS]);
+  });
+});
+
+describe("DTO length bounds", () => {
+  /**
+   * A syntactically valid email of exactly `length` chars, so the case isolates
+   * the length bound: `@IsEmail` caps the local part at 64 and each domain label
+   * at 63, hence a short local part and a domain split into 60-char labels.
+   */
+  const email = (length: number) => {
+    const local = "a".repeat(60);
+    const labels: string[] = [];
+    let remaining = length - local.length - 1;
+    while (remaining > 0) {
+      const take = Math.min(60, remaining);
+      labels.push("b".repeat(take));
+      remaining -= take + 1;
+    }
+    return `${local}@${labels.join(".")}`;
+  };
+
+  const spending = { date: "2026-07-01", label: "Courses", amount: 12.5, currency: "EUR" };
+  const recurring = { start: "2026-07-01", end: "2026-07-31", label: "Loyer", amount: 900, currency: "EUR" };
+  const exceptional = {
+    date: "2026-07-01",
+    label: "Réparation",
+    description: "Garage",
+    amount: 320,
+    currency: "EUR",
+    categoryName: "auto",
+    categoryColor: "#84c4f5",
+  };
+  const user = { name: "someone", email: "someone@example.com", password: "hunter2", baseCurrency: "EUR" };
+  const signIn = { email: "someone@example.com", password: "hunter2" };
+  const category = { name: "courses", color: "#84c4f5" };
+
+  // Object rows, not tuples: with a tuple shorter than the callback's parameter
+  // list, jest fills the gap with its `done` callback instead of `undefined`.
+  interface Case {
+    Dto: new () => object;
+    base: Record<string, unknown>;
+    field: string;
+    max: number;
+    /** How to build a value of a given length, when "xxx…" would not validate. */
+    build?: (length: number) => string;
+  }
+
+  const cases: Case[] = [
+    { Dto: CreateSpendingDto, base: spending, field: "label", max: FIELD_LIMITS.label },
+    { Dto: CreateSpendingDto, base: spending, field: "currency", max: FIELD_LIMITS.currency },
+    { Dto: UpdateSpendingDto, base: spending, field: "label", max: FIELD_LIMITS.label },
+    { Dto: CreateSpendingCategoryDto, base: { name: "courses" }, field: "name", max: FIELD_LIMITS.categoryName },
+    { Dto: CreateSpendingCategoryDto, base: { name: "courses" }, field: "color", max: FIELD_LIMITS.color },
+    { Dto: UpdateCategoryDto, base: category, field: "name", max: FIELD_LIMITS.categoryName },
+    { Dto: UpdateCategoryDto, base: category, field: "color", max: FIELD_LIMITS.color },
+    { Dto: CreateRecurringDto, base: recurring, field: "label", max: FIELD_LIMITS.label },
+    { Dto: CreateRecurringDto, base: recurring, field: "currency", max: FIELD_LIMITS.currency },
+    { Dto: UpdateRecurringDto, base: recurring, field: "label", max: FIELD_LIMITS.label },
+    { Dto: CreateExceptionalDto, base: exceptional, field: "label", max: FIELD_LIMITS.label },
+    { Dto: CreateExceptionalDto, base: exceptional, field: "description", max: FIELD_LIMITS.description },
+    {
+      Dto: CreateExceptionalDto,
+      base: exceptional,
+      field: "categoryName",
+      max: FIELD_LIMITS.exceptionalCategoryName,
+    },
+    { Dto: CreateExceptionalDto, base: exceptional, field: "categoryColor", max: FIELD_LIMITS.color },
+    { Dto: UpdateExceptionalDto, base: exceptional, field: "label", max: FIELD_LIMITS.label },
+    { Dto: UpdateExceptionalDto, base: exceptional, field: "description", max: FIELD_LIMITS.description },
+    {
+      Dto: UpdateExceptionalDto,
+      base: exceptional,
+      field: "categoryName",
+      max: FIELD_LIMITS.exceptionalCategoryName,
+    },
+    { Dto: AddUserDto, base: user, field: "name", max: FIELD_LIMITS.userName },
+    { Dto: AddUserDto, base: user, field: "email", max: FIELD_LIMITS.email, build: email },
+    { Dto: AddUserDto, base: user, field: "baseCurrency", max: FIELD_LIMITS.currency },
+    { Dto: SignInDto, base: signIn, field: "email", max: FIELD_LIMITS.email, build: email },
+  ];
+
+  const errorsFor = async (Dto: new () => object, payload: Record<string, unknown>, property: string) => {
+    const errors = await validate(plainToInstance(Dto, payload));
+    return errors.filter((error) => error.property === property);
+  };
+
+  const valueOf = ({ build }: Case, length: number) => (build ?? ((n: number) => "x".repeat(n)))(length);
+
+  it.each(cases)("$Dto.name — $field accepts exactly $max characters", async (testCase) => {
+    const { Dto, base, field, max } = testCase;
+
+    expect(await errorsFor(Dto, { ...base, [field]: valueOf(testCase, max) }, field)).toEqual([]);
+  });
+
+  it.each(cases)("$Dto.name — $field rejects one character over $max", async (testCase) => {
+    const { Dto, base, field, max } = testCase;
+
+    const errors = await errorsFor(Dto, { ...base, [field]: valueOf(testCase, max + 1) }, field);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty("maxLength");
+  });
+});

--- a/nest-api/src/config/field-limits.ts
+++ b/nest-api/src/config/field-limits.ts
@@ -1,0 +1,34 @@
+/**
+ * Maximum lengths of the user-writable text columns, mirroring
+ * `prisma/schema.prisma` (COS-180). Nothing validated a length before: an
+ * oversized input travelled all the way to MySQL and came back as a raw SQL
+ * error instead of a form message.
+ *
+ * The front mirrors this table in `front/src/schemas/fieldLimits.ts` — the two
+ * must move together, and both only ever move with the column.
+ */
+export const FIELD_LIMITS = {
+  /** `Spendings.label` and `Recurrings.label` — same width. */
+  label: 100,
+  /** `Exceptionals.description`. */
+  description: 255,
+  /** `Categories.name` — the categories the spendings reference. */
+  categoryName: 20,
+  /**
+   * `Exceptionals.categoryName` — exceptionals keep their category inline
+   * instead of referencing `Categories`, and the column is wider. Bounded on its
+   * own column, as the ticket asks; the divergence with `categoryName` predates
+   * COS-180.
+   */
+  exceptionalCategoryName: 50,
+  /** `Categories.color` and `Exceptionals.categoryColor` — hex, never near it. */
+  color: 20,
+  /** `Users.name`. */
+  userName: 20,
+  /** `Users.email`. */
+  email: 250,
+  /** `*.currency` and `Users.baseCurrency` — ISO 4217 codes. */
+  currency: 3,
+  /** `Users.language` — locale keys. */
+  language: 3,
+} as const;

--- a/nest-api/src/exceptionals/dto/create-exceptional.dto.ts
+++ b/nest-api/src/exceptionals/dto/create-exceptional.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class CreateExceptionalDto {
   @IsString()
@@ -8,10 +9,12 @@ export class CreateExceptionalDto {
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.description)
   description?: string;
 
   @IsNumber()
@@ -20,13 +23,16 @@ export class CreateExceptionalDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.currency)
   currency?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.exceptionalCategoryName)
   categoryName?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.color)
   categoryColor?: string;
 }

--- a/nest-api/src/exceptionals/dto/update-exceptional.dto.ts
+++ b/nest-api/src/exceptionals/dto/update-exceptional.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class UpdateExceptionalDto {
   @IsString()
@@ -8,10 +9,12 @@ export class UpdateExceptionalDto {
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.description)
   description?: string;
 
   @IsNumber()
@@ -20,9 +23,11 @@ export class UpdateExceptionalDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.exceptionalCategoryName)
   categoryName?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.color)
   categoryColor?: string;
 }

--- a/nest-api/src/recurrings/dto/create-recurring.dto.ts
+++ b/nest-api/src/recurrings/dto/create-recurring.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class CreateRecurringDto {
   @IsString()
@@ -12,6 +13,7 @@ export class CreateRecurringDto {
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsNumber()
@@ -20,5 +22,6 @@ export class CreateRecurringDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.currency)
   currency?: string;
 }

--- a/nest-api/src/recurrings/dto/update-recurring.dto.ts
+++ b/nest-api/src/recurrings/dto/update-recurring.dto.ts
@@ -1,9 +1,11 @@
-import { IsNotEmpty, IsNumber, IsString } from "class-validator";
+import { IsNotEmpty, IsNumber, IsString, MaxLength } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class UpdateRecurringDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsNumber()

--- a/nest-api/src/spendings/dto/create-spending-category.dto.ts
+++ b/nest-api/src/spendings/dto/create-spending-category.dto.ts
@@ -1,4 +1,5 @@
-import { IsOptional, IsString } from "class-validator";
+import { IsOptional, IsString, MaxLength } from "class-validator";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class CreateSpendingCategoryDto {
   @IsOptional()
@@ -7,9 +8,11 @@ export class CreateSpendingCategoryDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.categoryName)
   name?: string;
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.color)
   color?: string | null;
 }

--- a/nest-api/src/spendings/dto/create-spending.dto.ts
+++ b/nest-api/src/spendings/dto/create-spending.dto.ts
@@ -1,5 +1,6 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength, ValidateNested } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 import { CreateSpendingCategoryDto } from "./create-spending-category.dto";
 
 export class CreateSpendingDto {
@@ -9,6 +10,7 @@ export class CreateSpendingDto {
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsNumber()
@@ -21,5 +23,6 @@ export class CreateSpendingDto {
   category?: CreateSpendingCategoryDto;
 
   @IsString()
+  @MaxLength(FIELD_LIMITS.currency)
   currency: string;
 }

--- a/nest-api/src/spendings/dto/update-spending.dto.ts
+++ b/nest-api/src/spendings/dto/update-spending.dto.ts
@@ -1,10 +1,12 @@
-import { IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from "class-validator";
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength, ValidateNested } from "class-validator";
 import { Type } from "class-transformer";
+import { FIELD_LIMITS } from "@config/field-limits";
 import { CreateSpendingCategoryDto } from "./create-spending-category.dto";
 
 export class UpdateSpendingDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(FIELD_LIMITS.label)
   label: string;
 
   @IsNumber()

--- a/nest-api/src/users/dto/add-user.dto.ts
+++ b/nest-api/src/users/dto/add-user.dto.ts
@@ -1,11 +1,14 @@
-import { IsEmail, IsOptional, IsString, MinLength } from "class-validator";
+import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from "class-validator";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class AddUserDto {
   @IsString()
   @MinLength(1, { message: "Name is required" })
+  @MaxLength(FIELD_LIMITS.userName)
   name: string;
 
   @IsEmail()
+  @MaxLength(FIELD_LIMITS.email)
   email: string;
 
   @IsString()
@@ -14,6 +17,7 @@ export class AddUserDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.currency)
   baseCurrency?: string;
 
   @IsOptional()
@@ -21,5 +25,6 @@ export class AddUserDto {
 
   @IsOptional()
   @IsString()
+  @MaxLength(FIELD_LIMITS.language)
   language?: string;
 }

--- a/nest-api/src/users/dto/sign-in.dto.ts
+++ b/nest-api/src/users/dto/sign-in.dto.ts
@@ -1,7 +1,9 @@
-import { IsEmail, IsString, MinLength } from "class-validator";
+import { IsEmail, IsString, MaxLength, MinLength } from "class-validator";
+import { FIELD_LIMITS } from "@config/field-limits";
 
 export class SignInDto {
   @IsEmail()
+  @MaxLength(FIELD_LIMITS.email)
   email: string;
 
   @IsString()


### PR DESCRIPTION
No length was validated anywhere — not in a DTO, not in a zod schema — while every column behind those fields is a bounded VARCHAR. An oversized input travelled to MySQL and came back as a raw SQL error instead of a form message.

One table of lengths per side, both derived from schema.prisma: nest-api/src/config/field-limits.ts and front/src/schemas/fieldLimits.ts.

Back: @MaxLength on the 9 write DTOs (spendings, recurrings, exceptionals, categories, users), including the nested category payload.

Front: a single shared message, common.validation.tooLong(max) in @text (FR + EN), passed into the schema factories. Bounds the spending label, the exceptional label and description, and the email.

The exceptional description's error had no slot to render in — the trap the ticket warned about — so the FieldShell now takes it. The two category comboboxes have no error slot at all and commit whatever is typed (on selection, or simply on close), so their bound sits on the input: overflow becomes impossible rather than reported after the fact. CategoryFormModal is hand-rolled, so it checks the length explicitly.

Also fixes signup: `name` was derived from the email's local part while Users.name is a VarChar(20) and the form has no name field, so a long address failed the INSERT with nothing the user could correct. It is now truncated at the derivation — bounding it by validation would only have turned the SQL error into an equally unfixable 400.

Tests, on code that had none: 54 back cases, 12 of which re-read schema.prisma so the constants cannot drift from the columns, plus every bounded field at its exact length and one over; 8 front cases asserting the message the user actually reads, from the real FR dictionary.

The exceptional and login schemas move into their own files to be testable, following the spendingModal/schema.ts already in place. No behaviour change.