### PR TITLE
fix(front): draw the KPI sparklines once (COS-183)

### DIFF
--- a/front/src/components/statistics/StatMiniChart.tsx
+++ b/front/src/components/statistics/StatMiniChart.tsx
@@ -29,14 +29,20 @@ const niceCeil = (value: number): number => {
 const W = 300;
 const PAD = { top: 12, right: 8, bottom: 12, left: 8 };
 
+/** Default plot height — also what a KPI card reserves while its data loads. */
+export const MINI_CHART_HEIGHT = 150;
+
 /**
  * The KPI sparkline, shared by every stat card so they render identically:
  * a gradient area fill with solid x/y axes and a dashed grid (accent-green
  * verticals per the mockup) drawn ON TOP of the fill, an end-of-line dot, an
  * optional dashed average line, and an HTML y-axis graduation (SVG text would be
  * distorted by the stretched viewBox — the end dot is HTML for the same reason).
+ *
+ * The plot draws itself left→right on mount; give the component a `key` that
+ * changes with the series to replay that draw.
  */
-const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniChartProps) => {
+const StatMiniChart = ({ id, values, count, average, height = MINI_CHART_HEIGHT }: StatMiniChartProps) => {
   const { numberLocale } = useFormat();
   const statistics = useTranslations("statistics");
 
@@ -82,15 +88,21 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
         <span>{kFormat(max / 2)}</span>
         <span>0</span>
       </div>
-      <div className="relative min-w-0 flex-1">
+      <div
+        className="relative min-w-0 flex-1"
+        role="img"
+        aria-label={statistics.miniChart.ariaLabel}
+      >
+        {/* Three stacked layers, because only the series may animate while the
+            grid, the axes and the average line stay put — and the grid has to sit
+            between the gradient fill and the line. All three are absolute, so
+            paint order is DOM order and no z-index is needed.
+            1) gradient area — revealed left→right on mount. */}
         <svg
           viewBox={`0 0 ${W} ${height}`}
-          width="100%"
-          height={height}
           preserveAspectRatio="none"
-          className="block"
-          role="img"
-          aria-label={statistics.miniChart.ariaLabel}
+          className="pfa-anim-draw-x absolute inset-0 block size-full"
+          aria-hidden="true"
         >
           <defs>
             <linearGradient
@@ -112,14 +124,20 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
               />
             </linearGradient>
           </defs>
-
-          {/* gradient area (behind) */}
           <path
             d={areaPath(pixels, baseY)}
             fill={`url(#${id}-fill)`}
             stroke="none"
           />
+        </svg>
 
+        {/* 2) static chrome, never animated */}
+        <svg
+          viewBox={`0 0 ${W} ${height}`}
+          preserveAspectRatio="none"
+          className="absolute inset-0 block size-full"
+          aria-hidden="true"
+        >
           {/* dashed grid — drawn over the fill so it stays visible */}
           {hGrid.map((v) => (
             <line
@@ -186,18 +204,34 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
             strokeOpacity={0.7}
             vectorEffect="non-scaling-stroke"
           />
-
-          {/* series line (topmost) */}
-          <path
-            d={linePath(pixels)}
-            fill="none"
-            stroke="var(--accent-strong)"
-            strokeWidth={2}
-            strokeLinejoin="round"
-            strokeLinecap="round"
-            vectorEffect="non-scaling-stroke"
-          />
         </svg>
+
+        {/* 3) the series line and its end dot, revealed by a second clip that
+            starts with the area's — same class, same frame, so they stay in step. */}
+        <div className="pfa-anim-draw-x absolute inset-0">
+          <svg
+            viewBox={`0 0 ${W} ${height}`}
+            preserveAspectRatio="none"
+            className="absolute inset-0 block size-full"
+            aria-hidden="true"
+          >
+            <path
+              d={linePath(pixels)}
+              fill="none"
+              stroke="var(--accent-strong)"
+              strokeWidth={2}
+              strokeLinejoin="round"
+              strokeLinecap="round"
+              vectorEffect="non-scaling-stroke"
+            />
+          </svg>
+
+          {/* end dot — filled; HTML so it stays perfectly round under the stretched viewBox */}
+          <span
+            className="pointer-events-none absolute size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent-strong"
+            style={{ left: `${dotLeft}%`, top: `${dotTop}%` }}
+          />
+        </div>
 
         {avgY != null && (
           <span
@@ -207,12 +241,6 @@ const StatMiniChart = ({ id, values, count, average, height = 150 }: StatMiniCha
             {statistics.miniChart.averageShort}
           </span>
         )}
-
-        {/* end dot — filled; HTML so it stays perfectly round under the stretched viewBox */}
-        <span
-          className="pointer-events-none absolute size-1.5 -translate-x-1/2 -translate-y-1/2 rounded-full bg-accent-strong"
-          style={{ left: `${dotLeft}%`, top: `${dotTop}%` }}
-        />
       </div>
     </div>
   );

--- a/front/src/components/statistics/StatisticsKpis.tsx
+++ b/front/src/components/statistics/StatisticsKpis.tsx
@@ -15,7 +15,7 @@ import {
   monthShortLabels,
   yearTotal,
 } from "@components/statistics/helpers/statisticsData";
-import StatMiniChart from "@components/statistics/StatMiniChart";
+import StatMiniChart, { MINI_CHART_HEIGHT } from "@components/statistics/StatMiniChart";
 import { Tooltip } from "@components/ui/tooltip";
 import useDateLocale from "@i18n/useDateLocale";
 import useFormat from "@i18n/useFormat";
@@ -37,7 +37,12 @@ interface StatisticsKpisProps {
   compareExceptionals: ExceptionalItem[];
   biggestRegular: BiggestRegularExpense | null;
   showExceptionals: boolean;
+  /** True until every source feeding the four cards has landed. */
+  isLoading: boolean;
 }
+
+const KPI_GRID = "grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-4";
+const VALUE_CLASS = "num mb-1 mt-2.5 text-3xl font-medium leading-none tracking-tight";
 
 const cap = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
 
@@ -48,10 +53,33 @@ const Card = ({ label, children }: { label: string; children: React.ReactNode })
   </GlowCard>
 );
 
+/** Stand-in card, shaped like its loaded counterpart so the row never jumps. */
+const LoadingCard = ({ label, chart = false }: { label: string; chart?: boolean }) => {
+  const common = useTranslations("common");
+  return (
+    <Card label={label}>
+      {chart ? (
+        <>
+          <div className={cn(VALUE_CLASS, "text-ink-4")}>—</div>
+          <span className="text-xs text-ink-4">{common.loading}</span>
+          {/* the plot's exact height, so the card doesn't grow when data lands */}
+          <div
+            className="mt-4"
+            style={{ height: MINI_CHART_HEIGHT }}
+          />
+        </>
+      ) : (
+        // stands in for the two comparison rows these cards render once loaded
+        <div className="mt-2 min-h-20 text-xs text-ink-4">{common.loading}</div>
+      )}
+    </Card>
+  );
+};
+
 const Value = ({ amount }: { amount: number }) => {
   const { euro0 } = useFormat();
   return (
-    <div className="num mb-1 mt-2.5 text-3xl font-medium leading-none tracking-tight text-ink">
+    <div className={cn(VALUE_CLASS, "text-ink")}>
       {euro0(amount)}
       <span className="text-xl font-normal text-ink-3"> €</span>
     </div>
@@ -151,6 +179,7 @@ const StatisticsKpis = ({
   compareExceptionals,
   biggestRegular,
   showExceptionals,
+  isLoading,
 }: StatisticsKpisProps) => {
   const { euro0 } = useFormat();
   const statisticsText = useTranslations("statistics");
@@ -160,6 +189,28 @@ const StatisticsKpis = ({
   const compareTotalTip = useCursorHover();
 
   const { kpis: t } = statisticsText;
+
+  // One gate for the whole row rather than one per card: the four share a row
+  // height, and rendering them on partial data is what made the two sparklines
+  // climb in steps (COS-183) — every card value, hence the plot's own y scale,
+  // was recomputed as each request landed.
+  if (isLoading) {
+    return (
+      <section className={KPI_GRID}>
+        <LoadingCard
+          label={t.totalSpent(year)}
+          chart
+        />
+        <LoadingCard
+          label={t.avgPerMonth}
+          chart
+        />
+        <LoadingCard label={t.biggestMonth} />
+        <LoadingCard label={t.biggestExpense} />
+      </section>
+    );
+  }
+
   const data = statistics?.data;
   const regMonthly = monthlyTotals(data, year);
   const excMonthly = exceptionalMonthly(exceptionals);
@@ -192,8 +243,12 @@ const StatisticsKpis = ({
     : { label: t.regularExpenseFallback, amount: 0, date: null as string | null };
   const expenseScale = Math.max(Number(topExc?.amount ?? 0), regularBiggest.amount, 1);
 
+  // Remount key → replays the left→right draw when the series really changes
+  // (year switch, exceptionals toggle), not on every re-render.
+  const chartKey = `${year}-${showExceptionals ? "e" : "r"}`;
+
   return (
-    <section className="grid grid-cols-1 gap-4 xs:grid-cols-2 md:grid-cols-4">
+    <section className={KPI_GRID}>
       <Card label={t.totalSpent(year)}>
         <Value amount={total} />
         <span
@@ -213,6 +268,7 @@ const StatisticsKpis = ({
         </Tooltip>
         <div className="mt-4">
           <StatMiniChart
+            key={chartKey}
             id="kpi-total"
             values={cumulative(totalMonthly)}
             count={months}
@@ -228,6 +284,7 @@ const StatisticsKpis = ({
         </span>
         <div className="mt-4">
           <StatMiniChart
+            key={chartKey}
             id="kpi-avg"
             values={totalMonthly}
             count={months}

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -61,7 +61,7 @@ const StatisticsView = () => {
     return Array.from(new Set(requested));
   }, [selectedYear, compareYear, currentYear]);
 
-  const { statistics, categories } = useStatistics({ years });
+  const { statistics, categories, isLoading: statisticsLoading } = useStatistics({ years });
   const { dailyStats } = useDailyStats({ year: selectedYear });
   // Compare-year daily series for the day-of-week widget (COS-127) — only fetched
   // when "Compare to" is on.
@@ -72,9 +72,9 @@ const StatisticsView = () => {
   });
   // Dominant category per weekday, for that widget's hover tooltip (COS-127).
   const { weekdayCategories } = useWeekdayCategories({ year: selectedYear });
-  const { biggestRegular } = useBiggestRegularExpense({ year: selectedYear });
-  const { exceptionals } = useExceptionals({ year: selectedYear });
-  const { exceptionals: compareExceptionals } = useExceptionals({
+  const { biggestRegular, isLoading: biggestRegularLoading } = useBiggestRegularExpense({ year: selectedYear });
+  const { exceptionals, isLoading: exceptionalsLoading } = useExceptionals({ year: selectedYear });
+  const { exceptionals: compareExceptionals, isLoading: compareExceptionalsLoading } = useExceptionals({
     year: compareYear,
   });
   const dashboard = useDashboard();
@@ -172,6 +172,10 @@ const StatisticsView = () => {
         compareExceptionals={compareExceptionals}
         biggestRegular={biggestRegular}
         showExceptionals={showExceptionals}
+        // The KPI cards only render once all four of their sources are in: a
+        // partially-fed card shows a wrong value, and the two sparklines would
+        // rescale on each arrival instead of drawing once (COS-183).
+        isLoading={statisticsLoading || exceptionalsLoading || compareExceptionalsLoading || biggestRegularLoading}
       />
 
       <StatisticsForecast

--- a/front/src/components/statistics/services/useStatistics.tsx
+++ b/front/src/components/statistics/services/useStatistics.tsx
@@ -30,7 +30,7 @@ const useStatistics = ({ years }: UseStatisticsOptions) => {
     return StatisticsResponseSchema.parse(response.data);
   };
 
-  const { data, isPending } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: queryKey,
     queryFn: getStatistics,
     retry: true,
@@ -41,7 +41,12 @@ const useStatistics = ({ years }: UseStatisticsOptions) => {
     statistics: data,
     colors: data?.colors ?? {},
     categories: categories ?? [],
-    isLoading: isPending,
+    // The query is gated on the category list (it feeds the `categories` param),
+    // so it sits idle — which React Query reports as "not loading" — until the
+    // categories land: hence the explicit first leg. An account with zero
+    // categories has nothing to fetch and resolves to `false`, never to an
+    // endless loading state.
+    isLoading: categories === undefined || isLoading,
   };
 };
 


### PR DESCRIPTION
The two Statistics KPI plots looked like a broken animation: the curve appeared at once, then climbed in two or three abrupt steps. They had no animation at all. StatisticsKpis renders before its data lands, so each card was recomputed as every request arrived — nothing, then exceptionals only, then the full series — and StatMiniChart re-derives its y ceiling from the values on each render, so the whole curve was repositioned vertically at each step.

The four cards now render only once all of their sources are in, behind stand-in cards shaped like their loaded counterparts (the plot's exact height is reserved) so the row never jumps. useStatistics reports the loading state honestly: its query is gated on the category list, which React Query reports as "not loading" while idle, and an account with no categories has nothing to fetch — neither must read as loading forever.

The plot then draws itself left to right with pfa-anim-draw-x, the clip reveal already used by the dashboard sparkline, replayed by a remount key on a real series change (year, exceptionals toggle). The reveal covers the series only: the gradient area and the line-plus-end-dot are two animated layers sandwiching a static one, since the grid has to sit between the fill and the line and must not be swept in with it.