### PR TITLE
feat(stats): compare years in the category chart (PFA-162)

### DIFF
--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -16,6 +16,8 @@ interface StatisticsCategoryChartProps {
   series: CategorySeries[];
   /** Number of leading months to plot (elapsed months for the current year). */
   monthsCount: number;
+  compareYear: number;
+  compareEnabled: boolean;
   now: Date;
 }
 
@@ -24,6 +26,10 @@ const PAD_T = 28;
 const PAD_B = 54;
 const PAD_L = 52;
 const PAD_R = 16;
+/** Compare-year ghost bars: same hue as their category, faded back behind it. */
+const GHOST_OPACITY = 0.25;
+/** Half the width a ghost bar gains over the bar it sits behind, in px. */
+const GHOST_BLEED = 2.5;
 const Y0 = H - PAD_B; // 286
 const PLOT_H = Y0 - PAD_T; // 258
 
@@ -31,7 +37,14 @@ const range = (n: number): number[] => Array.from({ length: n }, (_, i) => i);
 
 /** "Monthly spendings by category" — grouped bars, one group per month and
  *  one bar per selected category. All data is real (from /statistics). */
-const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsCategoryChartProps) => {
+const StatisticsCategoryChart = ({
+  year,
+  series,
+  monthsCount,
+  compareYear,
+  compareEnabled,
+  now,
+}: StatisticsCategoryChartProps) => {
   const { euro0 } = useFormat();
   const statistics = useTranslations("statistics");
   const dateLocale = useDateLocale();
@@ -42,7 +55,16 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
   const isCurrentYear = year === now.getFullYear();
   const cm = now.getMonth();
 
-  const dataMax = Math.max(1, ...series.flatMap((s) => range(months).map((m) => s.monthly[m] ?? 0)));
+  // Same months on both years — the ghosts answer "and last year, over this very
+  // period?", so a compare year with no spend on any selected category draws nothing.
+  const showCompare = compareEnabled && series.some((s) => range(months).some((m) => (s.compareMonthly[m] ?? 0) > 0));
+
+  const plotted = (monthly: number[]) => range(months).map((m) => monthly[m] ?? 0);
+  const dataMax = Math.max(
+    1,
+    ...series.flatMap((s) => plotted(s.monthly)),
+    ...(showCompare ? series.flatMap((s) => plotted(s.compareMonthly)) : []),
+  );
   const yMax = niceCeil(dataMax);
 
   const plotW = Math.max(0, width - PAD_L - PAD_R);
@@ -51,10 +73,14 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
   const n = series.length;
   const gap = n > 1 ? 7 : 0;
   const barW = n > 0 ? (groupW - gap * (n - 1)) / n : 0;
+  // The ghost overflows its bar on both sides so it stays readable when last year
+  // was the smaller of the two — capped to keep 2px of air between neighbouring ghosts.
+  const ghostBleed = n > 1 ? Math.max(0, Math.min(GHOST_BLEED, (gap - 2) / 2)) : GHOST_BLEED;
+  const ghostW = barW + ghostBleed * 2;
   const labelFont = n >= 3 ? 8 : 9.5;
 
   /** Cumulated spend over the plotted months — Jan → current month, or the full year for a past one. */
-  const plottedTotal = (s: CategorySeries) => range(months).reduce((sum, m) => sum + (s.monthly[m] ?? 0), 0);
+  const plottedTotal = (monthly: number[]) => plotted(monthly).reduce((sum, value) => sum + value, 0);
 
   const cx = (m: number) => PAD_L + slotW * (m + 0.5);
   const yFor = (v: number) => Y0 - (Math.max(0, v) / yMax) * PLOT_H;
@@ -64,7 +90,8 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
     value: (yMax * i) / 4,
   }));
 
-  const subtitle = isCurrentYear ? statistics.ytdSubtitle(year, monthLabels[months - 1]) : `${year}`;
+  const period = isCurrentYear ? statistics.ytdSubtitle(year, monthLabels[months - 1]) : `${year}`;
+  const subtitle = showCompare ? statistics.categoryChart.subtitleCompare(period, compareYear) : period;
 
   return (
     <GlowCard
@@ -85,15 +112,30 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
               <LegendItem
                 className="capitalize"
                 swatch={
-                  <i
-                    className="inline-block size-2.5 rounded-xs"
-                    style={{ background: s.color }}
-                  />
+                  // Solid chip + faded chip, in that order: the legend swatch mirrors
+                  // the bar and the ghost behind it, so nothing else has to explain them.
+                  <span className="inline-flex items-center gap-0.5">
+                    <i
+                      className="inline-block size-2.5 rounded-xs"
+                      style={{ background: s.color }}
+                    />
+                    {showCompare && (
+                      <i
+                        className="inline-block size-2.5 rounded-xs"
+                        style={{ background: s.color, opacity: GHOST_OPACITY }}
+                      />
+                    )}
+                  </span>
                 }
               >
                 {s.name}
               </LegendItem>
-              <span className="num text-ink-2">{euro0(plottedTotal(s))} €</span>
+              <span className="num text-ink-2">{euro0(plottedTotal(s.monthly))} €</span>
+              {showCompare && (
+                <span className="num text-ink-4">
+                  {statistics.categoryChart.compareTotal(compareYear, euro0(plottedTotal(s.compareMonthly)))}
+                </span>
+              )}
             </div>
           ))}
         </div>
@@ -110,7 +152,11 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
             height={H}
             className="block"
             role="img"
-            aria-label={statistics.categoryChart.ariaLabel(year)}
+            aria-label={
+              showCompare
+                ? statistics.categoryChart.ariaLabelCompare(year, compareYear)
+                : statistics.categoryChart.ariaLabel(year)
+            }
           >
             {/* grid + y labels */}
             {gridRows.map((row) => (
@@ -136,16 +182,39 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
               </g>
             ))}
 
-            {/* grouped bars */}
+            {/* grouped bars — every ghost of the group first, so a wide ghost never
+                bleeds over the solid bar of the next category */}
             {range(months).map((m) => {
               const gx = cx(m) - groupW / 2;
               return (
                 <g key={`m-${m}`}>
+                  {showCompare &&
+                    series.map((s, i) => {
+                      const cv = s.compareMonthly[m] ?? 0;
+                      if (cv <= 0) return null;
+                      const gy = yFor(cv);
+                      return (
+                        <rect
+                          key={`ghost-${s.name}`}
+                          x={gx + i * (barW + gap) - ghostBleed}
+                          y={gy}
+                          width={ghostW}
+                          height={Y0 - gy}
+                          rx={3}
+                          fill={s.color}
+                          opacity={GHOST_OPACITY}
+                        />
+                      );
+                    })}
                   {series.map((s, i) => {
                     const v = s.monthly[m] ?? 0;
                     if (v <= 0) return null;
                     const bx = gx + i * (barW + gap);
                     const by = yFor(v);
+                    const cv = showCompare ? (s.compareMonthly[m] ?? 0) : 0;
+                    // The single label sits above whichever of the two bars is taller,
+                    // rather than landing inside a ghost that overshoots this year.
+                    const labelY = Math.min(by, cv > 0 ? yFor(cv) : by) - 6;
                     return (
                       <g key={s.name}>
                         <rect
@@ -159,7 +228,7 @@ const StatisticsCategoryChart = ({ year, series, monthsCount, now }: StatisticsC
                         />
                         <text
                           x={bx + barW / 2}
-                          y={by - 6}
+                          y={labelY}
                           fontSize={labelFont}
                           textAnchor="middle"
                           fill="var(--ink-2)"

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -27,7 +27,7 @@ import useMonthlyIncome from "@components/statistics/services/useMonthlyIncome";
 import useRecurringsDrawn from "@components/statistics/services/useRecurringsDrawn";
 import useStatistics from "@components/statistics/services/useStatistics";
 import useWeekdayCategories from "@components/statistics/services/useWeekdayCategories";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { CategorySeries } from "@components/statistics/interfaces/statisticsCategoryChartTypes";
 import type { TopCategoryRow } from "@components/statistics/interfaces/statisticsTopCategoriesTypes";
@@ -118,6 +118,8 @@ const StatisticsView = () => {
       };
     });
 
+  // The compare year is already part of the /statistics fetch, so the per-category
+  // compare series costs no extra request (PFA-162).
   const categorySeries: CategorySeries[] = selectedCategoryIds
     .map((id) => categories.find((c) => c.ID === id))
     .filter((c): c is (typeof categories)[number] => Boolean(c))
@@ -125,6 +127,7 @@ const StatisticsView = () => {
       name: category.name,
       color: statistics?.colors?.[category.name] ?? category.color,
       monthly: categoryMonthly(data, selectedYear, category.name),
+      compareMonthly: categoryMonthly(data, compareYear, category.name),
     }));
   const monthsCount = elapsedMonths(selectedYear, now);
 
@@ -137,6 +140,21 @@ const StatisticsView = () => {
     setSelectedCategoryIds((prev) =>
       prev.includes(id) ? prev.filter((c) => c !== id) : prev.length < MAX_CATEGORIES ? [...prev, id] : prev,
     );
+
+  // The category chart only exists once a category is picked, two screens below
+  // the (sticky) filter bar it is picked from — so nothing seems to happen. Bring
+  // it into view on the 0 → 1 transition only: the 2nd and 3rd category land in an
+  // already-visible widget, and yanking the page then would be hostile (PFA-162).
+  const categoryCardRef = useRef<HTMLDivElement>(null);
+  const previousCategoryCount = useRef(0);
+  useEffect(() => {
+    const count = selectedCategoryIds.length;
+    const appeared = previousCategoryCount.current === 0 && count === 1;
+    previousCategoryCount.current = count;
+    if (!appeared) return;
+    const reduce = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
+    categoryCardRef.current?.scrollIntoView({ behavior: reduce ? "auto" : "smooth", block: "start" });
+  }, [selectedCategoryIds]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -201,12 +219,21 @@ const StatisticsView = () => {
       />
 
       {categorySeries.length > 0 && (
-        <StatisticsCategoryChart
-          year={selectedYear}
-          series={categorySeries}
-          monthsCount={monthsCount}
-          now={now}
-        />
+        // `scroll-mt-36` clears the sticky filter bar (top-[76px] + its height), so
+        // the scrolled-to card lands under it rather than behind it.
+        <div
+          ref={categoryCardRef}
+          className="scroll-mt-36"
+        >
+          <StatisticsCategoryChart
+            year={selectedYear}
+            series={categorySeries}
+            monthsCount={monthsCount}
+            compareYear={compareYear}
+            compareEnabled={compareEnabled}
+            now={now}
+          />
+        </div>
       )}
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-[7fr_5fr]">

--- a/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
+++ b/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
@@ -7,4 +7,6 @@ export interface CategorySeries {
   color: string;
   /** 12-slot Jan→Dec monthly spend for this category. */
   monthly: number[];
+  /** Same series for the compare year — drawn as the ghost bar behind each bar. */
+  compareMonthly: number[];
 }

--- a/front/src/text/en/statistics.ts
+++ b/front/src/text/en/statistics.ts
@@ -65,7 +65,13 @@ const statistics: typeof frStatistics = {
   },
   categoryChart: {
     title: "Monthly spendings by category",
+    // Compare on: the plotted period, then the year it is held against.
+    subtitleCompare: (period: string, compareYear: number) => `${period} · compared to ${compareYear}`,
     ariaLabel: (year: number) => `Monthly spendings by category ${year}`,
+    ariaLabelCompare: (year: number, compareYear: number) =>
+      `Monthly spendings by category ${year}, compared to ${compareYear}`,
+    // Compare-year total, under the selected year's own in the legend.
+    compareTotal: (compareYear: number, total: string) => `${total} € in ${compareYear}`,
     tooltipShare: "Share",
     tooltipAmount: "Amount",
     tooltipTrend: "Trend",

--- a/front/src/text/fr/statistics.ts
+++ b/front/src/text/fr/statistics.ts
@@ -61,7 +61,13 @@ const statistics = {
   },
   categoryChart: {
     title: "Dépenses mensuelles par catégorie",
+    // Comparaison active : la période tracée, puis l'année comparée.
+    subtitleCompare: (period: string, compareYear: number) => `${period} · comparé à ${compareYear}`,
     ariaLabel: (year: number) => `Dépenses mensuelles par catégorie ${year}`,
+    ariaLabelCompare: (year: number, compareYear: number) =>
+      `Dépenses mensuelles par catégorie ${year}, comparées à ${compareYear}`,
+    // Cumul de l'année comparée, sous celui de l'année sélectionnée dans la légende.
+    compareTotal: (compareYear: number, total: string) => `${total} € en ${compareYear}`,
     tooltipShare: "Part",
     tooltipAmount: "Montant",
     tooltipTrend: "Tendance",


### PR DESCRIPTION
Two defects on the same widget. It only ever plotted the selected year, though the page-level "compare to" toggle sat right above it; and it is rendered two screens below the sticky filter bar it is summoned from, so picking a category looked like it did nothing at all.

Each series now carries its compare-year months — free, that year is already in the /statistics fetch — drawn as a faded ghost bar behind its own bar, same hue, slightly wider. The pairing survives three categories where three more dotted lines would not, and the legend swatch (solid chip, faded chip) is what explains it. The y scale takes both years in, the value label rises above the taller of the two, and the legend carries the compare-year total, there being no tooltip to read it from.

Picking the first category scrolls the card into view — that transition only, so the 2nd and 3rd land in a widget already on screen instead of yanking the page from under the picker.