### PR TITLE
fix(front): unsquash the weekday chart (COS-182)

### DIFF
--- a/front/src/components/statistics/StatisticsDayOfWeek.tsx
+++ b/front/src/components/statistics/StatisticsDayOfWeek.tsx
@@ -19,17 +19,23 @@ import { useEffect, useState } from "react";
 import type { DailyStat, WeekdayCategory } from "@src/schemas/stats";
 import type { ReactNode } from "react";
 
-// Row layout: fixed day-name and amount columns around the elastic bar column.
-const GRID_COLS = "grid grid-cols-[92px_1fr_152px] gap-3";
-const ROW_GRID = `${GRID_COLS} items-center`;
+// Row layout (COS-182). From `md` up: fixed day-name and amount columns around the
+// elastic bar column. Below it those two columns would leave the bar a few dozen
+// pixels, so the row stacks instead — day name and amount share the first line, the
+// bar spans the full width underneath.
+const MD_COLS = "md:grid-cols-[92px_1fr_152px]";
+const ROW_GRID = `grid grid-cols-[1fr_auto] items-start gap-x-3 gap-y-1.5 ${MD_COLS} md:items-center md:gap-y-0`;
 
-// Bar-column geometry, mirrored by the full-height overlays (the average line) so
-// they span the plot and line up with the bars. Must match GRID_COLS: a 92px
-// day-name column and a 152px amount column, each separated from the elastic bar
-// column by gap-3 (12px).
-const DAY_COL_PX = 92;
-const AMOUNT_COL_PX = 152;
-const COL_GAP_PX = 12;
+// Bands that must line up with the bar column alone (the average-line label, the
+// budget ticks, the full-height reference lines): full width while the bar is, then
+// the middle column from `md` up. `BAND_COLS` carries no `display`, so an overlay
+// can turn the band on at a breakpoint without fighting `grid` over one property.
+const BAND_COLS = `grid-cols-1 gap-x-3 ${MD_COLS}`;
+const BAND_GRID = `grid ${BAND_COLS}`;
+
+// How close to an edge the average line has to be for its label to stop being
+// centred on it and go flush instead, so the label never overflows the plot.
+const LABEL_EDGE_FRAC = 0.15;
 
 // Fixed-scale headroom so the top marker (2×budget, or the widest whisker) always
 // sits inside the plot with a little air past it (COS-132, COS-127).
@@ -96,8 +102,8 @@ const CompareBar = ({ frac, expanded }: { frac: number; expanded: boolean }) => 
   />
 );
 
-/** A dashed grey guide delimiting a colour zone, running the full height of the plot.
- *  1px to match the budget ticks at the bottom. */
+/** A dashed grey guide delimiting a colour zone, spanning the height of one row's
+ *  bar. 1px to match the budget ticks at the bottom. */
 const ThresholdGuide = ({ frac }: { frac: number }) => (
   <span
     className="absolute inset-y-0"
@@ -105,24 +111,96 @@ const ThresholdGuide = ({ frac }: { frac: number }) => (
   />
 );
 
-/** min→max "range" whisker: a thin connector with end caps, over the main bar. */
-const Whisker = ({ minFrac, maxFrac }: { minFrac: number; maxFrac: number }) => (
+interface GuidesProps {
+  /** Budget-threshold positions on the shared scale; null when no ceiling is set. */
+  budgetFrac: number | null;
+  dangerFrac: number | null;
+  /** The year's average daily spend, on the same scale. */
+  avgFrac: number;
+}
+
+/** The plot's vertical references — the optional colour-zone guides at the budget
+ *  thresholds, plus the year's average. Absolutely positioned, so the caller's
+ *  element decides how far down they run. */
+const Guides = ({ budgetFrac, dangerFrac, avgFrac }: GuidesProps) => (
+  <>
+    {budgetFrac != null && <ThresholdGuide frac={budgetFrac} />}
+    {dangerFrac != null && <ThresholdGuide frac={dangerFrac} />}
+    <span
+      className="absolute inset-y-0"
+      style={{ left: `${avgFrac * 100}%`, marginLeft: -1, borderLeft: "2px dashed var(--accent-strong)", opacity: 0.7 }}
+    />
+  </>
+);
+
+/**
+ * The references as one unbroken line down the whole plot, from `md` up: a band
+ * mirroring the row grid puts its middle cell exactly over the bar column, so a
+ * single full-height element spans every row — no dash ever restarts mid-plot.
+ */
+const PlotGuides = (props: GuidesProps) => (
+  <div
+    className={`${BAND_COLS} pointer-events-none absolute inset-0 hidden md:grid`}
+    aria-hidden
+  >
+    <BandSpacer />
+    <div className="relative">
+      <Guides {...props} />
+    </div>
+    <BandSpacer />
+  </div>
+);
+
+/** The same references over a single row's bar, below `md` only: the stacked row
+ *  puts a day name and an amount beside each bar, which a plot-height line would
+ *  strike through. */
+const RowGuides = (props: GuidesProps) => (
+  <div
+    className="pointer-events-none absolute inset-0 md:hidden"
+    aria-hidden
+  >
+    <Guides {...props} />
+  </div>
+);
+
+/** Typical-range whisker (p10→p90): a thin connector with end caps, over the main bar. */
+const Whisker = ({ lowFrac, highFrac }: { lowFrac: number; highFrac: number }) => (
   <div
     className="pointer-events-none absolute inset-0"
     aria-hidden
   >
     <span
       className="absolute top-1/2 h-px -translate-y-1/2 bg-ink-2/45"
-      style={{ left: `${minFrac * 100}%`, width: `${Math.max(0, maxFrac - minFrac) * 100}%` }}
+      style={{ left: `${lowFrac * 100}%`, width: `${Math.max(0, highFrac - lowFrac) * 100}%` }}
     />
     <span
       className="absolute inset-y-1 w-px bg-ink-2/80"
-      style={{ left: `${minFrac * 100}%` }}
+      style={{ left: `${lowFrac * 100}%` }}
     />
     <span
       className="absolute inset-y-1 w-px bg-ink-2/80"
-      style={{ left: `${maxFrac * 100}%` }}
+      style={{ left: `${highFrac * 100}%` }}
     />
+  </div>
+);
+
+/** Placeholder holding a band's day-name / amount column, from `md` up. */
+const BandSpacer = () => (
+  <span
+    aria-hidden
+    className="hidden md:block"
+  />
+);
+
+/** A budget threshold tick + its amount, under the bar column. `display` carries the
+ *  breakpoint at which the tick shows, so the two never crowd each other. */
+const BudgetTick = ({ frac, label, display }: { frac: number; label: string; display: string }) => (
+  <div
+    className={`absolute top-0 -translate-x-1/2 flex-col items-center ${display}`}
+    style={{ left: `${frac * 100}%` }}
+  >
+    <span className="h-1.5 w-px bg-ink-4" />
+    <span className="num mt-1 whitespace-nowrap text-2xs text-ink-4">{label}</span>
   </div>
 );
 
@@ -213,11 +291,13 @@ const StatisticsDayOfWeek = ({
   const dayBudget = weeklyCeiling != null && weeklyCeiling > 0 ? weeklyCeiling / 7 : null;
 
   // One euro scale shared by every mark — both years' averages, the selected
-  // year's whisker maxes and the budget markers — so bars, whiskers, the average
-  // line and the ticks are all directly comparable (COS-127).
+  // year's typical-range highs and the budget markers — so bars, whiskers, the
+  // average line and the ticks are all directly comparable (COS-127). The scale
+  // reads p90, never the yearly max (COS-182): a single expensive day would
+  // otherwise stretch it far enough to squash all seven bars against the left edge.
   const rawMax = Math.max(
     ...stats.map((s) => s.avgAmount),
-    ...stats.map((s) => s.max),
+    ...stats.map((s) => s.p90),
     ...(compareStats?.map((s) => s.avgAmount) ?? []),
     1,
   );
@@ -227,6 +307,15 @@ const StatisticsDayOfWeek = ({
   const avgFrac = scaleFrac(overall.avgAmount, scaleMax);
   const hasInsights = peakDow != null;
   const dangerBudget = dayBudget != null ? dayBudget * OVERSPEND_DANGER_RATIO : null;
+  const budgetFrac = dayBudget != null ? scaleFrac(dayBudget, scaleMax) : null;
+  const dangerFrac = dangerBudget != null ? scaleFrac(dangerBudget, scaleMax) : null;
+  // Centred on the average line, unless that would push the label out of the plot.
+  const avgLabelAlign =
+    avgFrac < LABEL_EDGE_FRAC
+      ? "translate-x-0"
+      : avgFrac > 1 - LABEL_EDGE_FRAC
+        ? "-translate-x-full"
+        : "-translate-x-1/2";
 
   return (
     <GlowCard
@@ -275,17 +364,17 @@ const StatisticsDayOfWeek = ({
       )}
 
       {/* average reference-line label, positioned over the bar column at its fraction. */}
-      <div className={`${ROW_GRID} mt-4`}>
-        <span aria-hidden />
+      <div className={`${BAND_GRID} mt-4`}>
+        <BandSpacer />
         <div className="relative h-4">
           <span
-            className="num absolute top-0 -translate-x-1/2 whitespace-nowrap text-2xs text-accent-strong"
+            className={`num absolute top-0 whitespace-nowrap text-2xs text-accent-strong ${avgLabelAlign}`}
             style={{ left: `${avgFrac * 100}%` }}
           >
             {dayOfWeek.averageLine(euro0(overall.avgAmount))}
           </span>
         </div>
-        <span aria-hidden />
+        <BandSpacer />
       </div>
 
       <div className="relative mt-1">
@@ -293,7 +382,7 @@ const StatisticsDayOfWeek = ({
             data-dow attribute (like the heatmap), so the tooltip follows the
             cursor across the rows without making each row separately interactive. */}
         <div
-          className="flex flex-col gap-2"
+          className="flex flex-col gap-4 md:gap-2"
           role="img"
           aria-label={dayOfWeek.title}
           onMouseMove={(e) => {
@@ -322,11 +411,11 @@ const StatisticsDayOfWeek = ({
                 data-dow={dow}
                 className={`${ROW_GRID} text-sm`}
               >
-                <span className="flex items-center gap-1.5 text-ink-2">
+                <span className="col-start-1 row-start-1 flex items-center gap-1.5 text-ink-2">
                   <span className="inline-flex w-2 justify-center text-2xs leading-none">{marker}</span>
                   {dayOfWeek.days[dow]}
                 </span>
-                <div className="flex flex-col justify-center">
+                <div className="relative col-start-1 col-end-3 row-start-2 flex flex-col justify-center md:col-start-2 md:row-start-1">
                   <div className="relative">
                     {dayBudget != null ? (
                       <WeekdayBulletBar
@@ -342,10 +431,10 @@ const StatisticsDayOfWeek = ({
                         opacity={0.85}
                       />
                     )}
-                    {s.max > 0 && (
+                    {s.p90 > s.p10 && (
                       <Whisker
-                        minFrac={scaleFrac(s.min, scaleMax)}
-                        maxFrac={scaleFrac(s.max, scaleMax)}
+                        lowFrac={scaleFrac(s.p10, scaleMax)}
+                        highFrac={scaleFrac(s.p90, scaleMax)}
                       />
                     )}
                   </div>
@@ -360,8 +449,13 @@ const StatisticsDayOfWeek = ({
                       />
                     </div>
                   )}
+                  <RowGuides
+                    budgetFrac={budgetFrac}
+                    dangerFrac={dangerFrac}
+                    avgFrac={avgFrac}
+                  />
                 </div>
-                <div className="num text-right">
+                <div className="num col-start-2 row-start-1 text-right md:col-start-3">
                   <div className={`font-medium ${overspendTextClass(level)}`}>{euro(s.avgAmount)} €</div>
                   <small className="block text-2xs font-normal text-ink-4">
                     {dayOfWeek.transactionsPerDay(pct1(s.avgTx))}
@@ -400,48 +494,32 @@ const StatisticsDayOfWeek = ({
           })}
         </div>
 
-        {/* Full-height reference lines over the bar column: the optional colour-zone
-            guides at the budget thresholds, plus the average line. */}
-        <div
-          className="pointer-events-none absolute inset-y-0"
-          style={{ left: DAY_COL_PX + COL_GAP_PX, right: AMOUNT_COL_PX + COL_GAP_PX }}
-          aria-hidden
-        >
-          {dayBudget != null && dangerBudget != null && (
-            <>
-              <ThresholdGuide frac={scaleFrac(dayBudget, scaleMax)} />
-              <ThresholdGuide frac={scaleFrac(dangerBudget, scaleMax)} />
-            </>
-          )}
-          <span
-            className="absolute inset-y-0"
-            style={{
-              left: `${avgFrac * 100}%`,
-              marginLeft: -1,
-              borderLeft: "2px dashed var(--accent-strong)",
-              opacity: 0.7,
-            }}
-          />
-        </div>
+        <PlotGuides
+          budgetFrac={budgetFrac}
+          dangerFrac={dangerFrac}
+          avgFrac={avgFrac}
+        />
       </div>
 
-      {/* Budget thresholds as small ticks beneath the bar column (36 € / 71 €). */}
-      {dayBudget != null && dangerBudget != null && (
-        <div className={`${ROW_GRID} mt-2`}>
-          <span aria-hidden />
+      {/* Budget thresholds as small ticks beneath the bar column. Stacked rows put the
+          two close enough to overlap on a narrow screen, so only the danger threshold
+          is kept below `md` — the legend spells out both amounts either way. */}
+      {budgetFrac != null && dangerFrac != null && dayBudget != null && dangerBudget != null && (
+        <div className={`${BAND_GRID} mt-2`}>
+          <BandSpacer />
           <div className="relative h-5">
-            {[dayBudget, dangerBudget].map((amount) => (
-              <div
-                key={amount}
-                className="absolute top-0 flex -translate-x-1/2 flex-col items-center"
-                style={{ left: `${scaleFrac(amount, scaleMax) * 100}%` }}
-              >
-                <span className="h-1.5 w-px bg-ink-4" />
-                <span className="num mt-1 whitespace-nowrap text-2xs text-ink-4">{euro0(amount)} €</span>
-              </div>
-            ))}
+            <BudgetTick
+              frac={budgetFrac}
+              label={`${euro0(dayBudget)} €`}
+              display="hidden md:flex"
+            />
+            <BudgetTick
+              frac={dangerFrac}
+              label={`${euro0(dangerBudget)} €`}
+              display="flex"
+            />
           </div>
-          <span aria-hidden />
+          <BandSpacer />
         </div>
       )}
 
@@ -490,7 +568,7 @@ const StatisticsDayOfWeek = ({
             </span>
           }
         >
-          {dayOfWeek.legend.range}
+          {dayOfWeek.legend.typicalRange}
         </LegendItem>
         <LegendItem swatch={<span className="inline-block h-0 w-4 border-t-2 border-dashed border-accent-strong/80" />}>
           {dayOfWeek.legend.average}
@@ -535,7 +613,15 @@ const StatisticsDayOfWeek = ({
                 </div>
                 <div className="mt-1.5 flex flex-col gap-0.5">
                   <TipRow
-                    label={dayOfWeek.tooltip.range}
+                    label={dayOfWeek.tooltip.typicalRange}
+                    value={
+                      <span className="num whitespace-nowrap">
+                        {dayOfWeek.tooltip.rangeValue(euro0(s.p10), euro0(s.p90))}
+                      </span>
+                    }
+                  />
+                  <TipRow
+                    label={dayOfWeek.tooltip.extremes}
                     value={
                       <span className="num whitespace-nowrap">
                         {dayOfWeek.tooltip.rangeValue(euro0(s.min), euro0(s.max))}

--- a/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
+++ b/front/src/components/statistics/helpers/__tests__/weekdayStats.test.ts
@@ -1,9 +1,43 @@
-import { overallDailyAverage, weekdayAverages, weekdayInsights } from "@components/statistics/helpers/weekdayStats";
+import {
+  overallDailyAverage,
+  percentile,
+  weekdayAverages,
+  weekdayInsights,
+} from "@components/statistics/helpers/weekdayStats";
 
 import type { WeekdayStat } from "@components/statistics/helpers/weekdayStats";
 import type { DailyStat } from "@src/schemas/stats";
 
 const day = (date: string, total: number, count: number): DailyStat => ({ date, total, count });
+
+/** Local calendar date as YYYY-MM-DD, matching the API's day keys. */
+const iso = (date: Date): string =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+
+describe("percentile", () => {
+  it("returns 0 for an empty series", () => {
+    expect(percentile([], 0.1)).toBe(0);
+    expect(percentile([], 0.9)).toBe(0);
+  });
+
+  it("returns the only value of a single-value series", () => {
+    expect(percentile([42], 0.1)).toBe(42);
+    expect(percentile([42], 0.9)).toBe(42);
+  });
+
+  it("interpolates linearly between the surrounding values", () => {
+    // Two values: p10 sits a tenth of the way from 10 to 30, p90 nine tenths.
+    expect(percentile([10, 30], 0.1)).toBeCloseTo(12, 10);
+    expect(percentile([10, 30], 0.9)).toBeCloseTo(28, 10);
+    // Exact positions need no interpolation.
+    expect(percentile([0, 10, 20, 30, 40], 0.5)).toBe(20);
+  });
+
+  it("clamps the fraction to the series bounds", () => {
+    expect(percentile([5, 10, 15], -1)).toBe(5);
+    expect(percentile([5, 10, 15], 2)).toBe(15);
+  });
+});
 
 describe("weekdayAverages", () => {
   // Current year, only Jan 1–8 realized. Jan 1 2023 is a Sunday, so the window
@@ -18,23 +52,49 @@ describe("weekdayAverages", () => {
 
   it("averages amount and tx per weekday over the weekday's real occurrences", () => {
     const result = weekdayAverages(days, 2023, now);
-    expect(result[0]).toEqual({ avgAmount: 100, avgTx: 2, min: 100, max: 100 }); // Monday: 100 over 1 occurrence
-    expect(result[6]).toEqual({ avgAmount: 20, avgTx: 1, min: 10, max: 30 }); // Sunday: (10+30)/2, (1+1)/2, range 10–30
-    expect(result[1]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0 }); // Tuesday: no spending
+    // Monday: 100 over 1 occurrence — a one-value series, so every percentile is 100.
+    expect(result[0]).toEqual({ avgAmount: 100, avgTx: 2, min: 100, max: 100, p10: 100, p90: 100 });
+    // Sunday: (10+30)/2, (1+1)/2, extremes 10–30, typical range interpolated between them.
+    expect(result[6]).toEqual({ avgAmount: 20, avgTx: 1, min: 10, max: 30, p10: 12, p90: 28 });
+    // Tuesday: no spending at all.
+    expect(result[1]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0, p10: 0, p90: 0 });
   });
 
   it("ranges min/max over that weekday's spending days only (not zero-spend occurrences)", () => {
     // Sunday has two spending days (10 and 30) among more Sunday occurrences; the
-    // whisker spans the actual spend, not a 0 floor.
+    // extremes span the actual spend, not a 0 floor.
     const result = weekdayAverages(days, 2023, now);
     expect(result[6].min).toBe(10);
     expect(result[6].max).toBe(30);
   });
 
+  it("counts realized zero-spend days in the typical range", () => {
+    // Five Sundays realized (Jan 1, 8, 15, 22, 29), only two with spending: the
+    // percentile series is [0, 0, 0, 100, 200], same population as the average.
+    const sundays = [day("2023-01-01", 100, 1), day("2023-01-08", 200, 1)];
+    const result = weekdayAverages(sundays, 2023, new Date(2023, 0, 29));
+    expect(result[6].p10).toBe(0); // three empty Sundays sit at the bottom of the series
+    expect(result[6].p90).toBeCloseTo(160, 10); // 100 + (200 − 100) × 0.6
+    expect(result[6].min).toBe(100); // extremes still ignore the empty days
+    expect(result[6].max).toBe(200);
+  });
+
+  it("keeps the typical range clear of a single outlier day", () => {
+    // 52 Mondays of 2022 at 50 € each, except one 5 000 € day: p90 stays at the
+    // usual level while max follows the outlier — this is what keeps the chart's
+    // scale (built on p90) readable on a real account.
+    const mondays = Array.from({ length: 52 }, (_, week) =>
+      day(iso(new Date(2022, 0, 3 + week * 7)), week === 0 ? 5000 : 50, 1),
+    );
+    const result = weekdayAverages(mondays, 2022, new Date(2023, 0, 8));
+    expect(result[0].p90).toBe(50);
+    expect(result[0].max).toBe(5000);
+  });
+
   it("excludes future-dated spendings from the averages", () => {
     const result = weekdayAverages(days, 2023, now);
     // 2023-06-01 (Thursday, index 3) is in the future → must not inflate Thursday.
-    expect(result[3]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0 });
+    expect(result[3]).toEqual({ avgAmount: 0, avgTx: 0, min: 0, max: 0, p10: 0, p90: 0 });
   });
 
   it("returns zeros for every weekday when there is no spending", () => {
@@ -75,7 +135,7 @@ describe("overallDailyAverage", () => {
 });
 
 describe("weekdayInsights", () => {
-  const s = (avgAmount: number): WeekdayStat => ({ avgAmount, avgTx: 0, min: 0, max: 0 });
+  const s = (avgAmount: number): WeekdayStat => ({ avgAmount, avgTx: 0, min: 0, max: 0, p10: 0, p90: 0 });
 
   it("flags the priciest and cheapest weekdays and the weekend delta", () => {
     // Mon40 Tue40 Wed80 Thu20 Fri40 Sat60 Sun60

--- a/front/src/components/statistics/helpers/weekdayStats.ts
+++ b/front/src/components/statistics/helpers/weekdayStats.ts
@@ -17,7 +17,15 @@ export interface WeekdayStat extends DailyAverage {
   min: number;
   /** Highest single-day total among that weekday's spending days (0 when none). */
   max: number;
+  /** Low end of the typical range — 10th percentile of that weekday's realized days. */
+  p10: number;
+  /** High end of the typical range — 90th percentile of the same series. */
+  p90: number;
 }
+
+/** The typical-range whisker spans the middle 80 % of a weekday's realized days. */
+const TYPICAL_LOW_P = 0.1;
+const TYPICAL_HIGH_P = 0.9;
 
 /** Monday-based day of week: 0 = Monday … 6 = Sunday (date-fns getDay is 0=Sunday). */
 const mondayDow = (date: Date): number => (getDay(date) + 6) % 7;
@@ -30,6 +38,22 @@ const isoOf = (date: Date): string => {
 };
 
 const mean = (values: number[]): number => (values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 0);
+
+/**
+ * Linear-interpolated percentile of an ascending-sorted series; `p` is a 0–1
+ * fraction, clamped. Returns 0 for an empty series. It backs the weekday
+ * "typical range" whisker (COS-182): unlike a raw min/max, a single outlier day
+ * can no longer stretch the range — and with it the whole chart's scale.
+ */
+export function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) {
+    return 0;
+  }
+  const position = (sorted.length - 1) * Math.max(0, Math.min(1, p));
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}
 
 /**
  * Elapsed (non-future) window of a year: how many days are realized and the ISO
@@ -45,12 +69,14 @@ function realizedWindow(year: number, now: Date): { realizedDays: number; lastRe
 
 /**
  * Average spend + transaction count per weekday (Mon..Sun) over the realized part
- * of `year`, plus each weekday's min/max single-day total, from the shared
- * /daily-stats series (COS-45, COS-48, COS-127). Zero-spend days count toward the
- * average: the sparse `days` only carries spending days, so the denominator is
- * each weekday's real occurrence count (not `days.length`). The min/max range,
- * however, spans only the days that actually had spending (the "range"
- * whisker). Future-dated spendings (current year) are excluded, matching the heatmap.
+ * of `year`, plus each weekday's typical range and its absolute extremes, from the
+ * shared /daily-stats series (COS-45, COS-48, COS-127). Zero-spend days count toward
+ * the average: the sparse `days` only carries spending days, so the denominator is
+ * each weekday's real occurrence count (not `days.length`). The p10/p90 typical
+ * range (COS-182) is drawn from that same full population, so the whisker describes
+ * exactly what the bar averages; `min`/`max` keep their narrower meaning — the
+ * extremes among the days that actually had spending, shown in the tooltip only.
+ * Future-dated spendings (current year) are excluded, matching the heatmap.
  */
 export function weekdayAverages(days: DailyStat[], year: number, now: Date): WeekdayStat[] {
   const { realizedDays, lastRealizedIso } = realizedWindow(year, now);
@@ -62,8 +88,7 @@ export function weekdayAverages(days: DailyStat[], year: number, now: Date): Wee
 
   const sumAmount = new Array<number>(7).fill(0);
   const sumTx = new Array<number>(7).fill(0);
-  const minAmount = new Array<number>(7).fill(Number.POSITIVE_INFINITY);
-  const maxAmount = new Array<number>(7).fill(0);
+  const spendingTotals: number[][] = Array.from({ length: 7 }, () => []);
   for (const day of days) {
     if (day.date.slice(0, 10) > lastRealizedIso) {
       continue; // future-dated spending
@@ -71,20 +96,25 @@ export function weekdayAverages(days: DailyStat[], year: number, now: Date): Wee
     const w = mondayDow(parseISO(day.date));
     sumAmount[w] += day.total;
     sumTx[w] += day.count;
-    if (day.total < minAmount[w]) {
-      minAmount[w] = day.total;
-    }
-    if (day.total > maxAmount[w]) {
-      maxAmount[w] = day.total;
-    }
+    spendingTotals[w].push(day.total);
   }
 
-  return occurrences.map((occ, w) => ({
-    avgAmount: occ > 0 ? sumAmount[w] / occ : 0,
-    avgTx: occ > 0 ? sumTx[w] / occ : 0,
-    min: Number.isFinite(minAmount[w]) ? minAmount[w] : 0,
-    max: maxAmount[w],
-  }));
+  return occurrences.map((occ, w) => {
+    const spending = spendingTotals[w].sort((a, b) => a - b);
+    // The realized days *without* spending belong to the distribution just as they
+    // belong to the average's denominator. They are all 0, so prepending them to the
+    // sorted spending totals yields the full ascending series without a second sort.
+    const zeroDays = Math.max(0, occ - spending.length);
+    const series = [...new Array<number>(zeroDays).fill(0), ...spending];
+    return {
+      avgAmount: occ > 0 ? sumAmount[w] / occ : 0,
+      avgTx: occ > 0 ? sumTx[w] / occ : 0,
+      min: spending[0] ?? 0,
+      max: spending[spending.length - 1] ?? 0,
+      p10: percentile(series, TYPICAL_LOW_P),
+      p90: percentile(series, TYPICAL_HIGH_P),
+    };
+  });
 }
 
 /**

--- a/front/src/text/en/statistics.ts
+++ b/front/src/text/en/statistics.ts
@@ -102,7 +102,9 @@ const statistics: typeof frStatistics = {
     // Signed delta % suffix (e.g. the tooltip's Delta badge).
     deltaPct: (pct: string) => `${pct}%`,
     tooltip: {
-      range: "Range (weeks)",
+      // The p10–p90 whisker drawn on the bar, then the year's absolute extremes (COS-182).
+      typicalRange: "Typical range",
+      extremes: "Min / max over the year",
       rangeValue: (min: string, max: string) => `${min} € - ${max} €`,
       txPerDay: "Transactions / day",
       dominantCategory: "Dominant category",
@@ -115,7 +117,7 @@ const statistics: typeof frStatistics = {
       under: (budget: string) => `≤ ${budget} €`,
       between: (budget: string, danger: string) => `${budget} – ${danger} €`,
       over: (danger: string) => `> ${danger} €`,
-      range: "min – max over the year",
+      typicalRange: "typical range (8 days out of 10)",
       average: "average",
       comparedYear: (year: number) => `compared year (${year})`,
     },

--- a/front/src/text/fr/statistics.ts
+++ b/front/src/text/fr/statistics.ts
@@ -98,7 +98,9 @@ const statistics = {
     // Signed delta % suffix (e.g. the tooltip's Delta badge).
     deltaPct: (pct: string) => `${pct} %`,
     tooltip: {
-      range: "Fourchette (semaines)",
+      // The p10–p90 whisker drawn on the bar, then the year's absolute extremes (COS-182).
+      typicalRange: "Fourchette habituelle",
+      extremes: "Min / max sur l'année",
       rangeValue: (min: string, max: string) => `${min} € - ${max} €`,
       txPerDay: "Transactions / jour",
       dominantCategory: "Catégorie dominante",
@@ -111,7 +113,7 @@ const statistics = {
       under: (budget: string) => `≤ ${budget} €`,
       between: (budget: string, danger: string) => `${budget} – ${danger} €`,
       over: (danger: string) => `> ${danger} €`,
-      range: "min – max sur l'année",
+      typicalRange: "fourchette habituelle (8 jours sur 10)",
       average: "moyenne",
       comparedYear: (year: number) => `année comparée (${year})`,
     },


### PR DESCRIPTION
The chart's scale was built on each weekday's yearly max, so a single expensive day pushed it far enough to squash all seven bars into the left tenth of the plot — and the min–max whisker feeding it spanned ~0 to that outlier, near-identical on every row. The scale now reads a p10–p90 typical range instead: bounded by construction, so the bars keep their length and the whisker never needs clamping. min/max stay, in the tooltip, beside the new typical-range row.

The row grid was also fixed at 92px/1fr/152px with no responsive variant, leaving the bar column ~60px wide on a phone and overlapping the budget ticks. Rows now stack below md — day name and amount on one line, full-width bar underneath — and the reference lines come from a band mirroring the grid columns rather than from hardcoded pixel offsets, so one full-height element still spans the whole plot.