### PR TITLE
feat(spendings): attach a receipt at creation (PFA-5)

### DIFF
--- a/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
+++ b/front/src/components/spendings/common/spendingModal/SpendingModal.tsx
@@ -112,10 +112,8 @@ const SpendingModal = ({
   // Date field for a month stepper — it just disables Date when recurring.
   const [recurringMonth] = useState<Date>(() => (month?.start ? startOfMonth(month.start) : startOfMonth(new Date())));
 
-  // MOCK — receipt-at-creation is visual only: POST /spendings returns no ID and
-  // /spendings/upload needs the spendingID, so the file can't be persisted at
-  // creation. Local preview only; add the receipt after creation via the row's
-  // receipt icon. De-mock tracked in COS-24. See REFACTO_NOTES.md §9.
+  // Receipt picked at creation: kept locally for the preview, then uploaded on
+  // the created row's ID by the create mutation (chained in useSpendings, PFA-5).
   const [isReceiptToggle, setIsReceiptToggle] = useState(false);
   const [receiptFile, setReceiptFile] = useState<File | null>(null);
   const [receiptPreview, setReceiptPreview] = useState<string | null>(null);
@@ -182,6 +180,7 @@ const SpendingModal = ({
     categoryOptions,
     selectedCategory,
     comboboxQuery,
+    receiptFile,
     createSpending,
     updateSpending,
     createRecurring,
@@ -259,14 +258,24 @@ const SpendingModal = ({
                 {modal.recurringToggle}
               </Toggle>
             )}
-            {/* Receipt is not applicable to a recurring — disabled, not removed. */}
-            <Toggle
-              active={isReceiptToggle}
-              onClick={() => setIsReceiptToggle((v) => !v)}
-              disabled={asRecurring}
-            >
-              {modal.attachReceipt}
-            </Toggle>
+            {/* Receipt is not applicable to a recurring — disabled, not removed.
+                In edit mode the toggle is hidden: the modal has no view of an
+                existing receipt, so attaching here could silently overwrite one —
+                the row's receipt icon (InvoiceModal) is the edit path. */}
+            {!isEditing && (
+              <Toggle
+                active={isReceiptToggle}
+                onClick={() => {
+                  // Turning the section off drops the picked file too — a hidden
+                  // receipt must never be silently uploaded on submit.
+                  if (isReceiptToggle) clearReceipt();
+                  setIsReceiptToggle(!isReceiptToggle);
+                }}
+                disabled={asRecurring}
+              >
+                {modal.attachReceipt}
+              </Toggle>
+            )}
           </div>
 
           {!asRecurring && isReceiptToggle && (

--- a/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
+++ b/front/src/components/spendings/common/spendingModal/useSpendingSubmit.ts
@@ -7,6 +7,7 @@ import startOfMonth from "date-fns/startOfMonth";
 import type { AuthUser } from "@auth/interfaces/authTypes";
 import type { CategoryOption, SpendingForm } from "@components/spendings/common/spendingModal/schema";
 import type { SpendingListItem } from "@components/spendings/interfaces/spendingListTypes";
+import type { CreateSpendingInput } from "@components/spendings/interfaces/spendingMutationTypes";
 import type { SpendingMutationPayload } from "@src/schemas/spendings";
 
 interface MutationLike<TPayload> {
@@ -28,7 +29,8 @@ interface UseSpendingSubmitOptions {
   categoryOptions: CategoryOption[];
   selectedCategory: CategoryOption | null;
   comboboxQuery: string;
-  createSpending: MutationLike<SpendingMutationPayload>;
+  receiptFile: File | null;
+  createSpending: MutationLike<CreateSpendingInput>;
   updateSpending: MutationLike<SpendingMutationPayload>;
   createRecurring: MutationLike<CreateRecurringPayload>;
   updateRecurring: MutationLike<SpendingMutationPayload>;
@@ -45,6 +47,7 @@ const useSpendingSubmit = ({
   categoryOptions,
   selectedCategory,
   comboboxQuery,
+  receiptFile,
   createSpending,
   updateSpending,
   createRecurring,
@@ -97,10 +100,6 @@ const useSpendingSubmit = ({
       id: spending?.ID,
     };
 
-    // NOTE: a receiptFile attached here is NOT uploaded — receipt-at-creation is
-    // visual only (see the MOCK note on the receipt state in SpendingModal.tsx).
-    // De-mock tracked in COS-24.
-
     if (isEditing) {
       if (recurringType) {
         updateRecurring.mutate(spendingEdited);
@@ -115,7 +114,7 @@ const useSpendingSubmit = ({
         };
         createRecurring.mutate({ spendingEdited, formattedMonth });
       } else {
-        createSpending.mutate(spendingEdited);
+        createSpending.mutate({ spendingEdited, receiptFile });
       }
     }
 

--- a/front/src/components/spendings/interfaces/spendingMutationTypes.ts
+++ b/front/src/components/spendings/interfaces/spendingMutationTypes.ts
@@ -1,0 +1,8 @@
+import type { SpendingMutationPayload } from "@src/schemas/spendings";
+
+// Input of the create-spending mutation: the payload plus the optional receipt
+// picked in the modal, uploaded right after the row is created (PFA-5).
+export interface CreateSpendingInput {
+  spendingEdited: SpendingMutationPayload;
+  receiptFile?: File | null;
+}

--- a/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
+++ b/front/src/components/spendings/invoiceModal/InvoiceModal.tsx
@@ -6,6 +6,7 @@ import Spinner from "@components/common/Spinner";
 import ConfirmDeleteDialog from "@components/shared/ConfirmDeleteDialog";
 import { Dropzone } from "@components/shared/Dropzone";
 import InvoiceImageModal from "@components/spendings/invoiceModal/invoiceImageModal/InvoiceImageModal";
+import { buildInvoiceUploadFormData } from "@components/spendings/services/invoiceUploadFormData";
 import { Button } from "@components/ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@components/ui/dialog";
 import useRequestHelper from "@helpers/useRequestHelper";
@@ -158,32 +159,7 @@ const InvoiceModal = ({ handleClickOutside: handleClickOutsideProp, spending }: 
 
   const sendInvoice = () => {
     if (!pendingFile || !userID) return;
-
-    const formData = new FormData();
-    formData.append("userID", userID);
-
-    switch (spending.itemType) {
-      case "recurring":
-        formData.append("itemType", "recurring");
-        if (spending.dateFrom) {
-          formData.append("dateFrom", spending.dateFrom);
-        }
-        break;
-      case "spending":
-        formData.append("itemType", "spending");
-        if (spending.date) {
-          formData.append("date", spending.date);
-        }
-        break;
-      default:
-        break;
-    }
-
-    formData.append("label", spending.label);
-    formData.append("spendingID", spending.ID);
-    formData.append("invoiceImageUpload", pendingFile);
-
-    uploadInvoiceImage(formData);
+    uploadInvoiceImage(buildInvoiceUploadFormData(spending, pendingFile));
   };
 
   const category = "category" in spending ? spending.category : null;

--- a/front/src/components/spendings/services/__tests__/invoiceUploadFormData.test.ts
+++ b/front/src/components/spendings/services/__tests__/invoiceUploadFormData.test.ts
@@ -1,0 +1,31 @@
+import { buildInvoiceUploadFormData } from "@components/spendings/services/invoiceUploadFormData";
+import { describe, expect, it } from "vitest";
+
+const file = new File(["x"], "receipt.png", { type: "image/png" });
+
+describe("buildInvoiceUploadFormData", () => {
+  it("builds the spending upload body with the file as the last part", () => {
+    const formData = buildInvoiceUploadFormData(
+      { ID: "s-1", itemType: "spending", label: "lunch", userID: "u-1", date: "2026-08-21" },
+      file,
+    );
+
+    // Order matters server-side: the text fields must precede the file part.
+    expect([...formData.keys()]).toEqual(["userID", "itemType", "date", "label", "spendingID", "invoiceImageUpload"]);
+    expect(formData.get("itemType")).toBe("spending");
+    expect(formData.get("date")).toBe("2026-08-21");
+    expect(formData.get("spendingID")).toBe("s-1");
+    expect(formData.get("invoiceImageUpload")).toBe(file);
+  });
+
+  it("uses dateFrom instead of date for a recurring", () => {
+    const formData = buildInvoiceUploadFormData(
+      { ID: "r-1", itemType: "recurring", label: "rent", userID: "u-1", dateFrom: "2026-08-01" },
+      file,
+    );
+
+    expect(formData.get("itemType")).toBe("recurring");
+    expect(formData.get("dateFrom")).toBe("2026-08-01");
+    expect(formData.get("date")).toBeNull();
+  });
+});

--- a/front/src/components/spendings/services/invoiceUploadFormData.ts
+++ b/front/src/components/spendings/services/invoiceUploadFormData.ts
@@ -1,0 +1,40 @@
+// Multipart body of POST /spendings/upload — shared by the row's InvoiceModal
+// and the receipt-at-creation chain (PFA-5).
+export interface InvoiceUploadTarget {
+  ID: string;
+  itemType: string;
+  label: string;
+  userID: string;
+  date?: string | null;
+  dateFrom?: string | null;
+}
+
+export const buildInvoiceUploadFormData = (target: InvoiceUploadTarget, file: File): FormData => {
+  const formData = new FormData();
+  formData.append("userID", target.userID);
+
+  switch (target.itemType) {
+    case "recurring":
+      formData.append("itemType", "recurring");
+      if (target.dateFrom) {
+        formData.append("dateFrom", target.dateFrom);
+      }
+      break;
+    case "spending":
+      formData.append("itemType", "spending");
+      if (target.date) {
+        formData.append("date", target.date);
+      }
+      break;
+    default:
+      break;
+  }
+
+  formData.append("label", target.label);
+  formData.append("spendingID", target.ID);
+  // The file must stay the last part: multer streams parts in order and derives
+  // the stored filename from itemType/date/label, which must already be parsed
+  // when the file part arrives.
+  formData.append("invoiceImageUpload", file);
+  return formData;
+};

--- a/front/src/components/spendings/services/useSpendings.ts
+++ b/front/src/components/spendings/services/useSpendings.ts
@@ -1,18 +1,25 @@
 import { useAuth } from "@auth/context/AuthContext";
 import useDatePickerWrapperStore from "@components/datePickerWrapper/store";
+import { buildInvoiceUploadFormData } from "@components/spendings/services/invoiceUploadFormData";
 import { displayPopup } from "@helpers/swalHelper";
 import useRequestHelper from "@helpers/useRequestHelper";
 import useTranslations from "@i18n/useTranslations";
 import { QUERY_KEYS } from "@lib/query/keys";
-import { SpendingListSchema, SpendingMutationPayloadSchema } from "@src/schemas/spendings";
+import {
+  CreateSpendingResponseSchema,
+  SpendingListSchema,
+  SpendingMutationPayloadSchema,
+} from "@src/schemas/spendings";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import endOfMonth from "date-fns/endOfMonth";
 import format from "date-fns/format";
 import getDate from "date-fns/getDate";
 import parseISO from "date-fns/parseISO";
 import startOfMonth from "date-fns/startOfMonth";
+import { toast } from "sonner";
 
 import type { SpendingDayGroup, SpendingItem } from "@components/spendings/interfaces/spendingListTypes";
+import type { CreateSpendingInput } from "@components/spendings/interfaces/spendingMutationTypes";
 import type { SpendingMutationPayload } from "@src/schemas/spendings";
 import type { AxiosError } from "axios";
 
@@ -124,9 +131,35 @@ const useSpendings = () => {
     });
   };
 
-  const createSpending = useMutation<unknown, AxiosError, SpendingMutationPayload>({
-    mutationFn: (spending) => {
-      return createSpendingService(spending);
+  const createSpending = useMutation<unknown, AxiosError, CreateSpendingInput>({
+    mutationFn: async ({ spendingEdited, receiptFile }) => {
+      const response = await createSpendingService(spendingEdited);
+      if (receiptFile) {
+        // Receipt-at-creation (PFA-5): chain the existing upload endpoint on the
+        // ID the create just returned. A failed upload must NOT fail the whole
+        // mutation — the row exists, so let onSuccess refresh the list and only
+        // surface a dedicated toast; the row's receipt icon is the retry path.
+        try {
+          const { ID } = CreateSpendingResponseSchema.parse(response.data);
+          await privateRequest("/spendings/upload", {
+            method: "POST",
+            data: buildInvoiceUploadFormData(
+              {
+                ID,
+                itemType: "spending",
+                label: spendingEdited.label,
+                userID: spendingEdited.userID,
+                date: spendingEdited.date,
+              },
+              receiptFile,
+            ),
+          });
+        } catch (e) {
+          console.log("error attaching receipt at creation : ", e);
+          toast.error(spendingsText.toasts.receiptUploadFailed);
+        }
+      }
+      return response;
     },
 
     onSuccess: async (_data, variables) => {
@@ -138,7 +171,7 @@ const useSpendings = () => {
       // the closure can be stale if the user changed week while the POST was in
       // flight). Creating a spending for another week must not yank the view to
       // it (product decision on the ticket's open edge case).
-      const createdDate = variables?.date;
+      const createdDate = variables?.spendingEdited.date;
       const currentRange = useDatePickerWrapperStore.getState().range;
       if (createdDate && currentRange?.some((day) => format(day, "yyyy-MM-dd") === createdDate)) {
         setScrollToDayIso(createdDate);

--- a/front/src/schemas/spendings.ts
+++ b/front/src/schemas/spendings.ts
@@ -70,6 +70,10 @@ export type RecurringItem = z.infer<typeof RecurringItemSchema>;
 // sums the actual per-month recurring rows from January through the current month.
 export const RecurringsDrawnSchema = z.object({ drawn: numberLikeSchema });
 
+// Response of POST /spendings: the new row's ID, so the receipt upload can
+// chain on it in the same creation flow (PFA-5).
+export const CreateSpendingResponseSchema = z.object({ ID: z.string() });
+
 export const SpendingMutationPayloadSchema = z.object({
   date: z.string().nullable().optional(),
   label: z.string().min(1),

--- a/front/src/text/en/spendings.ts
+++ b/front/src/text/en/spendings.ts
@@ -182,6 +182,7 @@ const spendings: typeof frSpendings = {
     recurringUpdated: "Fixed expense updated",
     recurringDeleted: "Fixed expense deleted",
     recurringsCopied: "Fixed expenses created",
+    receiptUploadFailed: "Receipt not attached — retry from the spending row",
   },
 };
 

--- a/front/src/text/fr/spendings.ts
+++ b/front/src/text/fr/spendings.ts
@@ -182,6 +182,7 @@ const spendings = {
     recurringUpdated: "dépense fixe mise à jour",
     recurringDeleted: "dépense fixe supprimée",
     recurringsCopied: "dépenses fixes créées",
+    receiptUploadFailed: "reçu non joint — réessayer depuis la ligne de la dépense",
   },
 };
 

--- a/nest-api/src/spendings/spendings.service.spec.ts
+++ b/nest-api/src/spendings/spendings.service.spec.ts
@@ -438,3 +438,21 @@ describe("SpendingsService.getLabelSuggestions", () => {
     expect(result).toEqual([{ label: "Secret", category: null }]);
   });
 });
+
+describe("SpendingsService.createSpending", () => {
+  it("returns the created spending's ID so the front can chain the receipt upload (PFA-5)", async () => {
+    const create = jest.fn().mockResolvedValue(undefined);
+    const prisma = { spendings: { create } } as unknown as never;
+    const service = new SpendingsService(prisma, {} as never, {} as never);
+
+    const result = await service.createSpending(
+      { date: "2026-08-21", label: "lunch", amount: 12.5, currency: "EUR" },
+      "user-1",
+    );
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const created = create.mock.calls[0][0].data as { ID: string; userID: string; label: string; itemType: string };
+    expect(created).toMatchObject({ userID: "user-1", label: "lunch", itemType: "spending" });
+    expect(result).toEqual({ ID: created.ID });
+  });
+});

--- a/nest-api/src/spendings/spendings.service.ts
+++ b/nest-api/src/spendings/spendings.service.ts
@@ -118,7 +118,7 @@ export class SpendingsService {
       currency: string;
     },
     userID: string,
-  ): Promise<string> {
+  ): Promise<{ ID: string }> {
     let categoryID: string | null = null;
 
     const category = dto.category;
@@ -162,7 +162,9 @@ export class SpendingsService {
       },
     });
 
-    return "new spending added";
+    // The ID lets the front chain POST /spendings/upload on the row it just
+    // created — a receipt can be attached in the same "new spending" flow (PFA-5).
+    return { ID: spendingID };
   }
 
   async updateSpending(

--- a/nest-api/test/jest-e2e.json
+++ b/nest-api/test/jest-e2e.json
@@ -13,6 +13,7 @@
     "^@recurrings/(.*)$": "<rootDir>/src/recurrings/$1",
     "^@dashboard/(.*)$": "<rootDir>/src/dashboard/$1",
     "^@stats/(.*)$": "<rootDir>/src/stats/$1",
-    "^@categories/(.*)$": "<rootDir>/src/categories/$1"
+    "^@categories/(.*)$": "<rootDir>/src/categories/$1",
+    "^@exceptionals/(.*)$": "<rootDir>/src/exceptionals/$1"
   }
 }

--- a/nest-api/test/spendings.e2e-spec.ts
+++ b/nest-api/test/spendings.e2e-spec.ts
@@ -364,9 +364,10 @@ describe("SpendingsController (e2e)", () => {
   describe("POST /api/spendings", () => {
     let existingCategoryID: string | null = null;
 
-    const assertSuccess = (res: { body: unknown; text: string }) => {
-      const body = typeof res.body === "string" ? res.body : res.text;
-      expect(body).toBe("new spending added");
+    // PFA-5: the create response carries the new row's ID so the front can chain
+    // the receipt upload on it.
+    const assertSuccess = (res: { body: unknown }) => {
+      expect(res.body).toMatchObject({ ID: expect.any(String) });
     };
 
     beforeAll(async () => {


### PR DESCRIPTION
The "attach receipt" section of the creation modal was visual only: the picked file stayed in browser memory and was dropped when the modal closed, so the spending was created with invoicefile NULL and no file on the server — silently, with no error.

POST /spendings now returns the created row's ID, so the front can chain the existing POST /spendings/upload on it. A failed upload no longer fails the mutation: the spending survives and a dedicated toast points to the row's receipt icon as the retry path.

The multipart body of the upload endpoint moves to a shared builder, used by both the row's InvoiceModal and the new creation chain. Toggling the receipt section off now clears the picked file, and the toggle is hidden in edit mode, where the modal has no view of an existing receipt and attaching one could silently overwrite it.

Also adds the missing @exceptionals alias to the e2e jest config, which prevented the whole back e2e suite from resolving app.module.