### PR TITLE
feat(auth): disable signup via env flag (COS-419)

### DIFF
--- a/front/.env.production
+++ b/front/.env.production
@@ -1,0 +1,4 @@
+# COS-419: sign-ups locked down to the owner. Set to "true" to reopen registration.
+# Inlined into the JS bundle at `next build` time (NEXT_PUBLIC_*), so this must live in
+# .env.production and not in ecosystem.config.cjs (PM2 env is too late for these vars).
+NEXT_PUBLIC_SIGNUPS_ENABLED=false

--- a/front/src/app/(public)/signup/page.tsx
+++ b/front/src/app/(public)/signup/page.tsx
@@ -10,6 +10,13 @@ import useTranslations from "@i18n/useTranslations";
 
 import type { LoginValues } from "@components/shared/interfaces/sharedLoginFormTypes";
 
+/**
+ * Locked down, not hidden (COS-419). `NEXT_PUBLIC_SIGNUPS_ENABLED === "false"` disables every
+ * field and the submit button while leaving the page and the form exactly where they are — the
+ * API refuses `POST /users/add` regardless, so this is a visible "no" rather than the actual gate.
+ */
+const signupsEnabled = process.env.NEXT_PUBLIC_SIGNUPS_ENABLED !== "false";
+
 export default function SignUp() {
   const login = useTranslations("login");
   const { signupService } = useSignupService();
@@ -36,6 +43,7 @@ export default function SignUp() {
         displayEmailField
         displayPasswordField
         displayConfirmPasswordField
+        disabled={!signupsEnabled}
       />
 
       <AuthSwitchLink

--- a/front/src/components/shared/interfaces/sharedLoginFormTypes.ts
+++ b/front/src/components/shared/interfaces/sharedLoginFormTypes.ts
@@ -20,4 +20,6 @@ export interface SharedLoginFormProps {
   serverError?: string | null;
   /** Called when the user edits email/password, so the parent can clear serverError. */
   onDismissError?: () => void;
+  /** Disables every field and the submit button while leaving the form in place (COS-419). */
+  disabled?: boolean;
 }

--- a/front/src/components/shared/sharedLoginForm/PasswordField.tsx
+++ b/front/src/components/shared/sharedLoginForm/PasswordField.tsx
@@ -15,10 +15,11 @@ interface PasswordFieldProps {
   autoComplete: string;
   invalid: boolean;
   registration: UseFormRegisterReturn;
+  disabled?: boolean;
 }
 
 /** Auth password input with its own show/hide toggle. */
-const PasswordField = ({ id, label, autoComplete, invalid, registration }: PasswordFieldProps) => {
+const PasswordField = ({ id, label, autoComplete, invalid, registration, disabled }: PasswordFieldProps) => {
   const login = useTranslations("login");
   const [show, setShow] = useState(false);
 
@@ -38,6 +39,7 @@ const PasswordField = ({ id, label, autoComplete, invalid, registration }: Passw
           autoComplete={autoComplete}
           className={cn(authInputClass, "pr-10.5")}
           aria-invalid={invalid}
+          disabled={disabled}
           {...registration}
         />
         <button

--- a/front/src/components/shared/sharedLoginForm/authInputClass.ts
+++ b/front/src/components/shared/sharedLoginForm/authInputClass.ts
@@ -9,4 +9,4 @@
  * card show through, which an opaque `bg-surface-base` would kill.
  */
 export const authInputClass =
-  "w-full rounded-sm border border-line px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg";
+  "w-full rounded-sm border border-line px-3.5 py-3 text-sm text-ink outline-none transition [background:oklch(0.12_0.008_250/0.75)] placeholder:text-ink-4 focus:border-[oklch(0.65_0.11_175)] focus:[background:oklch(0.13_0.008_250)] focus:shadow-[0_0_0_3px_oklch(0.65_0.11_175/0.15)] aria-invalid:border-neg disabled:cursor-not-allowed";

--- a/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
+++ b/front/src/components/shared/sharedLoginForm/sharedLoginForm.tsx
@@ -43,6 +43,7 @@ const SharedLoginForm = ({
   submitIcon,
   serverError,
   onDismissError,
+  disabled,
 }: SharedLoginFormProps) => {
   const login = useTranslations("login");
   const common = useTranslations("common");
@@ -107,6 +108,7 @@ const SharedLoginForm = ({
             autoComplete="email"
             className={authInputClass}
             aria-invalid={!!errors.email}
+            disabled={disabled}
             {...register("email", { onChange: clearFieldError("email") })}
           />
         </div>
@@ -119,6 +121,7 @@ const SharedLoginForm = ({
           autoComplete={displayConfirmPasswordField ? "new-password" : "current-password"}
           invalid={!!errors.password}
           registration={register("password", { onChange: clearFieldError("password") })}
+          disabled={disabled}
         />
       )}
 
@@ -129,6 +132,7 @@ const SharedLoginForm = ({
           autoComplete="new-password"
           invalid={!!errors.confirmPassword}
           registration={register("confirmPassword", { onChange: clearFieldError("confirmPassword") })}
+          disabled={disabled}
         />
       )}
 
@@ -169,7 +173,7 @@ const SharedLoginForm = ({
       <Button
         type="submit"
         variant="primary"
-        disabled={isSubmitting}
+        disabled={isSubmitting || disabled}
         className="h-auto w-full rounded-lg py-3 text-sm tracking-normal"
       >
         {buttonTitle}

--- a/nest-api/src/users/guards/signup.guard.ts
+++ b/nest-api/src/users/guards/signup.guard.ts
@@ -1,0 +1,12 @@
+import { CanActivate, ForbiddenException, Injectable } from "@nestjs/common";
+
+@Injectable()
+export class SignupGuard implements CanActivate {
+  canActivate(): boolean {
+    if (process.env.SIGNUPS_ENABLED === "false") {
+      throw new ForbiddenException("Sign-ups are currently disabled");
+    }
+
+    return true;
+  }
+}

--- a/nest-api/src/users/users.controller.ts
+++ b/nest-api/src/users/users.controller.ts
@@ -7,6 +7,7 @@ import { UpdateUserDto } from "@users/dto/update-user.dto";
 import { RedisService } from "@redis/redis.service";
 import { SessionAuthGuard } from "@spendings/guards/session-auth.guard";
 import { CsrfGuard } from "@users/guards/csrf.guard";
+import { SignupGuard } from "@users/guards/signup.guard";
 import { clearCsrfToken, getOrCreateCsrfToken, rotateCsrfToken } from "@users/csrf-token.util";
 
 import type { SignInResponse } from "@users/users.service";
@@ -58,6 +59,7 @@ export class UsersController {
   }
 
   @Post("add")
+  @UseGuards(SignupGuard)
   @HttpCode(HttpStatus.CREATED)
   async addUser(@Body() dto: AddUserDto, @Req() req: Request): Promise<SignInResponse & { csrfToken: string }> {
     const result = await this.usersService.addUser(dto);


### PR DESCRIPTION
Instance is meant for a single user (the owner); leaving /signup open let anyone create an account. Locked down, not hidden — the page and form stay in place, but every field and the submit button render disabled, and the API refuses POST /users/add regardless (the front alone isn't a security control).

- SignupGuard on POST /users/add returns 403 when SIGNUPS_ENABLED === "false", checked before DTO validation and any DB lookup.
- NEXT_PUBLIC_SIGNUPS_ENABLED disables the signup form's fields and submit button; read at Next build time, so it lives in front/.env.production rather than the PM2 ecosystem config.
- Both vars default to enabled when unset, so other checkouts/dev environments are unaffected.