### PR TITLE
fix(stats): fade the category chart's compare year (PFA-163)

### DIFF
--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -55,11 +55,15 @@ const StatisticsCategoryChart = ({
   const isCurrentYear = year === now.getFullYear();
   const cm = now.getMonth();
 
+  const plotted = (monthly: number[]) => range(months).map((m) => monthly[m] ?? 0);
   // Same months on both years — the ghosts answer "and last year, over this very
   // period?", so a compare year with no spend on any selected category draws nothing.
-  const showCompare = compareEnabled && series.some((s) => range(months).some((m) => (s.compareMonthly[m] ?? 0) > 0));
-
-  const plotted = (monthly: number[]) => range(months).map((m) => monthly[m] ?? 0);
+  // Deliberately blind to the toggle: every compare element stays mounted as long as
+  // the data exists, so it can fade both ways and, above all, so the card's height
+  // never depends on the toggle — a legend line appearing there shoves the whole
+  // page down (PFA-163). `showCompare` is the one that follows the switch.
+  const hasCompareData = series.some((s) => plotted(s.compareMonthly).some((value) => value > 0));
+  const showCompare = compareEnabled && hasCompareData;
   const dataMax = Math.max(
     1,
     ...series.flatMap((s) => plotted(s.monthly)),
@@ -119,10 +123,10 @@ const StatisticsCategoryChart = ({
                       className="inline-block size-2.5 rounded-xs"
                       style={{ background: s.color }}
                     />
-                    {showCompare && (
+                    {hasCompareData && (
                       <i
-                        className="inline-block size-2.5 rounded-xs"
-                        style={{ background: s.color, opacity: GHOST_OPACITY }}
+                        className="pfa-anim-compare inline-block size-2.5 rounded-xs"
+                        style={{ background: s.color, opacity: showCompare ? GHOST_OPACITY : 0 }}
                       />
                     )}
                   </span>
@@ -131,8 +135,12 @@ const StatisticsCategoryChart = ({
                 {s.name}
               </LegendItem>
               <span className="num text-ink-2">{euro0(plottedTotal(s.monthly))} €</span>
-              {showCompare && (
-                <span className="num text-ink-4">
+              {hasCompareData && (
+                <span
+                  className="num pfa-anim-compare text-ink-4"
+                  style={{ opacity: showCompare ? 1 : 0 }}
+                  aria-hidden={!showCompare}
+                >
                   {statistics.categoryChart.compareTotal(compareYear, euro0(plottedTotal(s.compareMonthly)))}
                 </span>
               )}
@@ -188,7 +196,7 @@ const StatisticsCategoryChart = ({
               const gx = cx(m) - groupW / 2;
               return (
                 <g key={`m-${m}`}>
-                  {showCompare &&
+                  {hasCompareData &&
                     series.map((s, i) => {
                       const cv = s.compareMonthly[m] ?? 0;
                       if (cv <= 0) return null;
@@ -196,13 +204,14 @@ const StatisticsCategoryChart = ({
                       return (
                         <rect
                           key={`ghost-${s.name}`}
+                          className="pfa-anim-compare"
                           x={gx + i * (barW + gap) - ghostBleed}
                           y={gy}
                           width={ghostW}
                           height={Y0 - gy}
                           rx={3}
                           fill={s.color}
-                          opacity={GHOST_OPACITY}
+                          opacity={showCompare ? GHOST_OPACITY : 0}
                         />
                       );
                     })}
@@ -211,13 +220,10 @@ const StatisticsCategoryChart = ({
                     if (v <= 0) return null;
                     const bx = gx + i * (barW + gap);
                     const by = yFor(v);
-                    const cv = showCompare ? (s.compareMonthly[m] ?? 0) : 0;
-                    // The single label sits above whichever of the two bars is taller,
-                    // rather than landing inside a ghost that overshoots this year.
-                    const labelY = Math.min(by, cv > 0 ? yFor(cv) : by) - 6;
                     return (
                       <g key={s.name}>
                         <rect
+                          className="pfa-anim-compare"
                           x={bx}
                           y={by}
                           width={barW}
@@ -226,13 +232,19 @@ const StatisticsCategoryChart = ({
                           fill={s.color}
                           opacity={0.9}
                         />
+                        {/* Always above its own bar, never above the ghost: a month where
+                            last year dwarfs this one would otherwise hang this year's small
+                            figure at the top of the ghost, as if it were the ghost's own.
+                            Translated rather than positioned — `y` on <text> is not a CSS
+                            geometry property, so it could not follow a scale change. */}
                         <text
                           x={bx + barW / 2}
-                          y={labelY}
+                          y={0}
+                          className="num pfa-anim-compare"
+                          style={{ transform: `translateY(${by - 6}px)` }}
                           fontSize={labelFont}
                           textAnchor="middle"
                           fill="var(--ink-2)"
-                          className="num"
                         >
                           {euro0(v)}
                         </text>

--- a/front/styles/animations.css
+++ b/front/styles/animations.css
@@ -67,3 +67,24 @@
   transform: translate(0, 10px);
   transition: all 300ms ease-out;
 }
+
+/* Statistics category chart (PFA-163) — the compare toggle changes the Y scale and
+   the ghost bars' opacity at once, so every bar glides to its new height instead of
+   snapping. `y`/`height` are SVG geometry properties: no Tailwind utility covers
+   them, and they animate wherever the browser exposes them to CSS — elsewhere the
+   new value simply applies at once, which is the old behaviour.
+   Vertical only, deliberately: `x`/`width` follow the container, and easing those
+   would leave the bars trailing behind the card through a window resize.
+   Also carried by the plain HTML legend bits, which only ever fade. */
+.pfa-anim-compare {
+  transition:
+    y 280ms ease-out,
+    height 280ms ease-out,
+    transform 280ms ease-out,
+    opacity 280ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  .pfa-anim-compare {
+    transition: none;
+  }
+}


### PR DESCRIPTION
Three things about the widget from PFA-162.

Toggling "compare to" swapped two states with nothing in between: the ghost bars popped, and since the y scale takes the compare year in, every solid bar changed height in the same jolt. The compare elements now stay mounted as long as the data exists and only cross their opacity, and .pfa-anim-compare eases y/height over 280ms — the beat the day-of-week widget already keeps. Not x/width: those follow the container, and easing them would leave the bars trailing behind the card through a resize.

The page moved, too. The legend gained a line when the toggle came on, which grew the card header and shoved everything below it down. Keeping that line mounted and merely transparent settles the height for good.

And the value label sat above the taller of the two bars, so a month where last year dwarfs this one hung this year's small figure at the top of the ghost, as if it were the ghost's own. It is back over its own bar, carried by a transform since y on a <text> is not a CSS geometry property and could not have followed a scale change.