### PR TITLE
feat(front): animate the spendings strip (COS-185)

### DIFF
--- a/front/src/components/shared/MoneyAmount.tsx
+++ b/front/src/components/shared/MoneyAmount.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import useFormat from "@i18n/useFormat";
+import useCountUp from "@lib/dataviz/useCountUp";
 import { cn } from "@lib/utils";
 
 interface MoneyAmountProps {
   value: number;
   /** Trailing unit inside the de-emphasised span. */
   unit?: string;
+  /** Count the integer part up from 0 — on mount and on every value change. */
+  animate?: boolean;
   /** Classes for the de-emphasised ",decimals unit" span (usually a smaller size). */
   decimalClassName?: string;
   /** Classes for the whole figure (main size / colour / `num`). */
@@ -18,10 +21,18 @@ interface MoneyAmountProps {
  * the one place that split lives. Set the main size/colour via `className` (or an
  * ancestor); the decimals are toned down (`font-normal text-ink-3`) and sized via
  * `decimalClassName`.
+ *
+ * Under `animate`, only the integer counts up; the cents stay pinned to their
+ * final value, like the "Remaining budget" heroes — rolling that small a span
+ * reads as flicker, not as motion.
  */
-function MoneyAmount({ value, unit = " €", decimalClassName, className }: MoneyAmountProps) {
+function MoneyAmount({ value, unit = " €", animate = false, decimalClassName, className }: MoneyAmountProps) {
   const { splitAmount } = useFormat();
-  const { int, dec, separator } = splitAmount(value);
+  // The integer comes from the animated value so it keeps its locale grouping at
+  // every frame; the decimals always come from the final one.
+  const counted = useCountUp(value, animate);
+  const { int } = splitAmount(counted);
+  const { dec, separator } = splitAmount(value);
   return (
     <span className={className}>
       {int}

--- a/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
+++ b/front/src/components/spendings/view/SpendingCategoryBreakdown.tsx
@@ -8,7 +8,7 @@ import SpendingsListModal from "@components/spendings/spendingsListModal/Spendin
 import { Tooltip } from "@components/ui/tooltip";
 import useFormat from "@i18n/useFormat";
 import useTranslations from "@i18n/useTranslations";
-import { CategoryTooltipContent, CategoryTrend } from "@lib/dataviz";
+import { CategoryTooltipContent, CategoryTrend, StackedBar } from "@lib/dataviz";
 import { cn } from "@lib/utils";
 import { ChevronDown } from "lucide-react";
 import { useState } from "react";
@@ -135,19 +135,20 @@ const SpendingCategoryBreakdown = ({ rows, rangeLabel }: SpendingCategoryBreakdo
         }
       />
 
-      <div className="mb-2.5 flex h-2 overflow-hidden rounded-sm">
-        {rowsWithTrend.map((r) => (
-          <span
-            key={r.key}
-            role="img"
-            className="block h-full"
-            aria-label={`${r.name} : ${pct1(r.pct)} % (${euro(r.total)} €)`}
-            style={{ width: `${r.pct.toFixed(2)}%`, background: r.color }}
-            onMouseMove={(e) => setHover({ target: r, x: e.clientX, y: e.clientY })}
-            onMouseLeave={() => setHover(null)}
-          />
-        ))}
-      </div>
+      {/* Grows from zero on mount and eases in place on a week change (COS-185).
+          Replaces a hand-rolled copy of this very bar, so the hover now goes
+          through the shared hit-testing: one labelled image for assistive tech
+          instead of one per segment, the per-category detail being read from the
+          list right below. */}
+      <StackedBar
+        animate
+        className="mb-2.5"
+        radius="var(--radius-sm)"
+        segments={rowsWithTrend.map((r) => ({ label: r.name, value: r.total, color: r.color }))}
+        ariaLabel={t.barAria}
+        onSegmentHover={(index, e) => setHover({ target: rowsWithTrend[index], x: e.clientX, y: e.clientY })}
+        onSegmentLeave={() => setHover(null)}
+      />
 
       <div
         id={DETAIL_ID}

--- a/front/src/components/spendings/view/SpendingSummary.tsx
+++ b/front/src/components/spendings/view/SpendingSummary.tsx
@@ -57,7 +57,8 @@ const SpendingSummary = ({
 
   // Hero "Remaining budget" — big number, split integer/decimals like the Dashboard
   // BudgetHero, red when over budget. The integer counts up via the reusable
-  // AnimatedNumber component; the cents stay fixed beside it.
+  // AnimatedNumber component; the cents stay fixed beside it. Every other figure in
+  // the strip counts up too (COS-185) — one lone moving number read as a glitch.
   const over = remaining < 0;
   const { int: remainingInt, dec: remainingDec, separator: remainingSeparator } = splitAmount(Math.abs(remaining));
   const remainingIntValue = Number(remainingInt.replace(/\D/g, ""));
@@ -114,6 +115,7 @@ const SpendingSummary = ({
         label={t.weekTotal}
         value={
           <MoneyAmount
+            animate
             value={weekTotal}
             decimalClassName="text-lg"
           />
@@ -122,13 +124,14 @@ const SpendingSummary = ({
       />
       <Cell
         label={t.transactions}
-        value={txCount}
+        value={<AnimatedNumber value={txCount} />}
         sub={t.transactionsSub(perDay)}
       />
       <Cell
         label={t.avgPerDay}
         value={
           <MoneyAmount
+            animate
             value={average}
             decimalClassName="text-lg"
           />
@@ -140,6 +143,7 @@ const SpendingSummary = ({
         value={
           biggest ? (
             <MoneyAmount
+              animate
               value={biggest.amount}
               decimalClassName="text-lg"
             />

--- a/front/src/lib/dataviz/AnimatedNumber.tsx
+++ b/front/src/lib/dataviz/AnimatedNumber.tsx
@@ -49,7 +49,7 @@ const AnimatedNumber = ({
 }: AnimatedNumberProps) => {
   const { numberLocale } = useFormat();
   const activeLocale = locale ?? numberLocale;
-  const animated = useCountUp(value, duration);
+  const animated = useCountUp(value, true, duration);
   const text = animated.toLocaleString(activeLocale, {
     minimumFractionDigits: decimals,
     maximumFractionDigits: decimals,

--- a/front/src/lib/dataviz/StackedBar.tsx
+++ b/front/src/lib/dataviz/StackedBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import useTween from "@lib/dataviz/useTween";
 import { cn } from "@lib/utils";
 
 import type { DonutSegment } from "@lib/dataviz/interfaces/dataVizTypes";
@@ -8,7 +9,10 @@ import type { MouseEvent } from "react";
 interface StackedBarProps {
   segments: DonutSegment[];
   height?: number;
-  radius?: number;
+  /** Corner radius — a number (px) or any CSS length (e.g. a radius token). */
+  radius?: number | string;
+  /** Grow the segments from zero on mount, and ease them in place on a change. */
+  animate?: boolean;
   className?: string;
   ariaLabel?: string;
   /** Fires on pointer move over the bar with the segment index under the cursor. */
@@ -17,11 +21,23 @@ interface StackedBarProps {
   onSegmentLeave?: () => void;
 }
 
+/** One slice, in its own component so it can own a tween hook (no hooks in a `.map`). */
+const Segment = ({ fraction, color, animate }: { fraction: number; color: string; animate: boolean }) => {
+  const width = useTween(fraction, animate);
+  return (
+    <span
+      className="block h-full"
+      style={{ width: `${width * 100}%`, background: color }}
+    />
+  );
+};
+
 /** Single horizontal stacked bar (e.g. a category distribution). */
 const StackedBar = ({
   segments,
   height = 8,
   radius = 4,
+  animate = false,
   className,
   ariaLabel,
   onSegmentHover,
@@ -59,14 +75,14 @@ const StackedBar = ({
       onMouseMove={onSegmentHover ? handleMove : undefined}
       onMouseLeave={onSegmentLeave}
     >
+      {/* Every segment shares one duration and one easing curve, so the whole bar
+          grows as a block and the proportions hold at every frame. */}
       {segments.map((seg) => (
-        <span
+        <Segment
           key={`${seg.label ?? ""}-${seg.color}`}
-          className="block h-full"
-          style={{
-            width: `${(Math.max(0, seg.value) / total) * 100}%`,
-            background: seg.color,
-          }}
+          fraction={Math.max(0, seg.value) / total}
+          color={seg.color}
+          animate={animate}
         />
       ))}
     </div>

--- a/front/src/lib/dataviz/useCountUp.ts
+++ b/front/src/lib/dataviz/useCountUp.ts
@@ -7,12 +7,18 @@ import { useEffect, useRef, useState } from "react";
  * changes — i.e. on mount, when the data loads, and on a month change. Respects
  * prefers-reduced-motion (snaps straight to the value). The setState runs inside
  * requestAnimationFrame (async), not synchronously in the effect.
+ *
+ * Pass `enabled = false` to bypass and return the raw target — same escape hatch
+ * (and same argument order) as the sibling `useTween`, so a component with an
+ * opt-in `animate` prop calls the hook unconditionally instead of burning a rAF
+ * loop counting to a value it never shows.
  */
-export default function useCountUp(target: number, duration = 850): number {
+export default function useCountUp(target: number, enabled = true, duration = 850): number {
   const [value, setValue] = useState(0);
   const rafRef = useRef(0);
 
   useEffect(() => {
+    if (!enabled) return;
     const reduce =
       typeof window !== "undefined" && Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
     let startTs = 0;
@@ -26,7 +32,7 @@ export default function useCountUp(target: number, duration = 850): number {
     };
     rafRef.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafRef.current);
-  }, [target, duration]);
+  }, [target, enabled, duration]);
 
-  return value;
+  return enabled ? value : target;
 }

--- a/front/src/text/en/spendings.ts
+++ b/front/src/text/en/spendings.ts
@@ -64,6 +64,9 @@ const spendings: typeof frSpendings = {
     expandAria: "Show category breakdown",
     collapseAria: "Hide category breakdown",
     expandHint: "Expand to see details",
+    // Label of the stacked bar as a whole — the per-category detail is read from
+    // the list below it.
+    barAria: "Weekly breakdown by category",
     // Suffix appended after the week range label in the pane header.
     rangeSuffix: " · week",
     // Per-category trend badge vs the previous week (COS-35).

--- a/front/src/text/fr/spendings.ts
+++ b/front/src/text/fr/spendings.ts
@@ -62,6 +62,9 @@ const spendings = {
     expandAria: "Afficher le détail par catégorie",
     collapseAria: "Masquer le détail par catégorie",
     expandHint: "Déplier pour voir le détail",
+    // Label of the stacked bar as a whole — the per-category detail is read from
+    // the list below it.
+    barAria: "Répartition hebdomadaire par catégorie",
     // Suffix appended after the week range label in the pane header.
     rangeSuffix: " · semaine",
     // Per-category trend badge vs the previous week (COS-35).


### PR DESCRIPTION
The strip of five widgets on the Spendings page was only half animated: the "Remaining budget" hero counted up from zero (COS-42) while the four tiles beside it snapped to their final value, so one lone moving number read as a glitch. The category breakdown bar had the same problem — every other gauge in the app grows from zero via useTween, that one did not.

Nothing new to animate with, the primitives were already there:

- MoneyAmount takes an `animate` prop (off by default, so the Dashboard callers are untouched). Only the integer counts up; the cents stay pinned to their final value, like the heroes — rolling that small a span reads as flicker.
- useCountUp gains the `enabled` flag useTween already had, in the same argument position, so an opt-in `animate` prop can call the hook unconditionally instead of burning a rAF loop on a value it never shows.
- StackedBar takes an `animate` prop too (each slice tweens its width from its own component, hooks not being allowed in a `.map`). One duration and one curve for all of them, so the bar grows as a block and the proportions hold at every frame. Its `radius` now also accepts a CSS length, to keep the breakdown bar on `--radius-sm`.

The breakdown bar itself was a hand-rolled copy of StackedBar, so it now uses the shared one: the hover goes through the built-in hit-testing and assistive tech gets one labelled image instead of one per segment — the per-category detail is read from the list right below it.

The sub-captions stay still: they are sentences interpolated from @text, and a counter in the middle of one would be unreadable.