### PR TITLE
chore(front): repair design-sync harness (COS-181)

### DIFF
--- a/front/.design-sync/NOTES.md
+++ b/front/.design-sync/NOTES.md
@@ -139,12 +139,42 @@ the DS surface, so it shares the bundle's sonner instance).
 
 ## Known render warns
 
-- `[RENDER_SKIPPED]` — the render check has **never** run. The user declined the playwright/chromium
-  install on the first sync, so the bundle is machine-unverified. A future sync that installs
-  playwright will produce genuinely new information; treat the first real run's findings as new, not
-  as regressions.
-- `[FONT_REMOTE]` — expected, see Fonts above.
-- `tokens: 3 missing, below threshold` — not investigated; under the converter's warn threshold.
+- `[FONT_REMOTE]` — expected, see Fonts above. Now lists Keania One too.
+- `tokens: 3 missing, below threshold` — `--pfa-circ` / `--pfa-dash` / `--pfa-gap` are set at runtime
+  by Donut/ProgressTrack inline styles, so they are EXPECTED to be absent from the static CSS. Under
+  the warn threshold since the Keania fix below removed the 4th.
+- ~~`[RENDER_SKIPPED]`~~ — the render check ran for the first time on 2026-07-27: **40/40 clean**.
+
+## Re-sync 2026-07-27 (2nd sync) — three things had rotted since the first
+
+The app moved a lot between syncs; none of this was visible until the render check finally ran.
+
+1. **`tsconfig.dts.json` needs `allowJs: true`** (was `false`). `LangKeys` is `keyof typeof` a plain-JS
+   module (`src/i18n/locales-dates.js`); with allowJs off tsc can't read it, the keyof collapses to
+   `string | number | symbol`, and `prepare.mjs` dies on `LocaleContext.tsx` (TS2345/TS2322) even
+   though the app itself typechecks clean. Symptom: `Command failed: ./node_modules/.bin/tsc -p
+   .design-sync/tsconfig.dts.json`, status 2.
+2. **`cfg.provider` = `LocaleProvider`, exported from `ds-entry.tsx`.** The i18n context landed after
+   the first sync, so 23 of 40 cards died with `useLocale must be used within a LocaleProvider` —
+   every component that formats money/dates/copy (MoneyAmount, ExportButton, ConfirmDeleteDialog,
+   PasswordField, CategoryComponent) plus every preview composing one. `componentSrcMap.LocaleProvider
+   = null` keeps it out of the card list. `conventions.md` was updated to match: it used to claim
+   "there is nothing to wrap", which is now false for generated designs too.
+   **Cost:** adding `cfg.provider` re-keys EVERY grade ("contract changed") — a 40-component regrade.
+3. **Keania One was missing from the font `@import`** (`--font-keania`, the `font-wordmark` token). No
+   card uses it, but the token ships in the DS vocabulary, so a design writing `font-wordmark` got a
+   fallback. Added to the Google-Fonts `@import` + bound on `:root` in `ds-styles.src.css`.
+
+**Playwright**: installed at 1.61.1 (matches the repo's `@playwright/test` pin). On macOS the browser
+cache is `~/Library/Caches/ms-playwright` (chromium-1228), NOT `~/.cache/ms-playwright` — the skill's
+check path is Linux-only, so it reads as "nothing cached" here.
+
+**Where this run stopped:** build + validate + capture all green (render check 40/40, no
+`[TOKENS_MISSING]`), verdict `ok: true`, `upload.any: true`, `deletePaths: []`. NOT yet done: grading
+the 40 components / 160 cells from `ds-bundle/_screenshots/review/<group>__<Name>.png` into
+`.design-sync/.cache/review/<Name>.grade.json`, then the conventions re-validation, a final driver run
+and the upload. **Nothing was uploaded** — the project still carries the first sync's anchor, which is
+the documented safe state (next run just re-verifies).
 
 ## Re-sync risks — what can silently go stale
 

--- a/front/.design-sync/config.json
+++ b/front/.design-sync/config.json
@@ -102,7 +102,11 @@
     "TextInput": "src/components/shared/TextInput.tsx",
     "Toaster": "src/components/ui/sonner.tsx",
     "Tooltip": "src/components/ui/tooltip.tsx",
-    "Spinner": null
+    "Spinner": null,
+    "LocaleProvider": null
+  },
+  "provider": {
+    "component": "LocaleProvider"
   },
   "cssEntry": ".design-sync/.cache/pfa-styles.css",
   "docsDir": ".design-sync/docs",

--- a/front/.design-sync/conventions.md
+++ b/front/.design-sync/conventions.md
@@ -2,9 +2,15 @@
 
 pfa is a personal-finance app: **dark-only**, French UI, dense numeric screens (budgets, spendings, categories, statistics).
 
-### Setup — there is nothing to wrap
+### Setup — wrap the app in `LocaleProvider`, nothing else
 
-No provider is required. The tokens are plain CSS custom properties on `:root` in `styles.css`, and **dark is the default** — do *not* add a `dark` class or a theme provider. `Tooltip` mounts its own Radix provider internally. The only global is `<Toaster />` (sonner), mounted once near the root, and only if you raise toasts.
+```jsx
+<LocaleProvider>{/* your screen */}</LocaleProvider>
+```
+
+Every component that formats money, dates or copy reads the locale from it — `MoneyAmount`, `ExportButton`, `ConfirmDeleteDialog`, `PasswordField`, `CategoryComponent` — and **throws** (`useLocale must be used within a LocaleProvider`) without it. It takes no props; the default locale is French.
+
+Nothing else needs wrapping. The tokens are plain CSS custom properties on `:root` in `styles.css`, and **dark is the default** — do *not* add a `dark` class or a theme provider. `Tooltip` mounts its own Radix provider internally. The only other global is `<Toaster />` (sonner), mounted once near the root, and only if you raise toasts.
 
 ### The styling idiom: Tailwind v4 utilities over pfa tokens
 

--- a/front/.design-sync/ds-entry.tsx
+++ b/front/.design-sync/ds-entry.tsx
@@ -41,3 +41,9 @@ export { default as ConfirmDeleteDialog } from "../src/components/shared/Confirm
 export { default as ExportButton } from "../src/components/shared/ExportButton";
 export { default as Logo } from "../src/components/shared/brand/Logo";
 export { default as CategoryComponent } from "../src/components/common/Category";
+// The i18n root. Every component that formats money, dates or copy calls
+// useLocale() under the hood (MoneyAmount, ExportButton, ConfirmDeleteDialog,
+// PasswordField, CategoryComponent…), and throws without this provider — so it
+// ships in the bundle for previews AND for generated designs. Excluded from the
+// component list via componentSrcMap (it renders nothing itself).
+export { LocaleProvider } from "../src/i18n/LocaleContext";

--- a/front/.design-sync/ds-styles.src.css
+++ b/front/.design-sync/ds-styles.src.css
@@ -1,10 +1,13 @@
 /* DS stylesheet source for design-sync — compiled by .design-sync/build-css.mjs.
    Not used by the app; the app compiles styles/globals.css through Next/PostCSS. */
 
-/* The app gets Geist + Geist Mono from next/font/google (src/app/layout.tsx),
-   which only exists inside the Next runtime. Source the same families from the
-   font host so the bundle is self-sufficient. */
-@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap');
+/* The app gets Geist + Geist Mono + Keania One from next/font/google
+   (src/app/layout.tsx), which only exists inside the Next runtime. Source the
+   same families from the font host so the bundle is self-sufficient. Keania is
+   the brand wordmark only (`font-wordmark`): no card uses it today, but the
+   token ships in the DS vocabulary, so it must resolve when a design writes it
+   (it was the `--font-keania` half of validate's [TOKENS_MISSING]). */
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&family=Keania+One&display=swap');
 
 @import '../styles/globals.css';
 
@@ -65,6 +68,7 @@
   color-scheme: dark;
   --font-geist-sans: 'Geist';
   --font-geist-mono: 'Geist Mono';
+  --font-keania: 'Keania One';
 }
 
 /* Paint the page dark — deliberately UNLAYERED and specificity (0,0,2).

--- a/front/.design-sync/tsconfig.dts.json
+++ b/front/.design-sync/tsconfig.dts.json
@@ -15,7 +15,11 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "declarationMap": false,
-    "allowJs": false,
+    // Must stay TRUE: `LangKeys` is `keyof typeof` a plain-JS module
+    // (`src/i18n/locales-dates.js`). With allowJs off tsc can't read it, the
+    // keyof collapses to `string | number | symbol`, and the declaration build
+    // dies on LocaleContext.tsx (TS2345/TS2322) even though the app typechecks.
+    "allowJs": true,
     "skipLibCheck": true,
     "rootDir": "..",
     "outDir": "../dist/types"


### PR DESCRIPTION
The app moved between the first DS publish and the second sync pass; three things had rotted in .design-sync/, invisible until the render check ran for the first time (it was skipped on the first sync).

- tsconfig.dts.json: allowJs back to true. LangKeys is `keyof typeof` a plain-JS module (src/i18n/locales-dates.js); with allowJs off tsc can't read it, the keyof collapses to string | number | symbol, and prepare.mjs dies on LocaleContext.tsx (TS2345/TS2322) even though the app typechecks clean.
- cfg.provider = LocaleProvider, exported from ds-entry.tsx. The i18n context landed after the first sync, so 23 of 40 cards died on `useLocale must be used within a LocaleProvider`. Kept out of the card list via componentSrcMap.LocaleProvider = null; conventions.md no longer claims there is nothing to wrap.
- Keania One was missing from the font @import, so the font-wordmark token fell back in generated designs.

Adding cfg.provider re-keys every grade ("contract changed"), so the next pass regrades all 40 components. Nothing was uploaded: the project still carries the first sync's anchor.