### PR TITLE
fix(deploy): scrape Spira ticket ids, not just COS- (PFA-164)

### DIFF
--- a/front/deploy-front.sh
+++ b/front/deploy-front.sh
@@ -144,7 +144,7 @@ deploy() {
     fi
   }
 
-  # Prepend this deploy's commits (+ Linear tickets) to the served changelog.
+  # Prepend this deploy's commits (+ Spira tickets) to the served changelog.
   # Always invoked as `write_deploy_log || log ...`, so errexit is ignored throughout:
   # a changelog hiccup can never fail or roll back an otherwise successful deploy.
   write_deploy_log() {
@@ -173,8 +173,13 @@ deploy() {
 
     # One git-log call, captured into a var (pipefail-safe: no `| grep -q` on a pipe git may SIGPIPE).
     COMMITS=$(git log --no-merges --pretty=format:'  %h  %ad  %s' --date=short "${RANGE[@]}")
+    # Ticket ids: the Spira project keys that ship out of this repo, plus the legacy COS- ones
+    # inherited from Linear. An explicit list rather than a generic KEY-N pattern, which would
+    # also drag in UTF-8 or SHA-256 — a new project deploying from here gets added here too.
+    # Sorted on prefix *and* number: `-u` dedupes on the sort keys alone, so keying on the number
+    # only would have kept one of IKN-51 / PFA-51 and dropped the other.
     TICKETS=$(printf '%s\n' "$COMMITS" \
-      | grep -oiE 'COS-[0-9]+' | tr 'a-z' 'A-Z' | sort -t- -k2,2n -u | paste -sd ',' - | sed 's/,/, /g' || true)
+      | grep -oiE '(COS|PFA|IKN)-[0-9]+' | tr 'a-z' 'A-Z' | sort -u -t- -k1,1 -k2,2n | paste -sd ',' - | sed 's/,/, /g' || true)
 
     ENTRY_TMP=$(mktemp)
     {

--- a/nest-api/deploy-api.sh
+++ b/nest-api/deploy-api.sh
@@ -117,7 +117,7 @@ pm2 reload ecosystem.config.js --env production 2>/dev/null || pm2 start ecosyst
 EOF
   }
 
-  # Prepend this deploy's commits (+ Linear tickets) to the served changelog.
+  # Prepend this deploy's commits (+ Spira tickets) to the served changelog.
   # Always invoked as `write_deploy_log || log ...`, so errexit is ignored throughout:
   # a changelog hiccup can never fail or roll back an otherwise successful deploy.
   write_deploy_log() {
@@ -146,8 +146,13 @@ EOF
 
     # One git-log call, captured into a var (pipefail-safe: no `| grep -q` on a pipe git may SIGPIPE).
     COMMITS=$(git log --no-merges --pretty=format:'  %h  %ad  %s' --date=short "${RANGE[@]}")
+    # Ticket ids: the Spira project keys that ship out of this repo, plus the legacy COS- ones
+    # inherited from Linear. An explicit list rather than a generic KEY-N pattern, which would
+    # also drag in UTF-8 or SHA-256 — a new project deploying from here gets added here too.
+    # Sorted on prefix *and* number: `-u` dedupes on the sort keys alone, so keying on the number
+    # only would have kept one of IKN-51 / PFA-51 and dropped the other.
     TICKETS=$(printf '%s\n' "$COMMITS" \
-      | grep -oiE 'COS-[0-9]+' | tr 'a-z' 'A-Z' | sort -t- -k2,2n -u | paste -sd ',' - | sed 's/,/, /g' || true)
+      | grep -oiE '(COS|PFA|IKN)-[0-9]+' | tr 'a-z' 'A-Z' | sort -u -t- -k1,1 -k2,2n | paste -sd ',' - | sed 's/,/, /g' || true)
 
     ENTRY_TMP=$(mktemp)
     {


### PR DESCRIPTION
Both deploy scripts prepend a changelog entry to the server, with a Tickets: line scraped out of the commit subjects. The scrape only ever looked for COS-, inherited from Linear, so since the move to Spira every PFA- and IKN- went straight through and the line came out empty.

A second fault sat behind it: `sort -t- -k2,2n -u` dedupes on the sort keys alone, and the only key was the number — two tickets of different projects sharing one (IKN-51, PFA-51) silently ate each other. The sort now keys on the prefix as well.

The key list is explicit rather than a generic [A-Z]{3}-[0-9]+, which would drag in UTF-8 and SHA-256; a new project deploying from here gets added in the same place. Both scripts carried the block verbatim, so both are fixed.