### PR TITLE
fix(stats): resize the bars, don't fade them (PFA-165)

### DIFF
--- a/front/src/components/statistics/StatisticsCategoryChart.tsx
+++ b/front/src/components/statistics/StatisticsCategoryChart.tsx
@@ -8,6 +8,7 @@ import useDateLocale from "@i18n/useDateLocale";
 import useFormat from "@i18n/useFormat";
 import useTranslations from "@i18n/useTranslations";
 import useElementWidth from "@lib/dataviz/useElementWidth";
+import useTweenTo from "@lib/dataviz/useTweenTo";
 
 import type { CategorySeries } from "@components/statistics/interfaces/statisticsCategoryChartTypes";
 
@@ -26,10 +27,12 @@ const PAD_T = 28;
 const PAD_B = 54;
 const PAD_L = 52;
 const PAD_R = 16;
-/** Compare-year ghost bars: same hue as their category, faded back behind it. */
-const GHOST_OPACITY = 0.25;
-/** Half the width a ghost bar gains over the bar it sits behind, in px. */
-const GHOST_BLEED = 2.5;
+/** The compare year's bar: same hue as its category, dimmed. */
+const COMPARE_OPACITY = 0.45;
+/** Air between a year and its compare bar once the pair is fully open, in px. */
+const PAIR_GAP = 2;
+/** The pair opens and closes, and the Y scale glides, over this long. */
+const COMPARE_ANIM_MS = 420;
 const Y0 = H - PAD_B; // 286
 const PLOT_H = Y0 - PAD_T; // 258
 
@@ -56,10 +59,10 @@ const StatisticsCategoryChart = ({
   const cm = now.getMonth();
 
   const plotted = (monthly: number[]) => range(months).map((m) => monthly[m] ?? 0);
-  // Same months on both years — the ghosts answer "and last year, over this very
-  // period?", so a compare year with no spend on any selected category draws nothing.
+  // Same months on both years — the compare bars answer "and last year, over this
+  // very period?", so a compare year with no spend on a category draws nothing.
   // Deliberately blind to the toggle: every compare element stays mounted as long as
-  // the data exists, so it can fade both ways and, above all, so the card's height
+  // the data exists, so it can animate both ways and, above all, so the card's height
   // never depends on the toggle — a legend line appearing there shoves the whole
   // page down (PFA-163). `showCompare` is the one that follows the switch.
   const hasCompareData = series.some((s) => plotted(s.compareMonthly).some((value) => value > 0));
@@ -71,27 +74,43 @@ const StatisticsCategoryChart = ({
   );
   const yMax = niceCeil(dataMax);
 
+  // Two tweens carry every bit of motion in this chart, in JS rather than CSS: SVG
+  // geometry only transitions where the browser exposes `y`/`height` to CSS, and a
+  // reduced-motion rule kills it outright — which left the toggle looking dead (PFA-165).
+  // `reveal` opens and closes the year/compare-year pair; `scaleMax` glides the whole
+  // plot when taking last year in changes the ceiling.
+  const reveal = useTweenTo(showCompare ? 1 : 0, COMPARE_ANIM_MS);
+  const scaleMax = useTweenTo(yMax, COMPARE_ANIM_MS);
+
   const plotW = Math.max(0, width - PAD_L - PAD_R);
   const slotW = plotW / months;
   const groupW = slotW * 0.62;
   const n = series.length;
   const gap = n > 1 ? 7 : 0;
-  const barW = n > 0 ? (groupW - gap * (n - 1)) / n : 0;
-  // The ghost overflows its bar on both sides so it stays readable when last year
-  // was the smaller of the two — capped to keep 2px of air between neighbouring ghosts.
-  const ghostBleed = n > 1 ? Math.max(0, Math.min(GHOST_BLEED, (gap - 2) / 2)) : GHOST_BLEED;
-  const ghostW = barW + ghostBleed * 2;
+  /** Width one category owns in a month's group, whether it shows one year or two. */
+  const catW = n > 0 ? (groupW - gap * (n - 1)) / n : 0;
+  // Turning the comparison on splits that slot in two, side by side — never one bar
+  // behind the other, where every month this year outspent last year would hide it
+  // and the growth would happen out of sight (PFA-165). Both halves are driven by
+  // `reveal`, so the toggle *is* a resize: this year's bar narrows to make room while
+  // last year's rises out of the baseline, and the reverse on the way out.
+  const pairW = Math.max(0, (catW - PAIR_GAP) / 2);
+  const barW = catW + (pairW - catW) * reveal;
+  const compareW = pairW * reveal;
+  const compareGap = PAIR_GAP * reveal;
   const labelFont = n >= 3 ? 8 : 9.5;
 
   /** Cumulated spend over the plotted months — Jan → current month, or the full year for a past one. */
   const plottedTotal = (monthly: number[]) => plotted(monthly).reduce((sum, value) => sum + value, 0);
 
   const cx = (m: number) => PAD_L + slotW * (m + 0.5);
-  const yFor = (v: number) => Y0 - (Math.max(0, v) / yMax) * PLOT_H;
+  const yFor = (v: number) => Y0 - (Math.max(0, v) / scaleMax) * PLOT_H;
 
+  // Gridlines never move; only the figures on them do, so they follow the tween and
+  // count to the new ceiling with the bars.
   const gridRows = range(5).map((i) => ({
     y: Y0 - (i * PLOT_H) / 4,
-    value: (yMax * i) / 4,
+    value: (scaleMax * i) / 4,
   }));
 
   const period = isCurrentYear ? statistics.ytdSubtitle(year, monthLabels[months - 1]) : `${year}`;
@@ -116,8 +135,8 @@ const StatisticsCategoryChart = ({
               <LegendItem
                 className="capitalize"
                 swatch={
-                  // Solid chip + faded chip, in that order: the legend swatch mirrors
-                  // the bar and the ghost behind it, so nothing else has to explain them.
+                  // Solid chip, dimmed chip: the legend swatch is the pair of bars in
+                  // miniature, so nothing else has to explain which year is which.
                   <span className="inline-flex items-center gap-0.5">
                     <i
                       className="inline-block size-2.5 rounded-xs"
@@ -125,8 +144,8 @@ const StatisticsCategoryChart = ({
                     />
                     {hasCompareData && (
                       <i
-                        className="pfa-anim-compare inline-block size-2.5 rounded-xs"
-                        style={{ background: s.color, opacity: showCompare ? GHOST_OPACITY : 0 }}
+                        className="inline-block size-2.5 rounded-xs transition-opacity duration-300 ease-out"
+                        style={{ background: s.color, opacity: showCompare ? COMPARE_OPACITY : 0 }}
                       />
                     )}
                   </span>
@@ -137,7 +156,7 @@ const StatisticsCategoryChart = ({
               <span className="num text-ink-2">{euro0(plottedTotal(s.monthly))} €</span>
               {hasCompareData && (
                 <span
-                  className="num pfa-anim-compare text-ink-4"
+                  className="num text-ink-4 transition-opacity duration-300 ease-out"
                   style={{ opacity: showCompare ? 1 : 0 }}
                   aria-hidden={!showCompare}
                 >
@@ -168,7 +187,9 @@ const StatisticsCategoryChart = ({
           >
             {/* grid + y labels */}
             {gridRows.map((row) => (
-              <g key={`grid-${row.value}`}>
+              // Keyed by its gridline, which never moves: the figure on it changes on
+              // every frame of a rescale.
+              <g key={`grid-${row.y}`}>
                 <line
                   x1={PAD_L}
                   x2={width - PAD_R}
@@ -190,64 +211,56 @@ const StatisticsCategoryChart = ({
               </g>
             ))}
 
-            {/* grouped bars — every ghost of the group first, so a wide ghost never
-                bleeds over the solid bar of the next category */}
+            {/* grouped bars — one slot per category, split into this year and last
+                year as the comparison opens */}
             {range(months).map((m) => {
               const gx = cx(m) - groupW / 2;
               return (
                 <g key={`m-${m}`}>
-                  {hasCompareData &&
-                    series.map((s, i) => {
-                      const cv = s.compareMonthly[m] ?? 0;
-                      if (cv <= 0) return null;
-                      const gy = yFor(cv);
-                      return (
-                        <rect
-                          key={`ghost-${s.name}`}
-                          className="pfa-anim-compare"
-                          x={gx + i * (barW + gap) - ghostBleed}
-                          y={gy}
-                          width={ghostW}
-                          height={Y0 - gy}
-                          rx={3}
-                          fill={s.color}
-                          opacity={showCompare ? GHOST_OPACITY : 0}
-                        />
-                      );
-                    })}
                   {series.map((s, i) => {
                     const v = s.monthly[m] ?? 0;
-                    if (v <= 0) return null;
-                    const bx = gx + i * (barW + gap);
+                    const cv = hasCompareData ? (s.compareMonthly[m] ?? 0) : 0;
+                    const slotX = gx + i * (catW + gap);
                     const by = yFor(v);
+                    const compareH = (Y0 - yFor(cv)) * reveal;
                     return (
                       <g key={s.name}>
-                        <rect
-                          className="pfa-anim-compare"
-                          x={bx}
-                          y={by}
-                          width={barW}
-                          height={Y0 - by}
-                          rx={3}
-                          fill={s.color}
-                          opacity={0.9}
-                        />
-                        {/* Always above its own bar, never above the ghost: a month where
-                            last year dwarfs this one would otherwise hang this year's small
-                            figure at the top of the ghost, as if it were the ghost's own.
-                            Translated rather than positioned — `y` on <text> is not a CSS
-                            geometry property, so it could not follow a scale change. */}
-                        <text
-                          x={bx + barW / 2}
-                          y={0}
-                          className="num pfa-anim-compare"
-                          style={{ transform: `translateY(${by - 6}px)` }}
-                          fontSize={labelFont}
-                          textAnchor="middle"
-                          fill="var(--ink-2)"
-                        >
-                          {euro0(v)}
-                        </text>
+                        {v > 0 && (
+                          <rect
+                            x={slotX}
+                            y={by}
+                            width={barW}
+                            height={Y0 - by}
+                            rx={3}
+                            fill={s.color}
+                            opacity={0.9}
+                          />
+                        )}
+                        {cv > 0 && compareW > 0.5 && compareH > 0.5 && (
+                          <rect
+                            x={slotX + barW + compareGap}
+                            y={Y0 - compareH}
+                            width={compareW}
+                            height={compareH}
+                            rx={3}
+                            fill={s.color}
+                            opacity={COMPARE_OPACITY}
+                          />
+                        )}
+                        {/* Centred on its own bar, so it travels with it as the bar
+                            narrows, and never drifts over last year's. */}
+                        {v > 0 && (
+                          <text
+                            x={slotX + barW / 2}
+                            y={by - 6}
+                            className="num"
+                            fontSize={labelFont}
+                            textAnchor="middle"
+                            fill="var(--ink-2)"
+                          >
+                            {euro0(v)}
+                          </text>
+                        )}
                       </g>
                     );
                   })}

--- a/front/src/components/statistics/StatisticsView.tsx
+++ b/front/src/components/statistics/StatisticsView.tsx
@@ -27,12 +27,16 @@ import useMonthlyIncome from "@components/statistics/services/useMonthlyIncome";
 import useRecurringsDrawn from "@components/statistics/services/useRecurringsDrawn";
 import useStatistics from "@components/statistics/services/useStatistics";
 import useWeekdayCategories from "@components/statistics/services/useWeekdayCategories";
+import { animatedScrollIntoView } from "@lib/scroll";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import type { CategorySeries } from "@components/statistics/interfaces/statisticsCategoryChartTypes";
 import type { TopCategoryRow } from "@components/statistics/interfaces/statisticsTopCategoriesTypes";
 
 const MAX_CATEGORIES = 3;
+/** Headroom kept above the scrolled-to card: the sticky filter bar (76px down,
+ *  ~56px tall) plus a little air, so the card's title clears it. */
+const STICKY_OFFSET = 144;
 
 const yearOptions = (currentYear: number): number[] => Array.from({ length: 7 }, (_, i) => currentYear - i);
 
@@ -142,18 +146,20 @@ const StatisticsView = () => {
     );
 
   // The category chart only exists once a category is picked, two screens below
-  // the (sticky) filter bar it is picked from — so nothing seems to happen. Bring
-  // it into view on the 0 → 1 transition only: the 2nd and 3rd category land in an
+  // the (sticky) filter bar it is picked from — so nothing seems to happen. Travel
+  // there on the 0 → 1 transition only: the 2nd and 3rd category land in an
   // already-visible widget, and yanking the page then would be hostile (PFA-162).
+  // The trip is animated by hand — the point is to *see* the page travel, and the
+  // native smooth scroll silently degrades to a jump (PFA-165). Returning the
+  // canceller as the cleanup stops it if the selection changes mid-flight.
   const categoryCardRef = useRef<HTMLDivElement>(null);
   const previousCategoryCount = useRef(0);
   useEffect(() => {
     const count = selectedCategoryIds.length;
     const appeared = previousCategoryCount.current === 0 && count === 1;
     previousCategoryCount.current = count;
-    if (!appeared) return;
-    const reduce = Boolean(window.matchMedia?.("(prefers-reduced-motion: reduce)").matches);
-    categoryCardRef.current?.scrollIntoView({ behavior: reduce ? "auto" : "smooth", block: "start" });
+    if (!appeared || !categoryCardRef.current) return;
+    return animatedScrollIntoView(categoryCardRef.current, { offset: STICKY_OFFSET });
   }, [selectedCategoryIds]);
 
   return (
@@ -219,12 +225,7 @@ const StatisticsView = () => {
       />
 
       {categorySeries.length > 0 && (
-        // `scroll-mt-36` clears the sticky filter bar (top-[76px] + its height), so
-        // the scrolled-to card lands under it rather than behind it.
-        <div
-          ref={categoryCardRef}
-          className="scroll-mt-36"
-        >
+        <div ref={categoryCardRef}>
           <StatisticsCategoryChart
             year={selectedYear}
             series={categorySeries}

--- a/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
+++ b/front/src/components/statistics/interfaces/statisticsCategoryChartTypes.ts
@@ -7,6 +7,6 @@ export interface CategorySeries {
   color: string;
   /** 12-slot Jan→Dec monthly spend for this category. */
   monthly: number[];
-  /** Same series for the compare year — drawn as the ghost bar behind each bar. */
+  /** Same series for the compare year — drawn as the dimmed bar beside each bar. */
   compareMonthly: number[];
 }

--- a/front/src/lib/dataviz/index.ts
+++ b/front/src/lib/dataviz/index.ts
@@ -17,6 +17,7 @@ export { default as useCountUp } from "@lib/dataviz/useCountUp";
 export { default as useCursorHover } from "@lib/dataviz/useCursorHover";
 export { default as useElementWidth } from "@lib/dataviz/useElementWidth";
 export { default as useTween } from "@lib/dataviz/useTween";
+export { default as useTweenTo } from "@lib/dataviz/useTweenTo";
 
 export type {
   AxisMarker,

--- a/front/src/lib/dataviz/useTweenTo.ts
+++ b/front/src/lib/dataviz/useTweenTo.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Eases a number toward `target` whenever it changes, starting *at* the first
+ * target — no animation on mount, unlike `useTween`, which always grows from 0.
+ * A change mid-flight eases from wherever the value currently is, so a toggle
+ * flipped twice in a row never snaps.
+ *
+ * The curve is the app's ease-out cubic, and the tween runs in JS on purpose: CSS
+ * transitions over SVG geometry (`y`, `height`) only animate where the browser
+ * exposes those attributes to CSS, and die entirely under a reduced-motion rule.
+ * Whether to animate at all is the caller's call, not this hook's.
+ */
+export default function useTweenTo(target: number, duration = 420): number {
+  const [value, setValue] = useState(target);
+  const fromRef = useRef(target);
+  const rafRef = useRef(0);
+
+  useEffect(() => {
+    const from = fromRef.current;
+    if (from === target) return; // already there → no rAF churn
+    let startTs = 0;
+    const tick = (ts: number) => {
+      if (!startTs) startTs = ts;
+      const p = Math.min(1, (ts - startTs) / duration);
+      const next = from + (target - from) * (1 - (1 - p) ** 3);
+      fromRef.current = next;
+      setValue(next);
+      if (p < 1) rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [target, duration]);
+
+  return value;
+}

--- a/front/src/lib/scroll.ts
+++ b/front/src/lib/scroll.ts
@@ -1,0 +1,50 @@
+"use client";
+
+interface AnimatedScrollOptions {
+  /** Headroom left above the element — the sticky toolbars live up there. */
+  offset?: number;
+  duration?: number;
+}
+
+/**
+ * Scrolls the window until `element` sits `offset` px below the viewport top, on a
+ * requestAnimationFrame ease-out. Returns a canceller (nothing to cancel when the
+ * element is already in place).
+ *
+ * Not `scrollIntoView({ behavior: "smooth" })`: browsers turn that one into an
+ * instant jump whenever the OS asks for reduced motion, and this scroll *is* the
+ * feedback that something appeared further down the page — skipped, it reads as
+ * "my click did nothing". Aborts the moment the user takes the wheel back, so it
+ * never fights them for the scrollbar.
+ */
+export const animatedScrollIntoView = (
+  element: HTMLElement,
+  { offset = 0, duration = 520 }: AnimatedScrollOptions = {},
+): (() => void) | undefined => {
+  const start = window.scrollY;
+  const distance = element.getBoundingClientRect().top - offset;
+  if (Math.abs(distance) < 2) return undefined;
+
+  let frame = 0;
+  const detach = () => {
+    window.removeEventListener("wheel", abort);
+    window.removeEventListener("touchstart", abort);
+  };
+  function abort() {
+    cancelAnimationFrame(frame);
+    detach();
+  }
+
+  const step = (ts: number, startTs = ts) => {
+    const p = Math.min(1, (ts - startTs) / duration);
+    window.scrollTo(0, start + distance * (1 - (1 - p) ** 3));
+    if (p < 1) frame = requestAnimationFrame((next) => step(next, startTs));
+    else detach();
+  };
+
+  window.addEventListener("wheel", abort, { passive: true });
+  window.addEventListener("touchstart", abort, { passive: true });
+  frame = requestAnimationFrame((ts) => step(ts));
+
+  return abort;
+};

--- a/front/styles/animations.css
+++ b/front/styles/animations.css
@@ -67,24 +67,3 @@
   transform: translate(0, 10px);
   transition: all 300ms ease-out;
 }
-
-/* Statistics category chart (PFA-163) — the compare toggle changes the Y scale and
-   the ghost bars' opacity at once, so every bar glides to its new height instead of
-   snapping. `y`/`height` are SVG geometry properties: no Tailwind utility covers
-   them, and they animate wherever the browser exposes them to CSS — elsewhere the
-   new value simply applies at once, which is the old behaviour.
-   Vertical only, deliberately: `x`/`width` follow the container, and easing those
-   would leave the bars trailing behind the card through a window resize.
-   Also carried by the plain HTML legend bits, which only ever fade. */
-.pfa-anim-compare {
-  transition:
-    y 280ms ease-out,
-    height 280ms ease-out,
-    transform 280ms ease-out,
-    opacity 280ms ease-out;
-}
-@media (prefers-reduced-motion: reduce) {
-  .pfa-anim-compare {
-    transition: none;
-  }
-}


### PR DESCRIPTION
The compare toggle animated the wrong property, and animated it where it could not be seen.

Turning the comparison on now splits each category's slot in two, side by side: this year's bar narrows to make room while last year's rises out of the baseline beside it, and the reverse on the way out. The toggle is a resize, in the open. It used to grow behind this year's bar, visible only in whatever part cleared the top — and on every month this year outspent last, not visible at all. What was left on screen was a translucent shape appearing, which reads as exactly the fade nobody asked for.

Both that reveal and the y scale are tweened in JS on an ease-out cubic, not in CSS: SVG geometry only transitions where the browser hands `y` and `height` to the cascade, and a reduced-motion rule cut it dead. Hence useTweenTo, which eases toward a target from wherever it stands and, unlike useTween, does not grow from zero on mount.

The scroll to a freshly summoned chart is animated by hand for the same reason — browsers turn a smooth scrollIntoView into a jump under reduced motion, and that trip is the whole feedback that something appeared two screens down. It steps aside the moment the user touches the wheel.