### PR TITLE
refactor(front): tokenize breakpoints (COS-135)

### DIFF
--- a/front/src/components/exceptionals/ExceptionalItem.tsx
+++ b/front/src/components/exceptionals/ExceptionalItem.tsx
@@ -40,12 +40,12 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
 
   return (
     <>
-      <div className="group grid grid-cols-[76px_minmax(0,1fr)_auto_auto] items-center gap-x-4.5 gap-y-4.5 border-b border-line-soft px-5 py-4 last:border-b-0 max-[759px]:grid-cols-[64px_1fr_auto] max-[759px]:grid-rows-[auto_auto] max-[759px]:gap-x-3 max-[759px]:gap-y-2.5 max-[759px]:px-4 max-[759px]:py-3.5">
-        <span className="rounded-sm border border-line-soft bg-surface-hi py-1.5 text-center font-mono text-xs capitalize tabular-nums text-ink-3 max-[759px]:col-start-1 max-[759px]:row-start-1 max-[759px]:self-start">
+      <div className="group grid grid-cols-[76px_minmax(0,1fr)_auto_auto] items-center gap-x-4.5 gap-y-4.5 border-b border-line-soft px-5 py-4 last:border-b-0 max-md:grid-cols-[64px_1fr_auto] max-md:grid-rows-[auto_auto] max-md:gap-x-3 max-md:gap-y-2.5 max-md:px-4 max-md:py-3.5">
+        <span className="rounded-sm border border-line-soft bg-surface-hi py-1.5 text-center font-mono text-xs capitalize tabular-nums text-ink-3 max-md:col-start-1 max-md:row-start-1 max-md:self-start">
           {dateLabel}
         </span>
 
-        <div className="flex min-w-0 flex-col gap-0.75 max-[759px]:col-start-2 max-[759px]:col-end-4 max-[759px]:row-start-1 max-[759px]:row-end-2">
+        <div className="flex min-w-0 flex-col gap-0.75 max-md:col-start-2 max-md:col-end-4 max-md:row-start-1 max-md:row-end-2">
           <div className="flex min-w-0 items-center gap-2">
             <span
               className="truncate text-sm font-medium text-ink"
@@ -72,11 +72,11 @@ const ExceptionalItem = ({ item, onEdit, monthlyAverage }: ExceptionalItemProps)
           )}
         </div>
 
-        <span className="whitespace-nowrap font-mono text-base font-medium tabular-nums text-ink max-[759px]:col-start-2 max-[759px]:row-start-2 max-[759px]:justify-self-start max-[759px]:self-center">
+        <span className="whitespace-nowrap font-mono text-base font-medium tabular-nums text-ink max-md:col-start-2 max-md:row-start-2 max-md:justify-self-start max-md:self-center">
           {amount} €
         </span>
 
-        <span className="flex gap-1.5 opacity-0 transition-opacity duration-100 group-hover:opacity-100 max-[759px]:col-start-3 max-[759px]:row-start-2 max-[759px]:justify-self-end max-[759px]:opacity-100 [@media(hover:none)]:opacity-100">
+        <span className="flex gap-1.5 opacity-0 transition-opacity duration-100 group-hover:opacity-100 max-md:col-start-3 max-md:row-start-2 max-md:justify-self-end max-md:opacity-100 [@media(hover:none)]:opacity-100">
           <IconButton
             variant="bordered"
             size={7}

--- a/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
+++ b/front/src/components/spendings/spendingsListModal/SpendingsListModal.tsx
@@ -98,16 +98,16 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
     >
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay className="fixed inset-0 z-[200] bg-[oklch(0.02_0.004_250/0.62)] backdrop-blur-sm animate-in fade-in duration-150 ease-out" />
-        <div className="pointer-events-none fixed inset-0 z-[201] grid place-items-center p-8 max-[640px]:p-3.5">
+        <div className="pointer-events-none fixed inset-0 z-[201] grid place-items-center p-8 max-sm:p-3.5">
           <DialogPrimitive.Content
-            className="pfa-card shadow-modal! pointer-events-auto flex max-h-[88vh] w-[min(1000px,94vw)] flex-col overflow-hidden animate-in fade-in slide-in-from-bottom-3.5 zoom-in-95 duration-200 max-[640px]:max-h-[92vh]"
+            className="pfa-card shadow-modal! pointer-events-auto flex max-h-[88vh] w-[min(1000px,94vw)] flex-col overflow-hidden animate-in fade-in slide-in-from-bottom-3.5 zoom-in-95 duration-200 max-sm:max-h-[92vh]"
             aria-describedby={undefined}
             onOpenAutoFocus={(e) => {
               e.preventDefault();
               searchRef.current?.focus({ preventScroll: true });
             }}
           >
-            <div className="flex shrink-0 items-center gap-3.5 border-b border-line bg-[linear-gradient(180deg,oklch(1_0_0/0.045),oklch(1_0_0/0.018))] px-5.5 py-4.5 max-[640px]:flex-wrap max-[640px]:gap-x-3 max-[640px]:gap-y-2.5">
+            <div className="flex shrink-0 items-center gap-3.5 border-b border-line bg-[linear-gradient(180deg,oklch(1_0_0/0.045),oklch(1_0_0/0.018))] px-5.5 py-4.5 max-sm:flex-wrap max-sm:gap-x-3 max-sm:gap-y-2.5">
               <span
                 className="size-7.5 shrink-0 rounded-md shadow-[inset_0_1px_0_oklch(1_0_0/0.25)]"
                 style={{ background: categoryColor }}
@@ -121,9 +121,9 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
                 <span className="text-2xs font-medium uppercase tracking-widest text-ink-4">{t.total}&nbsp;:</span>
                 <span className="font-mono text-base font-semibold tabular-nums text-ink">{euro(total)} €</span>
               </span>
-              <span className="flex-1 max-[640px]:order-5 max-[640px]:h-0 max-[640px]:basis-full" />
+              <span className="flex-1 max-sm:order-5 max-sm:h-0 max-sm:basis-full" />
               {periodLabel && (
-                <span className="whitespace-nowrap text-xs font-medium uppercase tracking-widest text-ink-3 max-[640px]:order-6">
+                <span className="whitespace-nowrap text-xs font-medium uppercase tracking-widest text-ink-3 max-sm:order-6">
                   {periodLabel}
                 </span>
               )}
@@ -175,7 +175,7 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
                       title={t.seeWeek}
                       onClick={() => goToDayWeek(date)}
                     >
-                      <div className="flex items-start justify-between gap-4 px-4.5 pt-3.75 group-hover:bg-[linear-gradient(180deg,oklch(0.72_0.15_230/0.06),transparent)] max-[640px]:flex-col max-[640px]:gap-2.5">
+                      <div className="flex items-start justify-between gap-4 px-4.5 pt-3.75 group-hover:bg-[linear-gradient(180deg,oklch(0.72_0.15_230/0.06),transparent)] max-sm:flex-col max-sm:gap-2.5">
                         <div className="flex items-center gap-2 pt-0.75 text-base font-bold uppercase text-ink group-hover:text-elec">
                           {format(parseISO(date), "EEEE dd MMMM", {
                             locale: dateLocale,
@@ -186,7 +186,7 @@ const SpendingsListModal = ({ handleClickOutside, periodType, categoryInfos, tot
                             strokeWidth={2.5}
                           />
                         </div>
-                        <div className="flex gap-5 max-[640px]:justify-between max-[640px]:self-stretch">
+                        <div className="flex gap-5 max-sm:justify-between max-sm:self-stretch">
                           <div className="text-right">
                             <span className="mb-1.5 block text-2xs font-medium tracking-wider text-ink-4">
                               {t.dayTotal}

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -160,31 +160,31 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
         >
           {/* min(400px,100%) so a narrow phone gets ONE full-width column instead of a
               forced 400px track overflowing to the right. */}
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(400px,100%),1fr))] gap-x-11 max-[520px]:grid-cols-1 max-[520px]:gap-x-0">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(400px,100%),1fr))] gap-x-11 max-xs:grid-cols-1 max-xs:gap-x-0">
             {rowsWithTrend.map((r) => (
               <button
                 key={r.key}
                 type="button"
                 onClick={() => setSelected(r)}
-                className="-mx-2 grid w-full cursor-pointer grid-cols-[14px_minmax(0,1fr)_76px_88px_60px] items-center gap-3 rounded-md border-b border-line-soft px-2 py-1.75 text-left text-sm transition-colors duration-100 hover:bg-surface-hi max-[520px]:grid-cols-[14px_minmax(0,1fr)_auto] max-[520px]:grid-rows-[auto_auto] max-[520px]:gap-x-2.5 max-[520px]:gap-y-0.75"
+                className="-mx-2 grid w-full cursor-pointer grid-cols-[14px_minmax(0,1fr)_76px_88px_60px] items-center gap-3 rounded-md border-b border-line-soft px-2 py-1.75 text-left text-sm transition-colors duration-100 hover:bg-surface-hi max-xs:grid-cols-[14px_minmax(0,1fr)_auto] max-xs:grid-rows-[auto_auto] max-xs:gap-x-2.5 max-xs:gap-y-0.75"
               >
                 <span
-                  className="size-2 rounded-xs max-[520px]:row-span-2 max-[520px]:row-start-1 max-[520px]:self-center"
+                  className="size-2 rounded-xs max-xs:row-span-2 max-xs:row-start-1 max-xs:self-center"
                   style={{ background: r.color }}
                 />
-                <span className="flex min-w-0 items-baseline gap-2 max-[520px]:col-start-2 max-[520px]:row-start-1">
+                <span className="flex min-w-0 items-baseline gap-2 max-xs:col-start-2 max-xs:row-start-1">
                   <span className="truncate capitalize text-ink">{r.name}</span>
                   <span className="num shrink-0 rounded-full border border-line-soft bg-surface-base px-1.75 text-2xs leading-normal text-ink-3">
                     {r.count}
                   </span>
                 </span>
-                <span className="num text-right text-ink-2 max-[520px]:col-start-2 max-[520px]:row-start-2 max-[520px]:justify-self-start max-[520px]:text-left">
+                <span className="num text-right text-ink-2 max-xs:col-start-2 max-xs:row-start-2 max-xs:justify-self-start max-xs:text-left">
                   {pct1(r.pct)} %
                 </span>
-                <span className="num text-right text-ink max-[520px]:col-start-3 max-[520px]:row-start-1 max-[520px]:justify-self-end">
+                <span className="num text-right text-ink max-xs:col-start-3 max-xs:row-start-1 max-xs:justify-self-end">
                   {euro(r.total)} €
                 </span>
-                <span className="max-[520px]:col-start-3 max-[520px]:row-start-2 max-[520px]:justify-self-end">
+                <span className="max-xs:col-start-3 max-xs:row-start-2 max-xs:justify-self-end">
                   {r.trend && <CategoryTrend {...r.trend} />}
                 </span>
               </button>

--- a/front/src/components/spendings/view/SpendingDayCard.tsx
+++ b/front/src/components/spendings/view/SpendingDayCard.tsx
@@ -144,7 +144,7 @@ const SpendingDayCard = ({
   return (
     <div
       className={cn(
-        "flex h-125 flex-col overflow-hidden scroll-mt-42 rounded-2xl! min-[760px]:h-116 min-[768px]:scroll-mt-94",
+        "flex h-125 flex-col overflow-hidden scroll-mt-42 rounded-2xl! md:h-116 md:scroll-mt-94",
         isToday
           ? "border border-elec bg-surface-elev shadow-[0_0_0_1px_var(--elec),0_16px_44px_oklch(0.72_0.15_230/0.24),inset_0_1px_0_oklch(1_0_0/0.06)]"
           : "pfa-card",

--- a/front/src/components/spendings/view/SpendingSummary.tsx
+++ b/front/src/components/spendings/view/SpendingSummary.tsx
@@ -91,10 +91,10 @@ const SpendingSummary = ({
     );
 
   return (
-    <DividedStrip className="grid-cols-2 min-[760px]:grid-cols-5">
+    <DividedStrip className="grid-cols-2 md:grid-cols-5">
       {/* Hero — full-width banner on mobile, one equal-width cell (1/5) on desktop
           like the other four. Its font stays big; the four keep theirs too. */}
-      <div className="col-span-2 bg-card px-5 py-4 min-[760px]:col-span-1">
+      <div className="col-span-2 bg-card px-5 py-4 md:col-span-1">
         <Overline className="mb-2 block">{t.remaining}</Overline>
         <div
           className={cn(

--- a/front/src/components/spendings/view/SpendingTxRow.tsx
+++ b/front/src/components/spendings/view/SpendingTxRow.tsx
@@ -43,7 +43,7 @@ const SpendingTxRow = ({ spending, onEdit }: SpendingTxRowProps) => {
   };
 
   return (
-    <div className="group relative grid grid-cols-[minmax(0,1fr)_auto_78px] items-center gap-3 border-t border-line-soft py-2.75 first:border-t-0 before:pointer-events-none before:absolute before:inset-x-0 before:inset-y-px before:z-0 before:rounded-lg before:transition-colors before:duration-100 before:content-[''] hover:before:bg-surface-hi max-[759px]:grid-cols-[minmax(0,1fr)_auto] max-[759px]:grid-rows-[auto_auto] max-[759px]:gap-y-1.5">
+    <div className="group relative grid grid-cols-[minmax(0,1fr)_auto_78px] items-center gap-3 border-t border-line-soft py-2.75 first:border-t-0 before:pointer-events-none before:absolute before:inset-x-0 before:inset-y-px before:z-0 before:rounded-lg before:transition-colors before:duration-100 before:content-[''] hover:before:bg-surface-hi max-md:grid-cols-[minmax(0,1fr)_auto] max-md:grid-rows-[auto_auto] max-md:gap-y-1.5">
       {confirming ? (
         <div
           className="relative z-10 col-span-full flex items-center gap-3 rounded-lg border border-danger-border-soft bg-danger-surface py-2 pl-3.75 pr-2.5 shadow-[0_6px_20px_oklch(0.3_0.16_25/0.28)]"
@@ -70,13 +70,13 @@ const SpendingTxRow = ({ spending, onEdit }: SpendingTxRowProps) => {
         </div>
       ) : (
         <>
-          <span className="relative z-10 flex min-w-0 items-center gap-2.5 text-sm text-ink max-[759px]:col-start-1 max-[759px]:row-start-1 max-[759px]:text-base">
+          <span className="relative z-10 flex min-w-0 items-center gap-2.5 text-sm text-ink max-md:col-start-1 max-md:row-start-1 max-md:text-base">
             <span
               className="h-5.5 w-0.75 shrink-0 rounded-xs"
               style={{ background: color }}
             />
             <span
-              className="truncate max-[759px]:line-clamp-2 max-[759px]:whitespace-normal"
+              className="truncate max-md:line-clamp-2 max-md:whitespace-normal"
               title={spending.label}
             >
               {spending.label}
@@ -93,9 +93,9 @@ const SpendingTxRow = ({ spending, onEdit }: SpendingTxRowProps) => {
           </span>
 
           {category && (
-            <span className="relative z-10 justify-self-end max-[759px]:col-start-1 max-[759px]:row-start-2 max-[759px]:justify-self-start">
+            <span className="relative z-10 justify-self-end max-md:col-start-1 max-md:row-start-2 max-md:justify-self-start">
               <span
-                className={cn(TAG_CHIP, "max-[759px]:border-transparent max-[759px]:bg-transparent max-[759px]:p-0")}
+                className={cn(TAG_CHIP, "max-md:border-transparent max-md:bg-transparent max-md:p-0")}
                 style={{ color }}
               >
                 {category}
@@ -103,12 +103,12 @@ const SpendingTxRow = ({ spending, onEdit }: SpendingTxRowProps) => {
             </span>
           )}
 
-          <span className="relative z-10 justify-self-end whitespace-nowrap text-right font-mono text-sm font-medium tabular-nums text-ink max-[759px]:col-start-2 max-[759px]:row-start-1 max-[759px]:self-center">
+          <span className="relative z-10 justify-self-end whitespace-nowrap text-right font-mono text-sm font-medium tabular-nums text-ink max-md:col-start-2 max-md:row-start-1 max-md:self-center">
             {euro(spending.amount)}
             <span className="text-xs font-normal text-ink-3"> €</span>
           </span>
 
-          <span className="absolute right-22 top-1/2 z-20 hidden -translate-y-1/2 items-center gap-1.5 bg-[linear-gradient(90deg,transparent,var(--surface-hi)_26px)] pl-7.5 group-hover:flex max-[759px]:static max-[759px]:col-start-2 max-[759px]:row-start-2 max-[759px]:flex max-[759px]:translate-y-0 max-[759px]:justify-self-end max-[759px]:bg-none max-[759px]:p-0">
+          <span className="absolute right-22 top-1/2 z-20 hidden -translate-y-1/2 items-center gap-1.5 bg-[linear-gradient(90deg,transparent,var(--surface-hi)_26px)] pl-7.5 group-hover:flex max-md:static max-md:col-start-2 max-md:row-start-2 max-md:flex max-md:translate-y-0 max-md:justify-self-end max-md:bg-none max-md:p-0">
             <IconButton
               variant="bordered"
               size={7}

--- a/front/src/components/spendings/view/SpendingView.tsx
+++ b/front/src/components/spendings/view/SpendingView.tsx
@@ -221,7 +221,7 @@ const SpendingView = () => {
       {isInitialLoading ? (
         <div className="grid place-items-center py-16 text-sm text-ink-4">{common.loading}</div>
       ) : (
-        <section className="grid grid-cols-1 items-start gap-4 min-[760px]:grid-cols-[repeat(auto-fill,minmax(500px,1fr))]">
+        <section className="grid grid-cols-1 items-start gap-4 md:grid-cols-[repeat(auto-fill,minmax(500px,1fr))]">
           {groups.map((group, i) => (
             <SpendingDayCard
               key={group.dayOfMonth}

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -193,7 +193,7 @@ const StatisticsKpis = ({
   const expenseScale = Math.max(Number(topExc?.amount ?? 0), regularBiggest.amount, 1);
 
   return (
-    <section className="grid grid-cols-1 gap-4 min-[520px]:grid-cols-2 min-[768px]:grid-cols-4">
+    <section className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-4">
       <Card label={t.totalSpent(year)}>
         <Value amount={total} />
         <span

--- a/front/styles/globals.css
+++ b/front/styles/globals.css
@@ -7,6 +7,7 @@ layer(base);
 @custom-variant dark (&:is(.dark *));
 
 /* Design tokens — by type */
+@import './tokens/breakpoints.css';
 @import './tokens/colors.css';
 @import './tokens/radius.css';
 @import './tokens/typography.css';

--- a/front/styles/tokens/breakpoints.css
+++ b/front/styles/tokens/breakpoints.css
@@ -1,0 +1,10 @@
+/* Breakpoint scale — the responsive vocabulary of the app (COS-135). Tailwind's
+ * `sm` (640), `md` (768) and `lg` (1024) defaults are kept as-is; only the phone
+ * step below `sm` is missing, so `xs` is added here. Declaring a `--breakpoint-*`
+ * gives both the min-width variant (`xs:`) and its max-width mirror (`max-xs:`).
+ * Two one-off widths stay arbitrary on their single site — `min-[1000px]` on the
+ * Dashboard grid and `min-[1100px]` on the Dépenses summary type — they are not
+ * a shared step; promote them only if a second usage shows up. */
+@theme {
+  --breakpoint-xs: 32.5rem; /* 520px — phone */
+}


### PR DESCRIPTION
COS-130 inlined the mockups' media queries as hardcoded `(min|max)-[Npx]:` variants. Declare the missing phone step as `--breakpoint-xs` (520px) in a new tokens/breakpoints.css, and map every other custom width onto Tailwind's own scale:

  max-[520px] -> max-xs   min-[520px]        -> xs
  max-[640px] -> max-sm   min-[760|768px]    -> md
  max-[759px] -> max-md

759/760 was an 8px drift between two mockups, not a distinct breakpoint: it folds into md (768). SpendingDayCard carried both 760 and 768 on the same element, so it now reflows once.

Left arbitrary on purpose: min-[1000px] (Dashboard grid) and min-[1100px] (Dépenses summary type) — one site each, not a scale.